### PR TITLE
docs(runbooks): add ci-infra runbook

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -14,6 +14,12 @@ Purpose: create the S3 bucket and DynamoDB table used by Terraform state and loc
 
 - Runbook: `docs/runbooks/terraform-backend-bootstrap.md`
 
+## 2.1) CI workflow reference (recommended)
+
+Purpose: understand what `ci-infra` validates on PRs and how manual apply works.
+
+- Runbook: `docs/runbooks/ci-infra.md`
+
 ## 3) Terraform live roots (per environment)
 
 Purpose: initialize and validate the Terraform roots for each environment.

--- a/docs/runbooks/ci-infra.md
+++ b/docs/runbooks/ci-infra.md
@@ -1,0 +1,49 @@
+# Runbook: ci-infra workflow
+
+This runbook explains what the `ci-infra` GitHub Actions workflow does and when to use it.
+
+## When it runs
+
+- On pull requests that touch `infra/**` or the workflow file itself.
+- Manually via `workflow_dispatch` for controlled applies.
+
+## What happens on pull_request
+
+Jobs run in CI to validate Terraform safely (no apply):
+
+1. `fmt`: `terraform fmt -check -recursive infra/aws`
+2. `validate-modules`: init/validate each module under `infra/aws/modules/*` (backend disabled).
+3. `validate-plan`:
+   - `bootstrap`: local backend (`-backend=false`) + validate + plan with required vars.
+   - `live-dev` and `live-prod`: remote backend init (S3 + DynamoDB) + validate + plan.
+4. `tfsec`: static scan for common Terraform security issues (cost-aware exclusions).
+
+### Which environment is targeted in CI?
+
+- For `bootstrap`: no environment, local backend only.
+- For `live-dev` and `live-prod`: the workflow initializes the remote backend using:
+  - bucket: `${TF_STATE_BUCKET}`
+  - lock table: `${TF_LOCK_TABLE_NAME}`
+  - keys: `cloudradar/dev/terraform.tfstate` and `cloudradar/prod/terraform.tfstate`
+
+These jobs do **not** apply changes. They only validate and plan.
+
+## Manual apply (workflow_dispatch)
+
+The `apply` job runs only when triggered manually:
+
+- Select `environment` (`dev` or `prod`).
+- Set `auto_approve=true` to allow apply.
+- Uses the same S3/DynamoDB backend and the OIDC role.
+
+## Required repo variables
+
+- `AWS_TERRAFORM_ROLE_ARN`
+- `AWS_REGION`
+- `TF_STATE_BUCKET`
+- `TF_LOCK_TABLE_NAME`
+
+## Related files
+
+- Workflow: `.github/workflows/ci-infra.yml`
+- Backend bootstrap runbook: `docs/runbooks/terraform-backend-bootstrap.md`


### PR DESCRIPTION
## Summary
- Add a dedicated runbook for the `ci-infra` workflow.
- Link it from the runbooks index.

## Details
- Runbook: `docs/runbooks/ci-infra.md`
- Index update: `docs/runbooks/README.md`

## Testing
- Docs only

Closes #50

Fixes #50

Refs #57
