### PR TITLE
docs(agents): require clickable links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@
 - Keep issue status in the GitHub Project updated as work progresses (Backlog → In progress → Done/Cancelled).
 - Use the Project "Ready" column as the queue of next tickets: move one ticket to Ready, start it, move it to In progress, then refresh Ready.
 - Always keep the Project backlog board up to date.
+- In issues and PRs, include clickable links whenever referencing docs, ADRs, runbooks, or other resources.
 - Close GitHub issues once DoD is verified and evidence is recorded.
 - In GitHub, always keep artifacts fully populated and well-maintained.
 - For commits, workflows, issues, PRs, and project items, fill required metadata (assignees, labels, project, milestone, reviewers, and links) consistently.


### PR DESCRIPTION
## Summary
- require clickable links in issues/PRs when referencing docs or ADRs

## Testing
- not run (docs only)

Refs #55
