### PR TITLE
fix(infra): open dev edge cidr for ci

### DIFF
--- a/infra/aws/live/dev/terraform.tfvars.example
+++ b/infra/aws/live/dev/terraform.tfvars.example
@@ -22,7 +22,7 @@ k3s_root_volume_size      = 40
 
 edge_instance_type       = "t3.micro"
 edge_root_volume_size    = 40
-edge_allowed_cidrs       = ["203.0.113.10/32"]
+edge_allowed_cidrs       = ["0.0.0.0/0"]
 edge_server_name         = "_"
 edge_basic_auth_user     = "cloudradar"
 edge_basic_auth_ssm_parameter_name = "/cloudradar/edge/basic-auth"


### PR DESCRIPTION
## Summary
- Fix the dev tfvars example value so `edge_allowed_cidrs = ["0.0.0.0/0"]` allows CI smoke tests to reach `/healthz`.

## Testing
- Not run (config example).

Fixes #106
