### PR TITLE
fix(ci): remove var-file from validate

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -184,7 +184,7 @@ jobs:
             -backend-config="key=${TF_KEY}"
 
       - name: Terraform validate
-        run: terraform -chdir="${TF_DIR}" validate -var-file=terraform.tfvars.example
+        run: terraform -chdir="${TF_DIR}" validate
 
       - name: Terraform plan
         run: terraform -chdir="${TF_DIR}" plan -input=false -no-color -var-file=terraform.tfvars.example


### PR DESCRIPTION
## Summary
Remove unsupported -var-file flag from terraform validate in ci-infra apply job to fix workflow failures.

## Testing
- Not run (CI workflow_dispatch on branch).

Fixes #71