### PR TITLE
feat(infra): bootstrap sqlite backup bucket

### DIFF
--- a/.github/workflows/bootstrap-terraform-backend.yml
+++ b/.github/workflows/bootstrap-terraform-backend.yml
@@ -14,6 +14,9 @@ on:
         description: "DynamoDB table name for Terraform locks"
         required: true
         default: "cloudradar-tf-lock"
+      backup_bucket_name:
+        description: "Optional S3 bucket name for SQLite backups"
+        required: false
       role_arn:
         description: "Optional role ARN to assume (defaults to AWS_TERRAFORM_ROLE_ARN variable)"
         required: false
@@ -49,4 +52,5 @@ jobs:
           terraform -chdir=infra/aws/bootstrap apply -auto-approve \
             -var="region=${{ inputs.region || vars.AWS_REGION }}" \
             -var="state_bucket_name=${{ inputs.state_bucket_name }}" \
-            -var="lock_table_name=${{ inputs.lock_table_name || vars.TF_LOCK_TABLE_NAME }}"
+            -var="lock_table_name=${{ inputs.lock_table_name || vars.TF_LOCK_TABLE_NAME }}" \
+            -var="backup_bucket_name=${{ inputs.backup_bucket_name || vars.TF_SQLITE_BACKUP_BUCKET }}"

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -35,6 +35,7 @@ env:
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
   TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
   TF_LOCK_TABLE_NAME: ${{ vars.TF_LOCK_TABLE_NAME }}
+  TF_SQLITE_BACKUP_BUCKET: ${{ vars.TF_SQLITE_BACKUP_BUCKET }}
   TF_ROLE_ARN: ${{ vars.AWS_TERRAFORM_ROLE_ARN }}
 
 jobs:
@@ -104,7 +105,8 @@ jobs:
           terraform -chdir=${{ matrix.dir }} plan -input=false -no-color \
             -var="region=${AWS_REGION}" \
             -var="state_bucket_name=${TF_STATE_BUCKET}" \
-            -var="lock_table_name=${TF_LOCK_TABLE_NAME}"
+            -var="lock_table_name=${TF_LOCK_TABLE_NAME}" \
+            -var="backup_bucket_name=${TF_SQLITE_BACKUP_BUCKET}"
 
       - name: Terraform plan
         if: ${{ matrix.name != 'bootstrap' }}

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -171,6 +171,7 @@ flowchart LR
 - Edge depends on the SSM/S3 endpoints being created first to avoid cloud-init timeouts during bootstrap.
 - ArgoCD is bootstrapped via SSM from CI after infrastructure apply, then manages k8s apps via GitOps.
 - Edge package installs use the S3 gateway endpoint plus SG egress to the S3 prefix list.
+- SQLite backup bucket is provisioned by the Terraform bootstrap stack to keep it outside environment destroys.
 - TODO: set edge `server_name` to the public DNS name once available (remove nginx warning).
 - TODO: improve edge HA by running nginx on public k3s nodes + ASG (min 1, ideally 2+) with vertical scaling as needed.
 - TODO: migrate edge TLS to ACM + Route53 (issue #14).

--- a/docs/runbooks/ci-infra.md
+++ b/docs/runbooks/ci-infra.md
@@ -118,6 +118,7 @@ Use the dedicated destroy workflow when you need to tear down an environment.
 - `AWS_REGION`
 - `TF_STATE_BUCKET`
 - `TF_LOCK_TABLE_NAME`
+- `TF_SQLITE_BACKUP_BUCKET` (optional, SQLite backups bucket)
 
 ## Related files
 

--- a/docs/runbooks/terraform-backend-bootstrap.md
+++ b/docs/runbooks/terraform-backend-bootstrap.md
@@ -16,6 +16,7 @@ using a temporary local Terraform state.
 2) Provide:
    - `state_bucket_name` (globally unique)
    - `lock_table_name` (prefilled from `TF_LOCK_TABLE_NAME`)
+   - `backup_bucket_name` (optional, SQLite backups bucket)
    - `region` (prefilled from `AWS_REGION`)
 
 Example bucket name:
@@ -27,12 +28,14 @@ gh workflow run bootstrap-terraform-backend \
   --ref main \
   -f region=us-east-1 \
   -f state_bucket_name=cloudradar-tfstate-<account-id> \
-  -f lock_table_name=cloudradar-tf-lock
+  -f lock_table_name=cloudradar-tf-lock \
+  -f backup_bucket_name=cloudradar-dev-<account-id>-sqlite-backups
 ```
 
 ## Outputs
 - S3 state bucket created with versioning, encryption, public access blocked.
 - DynamoDB lock table created (PAY_PER_REQUEST).
+- SQLite backup bucket created (if `backup_bucket_name` provided).
 
 ## Remote backend configuration (post-bootstrap)
 After the backend exists, configure Terraform roots to use it.

--- a/infra/aws/bootstrap/main.tf
+++ b/infra/aws/bootstrap/main.tf
@@ -43,3 +43,11 @@ resource "aws_dynamodb_table" "tf_lock" {
 
   tags = var.tags
 }
+
+module "sqlite_backups" {
+  count  = var.backup_bucket_name != null && var.backup_bucket_name != "" ? 1 : 0
+  source = "../modules/backup-bucket"
+
+  name = var.backup_bucket_name
+  tags = var.tags
+}

--- a/infra/aws/bootstrap/outputs.tf
+++ b/infra/aws/bootstrap/outputs.tf
@@ -7,3 +7,13 @@ output "lock_table_name" {
   value       = aws_dynamodb_table.tf_lock.name
   description = "Terraform lock table name."
 }
+
+output "backup_bucket_name" {
+  value       = var.backup_bucket_name != null && var.backup_bucket_name != "" ? module.sqlite_backups[0].bucket_name : null
+  description = "SQLite backup bucket name (if created)."
+}
+
+output "backup_bucket_arn" {
+  value       = var.backup_bucket_name != null && var.backup_bucket_name != "" ? module.sqlite_backups[0].bucket_arn : null
+  description = "SQLite backup bucket ARN (if created)."
+}

--- a/infra/aws/bootstrap/variables.tf
+++ b/infra/aws/bootstrap/variables.tf
@@ -15,6 +15,12 @@ variable "lock_table_name" {
   default     = "cloudradar-tf-lock"
 }
 
+variable "backup_bucket_name" {
+  type        = string
+  description = "Optional S3 bucket name for SQLite backups."
+  default     = null
+}
+
 variable "tags" {
   type        = map(string)
   description = "Common tags for backend resources."

--- a/infra/aws/live/dev/main.tf
+++ b/infra/aws/live/dev/main.tf
@@ -29,7 +29,7 @@ locals {
     if key != "health" || (port != var.edge_dashboard_nodeport && port != var.edge_api_nodeport)
   }
 
-  sqlite_backup_bucket_name = "${var.project}-${var.environment}-${data.aws_caller_identity.current.account_id}-sqlite-backups"
+  sqlite_backup_bucket_name = var.sqlite_backup_bucket_name != null ? var.sqlite_backup_bucket_name : "${var.project}-${var.environment}-${data.aws_caller_identity.current.account_id}-sqlite-backups"
 }
 
 data "aws_prefix_list" "s3" {
@@ -45,13 +45,6 @@ module "vpc" {
   public_subnet_cidrs  = var.public_subnet_cidrs
   private_subnet_cidrs = var.private_subnet_cidrs
   tags                 = local.tags
-}
-
-module "sqlite_backups" {
-  source = "../../modules/backup-bucket"
-
-  name = local.sqlite_backup_bucket_name
-  tags = local.tags
 }
 
 module "nat_instance" {

--- a/infra/aws/live/dev/outputs.tf
+++ b/infra/aws/live/dev/outputs.tf
@@ -80,10 +80,10 @@ output "edge_security_group_id" {
 
 output "sqlite_backup_bucket_name" {
   description = "S3 bucket name for SQLite backups."
-  value       = module.sqlite_backups.bucket_name
+  value       = local.sqlite_backup_bucket_name
 }
 
 output "sqlite_backup_bucket_arn" {
   description = "S3 bucket ARN for SQLite backups."
-  value       = module.sqlite_backups.bucket_arn
+  value       = "arn:aws:s3:::${local.sqlite_backup_bucket_name}"
 }

--- a/infra/aws/live/dev/terraform.tfvars.example
+++ b/infra/aws/live/dev/terraform.tfvars.example
@@ -20,6 +20,9 @@ k3s_root_volume_size      = 40
 # k3s_server_extra_args = ["--tls-san=example.com"]
 # k3s_agent_extra_args  = []
 
+# Optional: use the bootstrap-created SQLite backup bucket.
+# sqlite_backup_bucket_name = "cloudradar-dev-<account-id>-sqlite-backups"
+
 edge_instance_type       = "t3.micro"
 # edge_ami_id             = "ami-xxxxxxxxxxxxxxxxx"
 edge_root_volume_size    = 40

--- a/infra/aws/live/dev/variables.tf
+++ b/infra/aws/live/dev/variables.tf
@@ -98,6 +98,12 @@ variable "k3s_agent_extra_args" {
   default     = []
 }
 
+variable "sqlite_backup_bucket_name" {
+  description = "Optional SQLite backup bucket name (created by bootstrap)."
+  type        = string
+  default     = null
+}
+
 variable "edge_instance_type" {
   description = "Instance type for the edge EC2 instance."
   type        = string


### PR DESCRIPTION
## Summary
- create the SQLite backup bucket in the bootstrap stack
- remove bucket creation from live/dev and pass bucket name into k3s
- wire bootstrap workflow + ci-infra validation for the backup bucket input
- document bootstrap inputs and IAM inventory reference

## Testing
- not run (workflow/infra changes)
