### PR TITLE
fix(infra): open admin nodeport from edge

### DIFF
--- a/infra/aws/live/dev/main.tf
+++ b/infra/aws/live/dev/main.tf
@@ -23,6 +23,7 @@ locals {
     dashboard = var.edge_dashboard_nodeport
     api       = var.edge_api_nodeport
     health    = local.edge_health_nodeport
+    admin     = var.edge_admin_nodeport
   }
   edge_nodeport_rules_filtered = {
     for key, port in local.edge_nodeport_rules : key => port


### PR DESCRIPTION
## Summary
- include admin nodeport in edge -> k3s SG rules

## Testing
- not run (infra change; apply via ci-infra)

Fixes #161