### PR TITLE
docs(runbooks): consolidate IAM MVP policy

### DIFF
--- a/docs/runbooks/aws-account-bootstrap.md
+++ b/docs/runbooks/aws-account-bootstrap.md
@@ -68,7 +68,7 @@ Example trust policy:
 }
 ```
 
-### 6) Attach minimal policy for bootstrap
+### 6) Backend bootstrap policy (S3 + DynamoDB)
 Start with permissions required to create:
 - S3 bucket (state)
 - DynamoDB table (lock)
@@ -106,6 +106,73 @@ Minimal policy example:
 }
 ```
 
+### 6.1) Infra MVP policy (VPC + EC2 + EBS + routes)
+This policy enables MVP infrastructure provisioning (VPC + EC2 + EBS + SG + routes)
+without granting admin rights.
+
+Save as `cloudradar-infra-baseline.json`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VpcEc2Baseline",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVpc",
+        "ec2:DeleteVpc",
+        "ec2:ModifyVpcAttribute",
+        "ec2:CreateSubnet",
+        "ec2:DeleteSubnet",
+        "ec2:CreateInternetGateway",
+        "ec2:DeleteInternetGateway",
+        "ec2:AttachInternetGateway",
+        "ec2:DetachInternetGateway",
+        "ec2:CreateRouteTable",
+        "ec2:DeleteRouteTable",
+        "ec2:CreateRoute",
+        "ec2:DeleteRoute",
+        "ec2:AssociateRouteTable",
+        "ec2:DisassociateRouteTable",
+        "ec2:CreateSecurityGroup",
+        "ec2:DeleteSecurityGroup",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:CreateVolume",
+        "ec2:DeleteVolume",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:CreateTags",
+        "ec2:DeleteTags",
+        "ec2:Describe*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Attach it to the Terraform role:
+
+```bash
+aws iam put-role-policy \
+  --role-name CloudRadarTerraformRole \
+  --policy-name CloudRadarInfraBaseline \
+  --policy-document file://cloudradar-infra-baseline.json
+```
+
+### 6.2) Policy summary table
+
+| Policy | Purpose | Services | Used by |
+| --- | --- | --- | --- |
+| Backend bootstrap policy | Create state/lock for Terraform | S3, DynamoDB | CloudRadarTerraformRole |
+| Infra MVP policy | Provision MVP infra | EC2/VPC, EBS, Security Groups, Routes | CloudRadarTerraformRole |
+
 ### 7) Record outputs for CI
 - AWS Account ID
 - OIDC Provider ARN
@@ -122,8 +189,14 @@ Store these values in a secure place and in GitHub Actions variables if needed.
 - Bootstrap IAM user: `CloudRadarBootstrapUser`
 - MFA device name: `<MFA_DEVICE_NAME>` (e.g., `bitwarden_<name>`)
 - Bootstrap role: `CloudRadarBootstrapRole`
+- Local IAM user (CLI): `CloudRadarTerraformUser` (assumes the Terraform role)
 - CI role: `CloudRadarTerraformRole`
 - OIDC provider tag/name: `github-actions-oidc`
+
+## Auth paths (GitHub Actions vs AWS CLI)
+- **GitHub Actions** uses OIDC to assume `CloudRadarTerraformRole` (no IAM user or static keys).
+- **AWS CLI (local)** uses a profile for `CloudRadarTerraformUser`, then assumes `CloudRadarTerraformRole`.
+  The user needs only `sts:AssumeRole` + MFA.
 
 ### Bootstrap role permissions (simplified)
 If you had to broaden permissions during bootstrap, keep them scoped to the


### PR DESCRIPTION
## Summary
- Consolidate IAM MVP policy guidance into aws-account-bootstrap.
- Clarify bootstrap vs infra policy and add a summary table.

## Details
- Runbook: `docs/runbooks/aws-account-bootstrap.md`

## Testing
- Docs only

Closes #63

Refs #57
