### PR TITLE
docs(agents): clarify workflow testing and secrets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@
 - Keep changes small, incremental, and easy to review.
 - If splitting changes into multiple commits improves clarity, do so.
 - When a clean separation is not too complex or costly, prefer the clean option and keep scopes separated.
+- When workflows are hard to test before merge, validate the key steps locally (e.g., Terraform validate/plan).
 
 ### 4.2 Context & Documentation Hygiene
 - At session start, load context from `.codex-context.md` without asking (if present), then confirm it was loaded and provide a brief recap (recent actions and next planned steps).
@@ -58,6 +59,7 @@
 ### 4.6 Security & Access
 - Do not commit real emails or account identifiers; use placeholders in the repo.
 - Never share credentials (even temporary) in chat or documentation.
+- Never commit sensitive data (non-exhaustive): credentials, tokens, API keys, passwords, real emails, or personal info.
 - Prefer credential export without writing files to disk.
 - For bootstrap tasks, provide both a runbook and a script, and map steps between them.
 - After bootstrap, avoid leaving broad IAM user policies attached; prefer least-privilege roles via OIDC.


### PR DESCRIPTION
## Summary
- Clarify local validation for workflow steps when pre-merge testing is hard.
- Strengthen the sensitive-data rule with a non-exhaustive list.

## Testing
- Docs only

Refs #55
