### PR TITLE
fix(ci): pass tfvars to destroy

### DIFF
--- a/.github/workflows/ci-infra-destroy.yml
+++ b/.github/workflows/ci-infra-destroy.yml
@@ -77,4 +77,4 @@ jobs:
         run: terraform -chdir="${TF_DIR}" validate
 
       - name: Terraform destroy
-        run: terraform -chdir="${TF_DIR}" destroy -input=false -auto-approve
+        run: terraform -chdir="${TF_DIR}" destroy -input=false -auto-approve -var-file=terraform.tfvars.example


### PR DESCRIPTION
## Summary
Add terraform.tfvars.example to ci-infra-destroy to satisfy required variables.

## Testing
- Not run (workflow_dispatch on branch).

Fixes #73