### PR TITLE
fix(infra): add swap for k3s nodes

### DIFF
--- a/infra/aws/modules/k3s/templates/cloud-init-agent.yaml
+++ b/infra/aws/modules/k3s/templates/cloud-init-agent.yaml
@@ -3,4 +3,14 @@ package_update: true
 runcmd:
   - (command -v dnf >/dev/null 2>&1 && dnf install -y amazon-ssm-agent) || (command -v yum >/dev/null 2>&1 && yum install -y amazon-ssm-agent)
   - systemctl enable --now amazon-ssm-agent
+  - |
+      if ! swapon --show | grep -q '/swapfile'; then
+        if [ ! -f /swapfile ]; then
+          fallocate -l 2G /swapfile
+          chmod 600 /swapfile
+          mkswap /swapfile
+        fi
+        swapon /swapfile
+      fi
+      grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
   - curl -sfL https://get.k3s.io | K3S_URL="https://${server_private_ip}:6443" K3S_TOKEN="${k3s_token}" INSTALL_K3S_EXEC="agent${agent_args}" sh -

--- a/infra/aws/modules/k3s/templates/cloud-init-server.yaml
+++ b/infra/aws/modules/k3s/templates/cloud-init-server.yaml
@@ -11,4 +11,14 @@ users:
 runcmd:
   - (command -v dnf >/dev/null 2>&1 && dnf install -y amazon-ssm-agent) || (command -v yum >/dev/null 2>&1 && yum install -y amazon-ssm-agent)
   - systemctl enable --now amazon-ssm-agent
+  - |
+      if ! swapon --show | grep -q '/swapfile'; then
+        if [ ! -f /swapfile ]; then
+          fallocate -l 2G /swapfile
+          chmod 600 /swapfile
+          mkswap /swapfile
+        fi
+        swapon /swapfile
+      fi
+      grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
   - curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --secrets-encryption${server_args}" K3S_TOKEN="${k3s_token}" sh -


### PR DESCRIPTION
## Summary
- add 2GB swap setup to k3s server/agent cloud-init
- persist swap in /etc/fstab for reuse on reboot

## Testing
- not run (cloud-init change)

Fixes #147