### PR TITLE
fix(k8s): add processor startup probe

### DIFF
--- a/k8s/apps/processor/deployment.yaml
+++ b/k8s/apps/processor/deployment.yaml
@@ -44,10 +44,20 @@ spec:
             httpGet:
               path: /healthz
               port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz
               port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            failureThreshold: 30
+            periodSeconds: 2
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## Summary
- add startup probe and delays to avoid processor crash loops during boot

## Testing
- not run (manifest change)

Refs #5
