### PR TITLE
docs(meta): add GitHub issue/PR templates and metadata verification workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,51 @@
+---
+name: Bug Report
+about: Report something that isn't working
+title: "fix(infra|k8s|app|obs|edge|meta|adr|agents): brief description"
+labels: "bug"
+assignees: ""
+---
+
+## Describe the Bug
+<!-- Clear description of what's broken -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What should happen instead? -->
+
+## Actual Behavior
+<!-- What actually happens? -->
+
+## Environment
+- [ ] Local development
+- [ ] AWS dev environment
+- [ ] Kubernetes cluster (k3s)
+- [ ] Other: _________
+
+## Logs / Error Output
+```
+Paste logs, error messages, or stack traces here
+```
+
+## Root Cause (if known)
+<!-- Where do you think the issue is? Terraform/K8s/App/etc -->
+
+## Suggested Fix
+<!-- Optional: how should this be fixed? -->
+
+## Related Issues
+<!-- Link any related issues or PRs -->
+
+---
+
+**Before submitting:**
+- [ ] Title follows format: `fix(scope): description`
+- [ ] Scope is one of: `infra`, `k8s`, `app`, `obs`, `edge`, `meta`, `adr`, `agents`
+- [ ] Labels added: `bug` + `area/*` + version label (`v1-mvp`, `v1.1`, or `v2`)
+- [ ] Priority label added: `p0`, `p1`, `p2`, or `p3`
+- [ ] Assignee set (usually yourself)
+- [ ] Milestone set (`v1-mvp`, `v1.1`, or `v2`)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/ClementV78/CloudRadar/tree/main/docs
+    about: Check docs, ADRs, and runbooks before creating issues
+  - name: Architecture Decisions
+    url: https://github.com/ClementV78/CloudRadar/tree/main/docs/architecture/decisions
+    about: Review ADRs for design decisions
+  - name: Issue Log
+    url: https://github.com/ClementV78/CloudRadar/blob/main/docs/runbooks/issue-log.md
+    about: Check past issues for similar problems

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,35 @@
+---
+name: Documentation
+about: Improve or add documentation
+title: "docs(infra|k8s|app|obs|meta|adr|agents): brief description"
+labels: "documentation"
+assignees: ""
+---
+
+## What Needs to be Documented
+<!-- What documentation is missing or needs improvement? -->
+
+## Current State
+<!-- Is there any existing documentation? Where is it? -->
+
+## Proposed Documentation
+<!-- Outline or draft of the new/updated documentation -->
+
+## Files to Update
+- 
+- 
+
+## Definition of Done
+- [ ] Documentation written/updated
+- [ ] All links and references are correct
+- [ ] Follows markdown style guide
+- [ ] Related issues/ADRs linked if applicable
+
+---
+
+**Before submitting:**
+- [ ] Title follows format: `docs(scope): description`
+- [ ] Scope is one of: `infra`, `k8s`, `app`, `obs`, `meta`, `adr`, `agents`
+- [ ] Labels added: `documentation` + version label if applicable (`v1-mvp`, `v1.1`, or `v2`)
+- [ ] Assignee set (usually yourself)
+- [ ] Milestone set if applicable (not required for documentation)

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,38 @@
+---
+name: Feature Request
+about: Propose a new feature or enhancement
+title: "feat(infra|k8s|app|obs|edge|meta|adr|agents): brief description"
+labels: "enhancement"
+assignees: ""
+---
+
+## Problem Statement
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Proposed Solution
+<!-- Describe the desired feature and how it should work -->
+
+## Implementation Notes
+- [ ] Impacts infrastructure (Terraform/AWS)
+- [ ] Impacts Kubernetes manifests
+- [ ] Impacts application code (Java)
+- [ ] Impacts observability (metrics/dashboards)
+- [ ] Requires documentation updates
+
+## Definition of Done
+- [ ] Code reviewed and merged
+- [ ] Documentation updated (README, ADR, runbooks)
+- [ ] Related issues/PRs linked
+- [ ] Tests added (if applicable)
+
+## Additional Context
+<!-- Any relevant information, designs, sketches, or links -->
+
+---
+
+**Before submitting:**
+- [ ] Title follows format: `feat(scope): description`
+- [ ] Scope is one of: `infra`, `k8s`, `app`, `obs`, `edge`, `meta`, `adr`, `agents`
+- [ ] Labels added: `area/*` + version label (`v1-mvp`, `v1.1`, or `v2`)
+- [ ] Assignee set (usually yourself)
+- [ ] Milestone set (`v1-mvp`, `v1.1`, or `v2`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## What Changed
+<!-- Brief description of the changes -->
+
+## Why
+<!-- Link the issue: Closes #XXX (for features) or Fixes #XXX (for bugs) -->
+
+Closes #
+
+## Files Affected
+- 
+- 
+
+## Notes
+<!-- Any additional context (breaking changes, deployment notes, etc.) -->
+
+---
+
+**Before submitting:**
+- [ ] Title follows format: `type(scope): description`
+- [ ] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
+- [ ] All CI checks pass
+- [ ] Documentation updated (if applicable)

--- a/.github/workflows/verify-issue-metadata.yml
+++ b/.github/workflows/verify-issue-metadata.yml
@@ -1,0 +1,115 @@
+name: Verify Issue Metadata
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  check-metadata:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check metadata
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const missing = [];
+            
+            // Check assignees
+            if (!issue.assignees || issue.assignees.length === 0) {
+              missing.push("❌ **Assignee**: Not assigned");
+            } else {
+              missing.push("✅ Assignee: " + issue.assignees.map(a => `@${a.login}`).join(", "));
+            }
+            
+            // Check labels
+            if (!issue.labels || issue.labels.length === 0) {
+              missing.push("❌ **Labels**: Not set");
+            } else {
+              missing.push("✅ Labels: " + issue.labels.map(l => `\`${l.name}\``).join(", "));
+            }
+            
+            // Check milestone
+            if (!issue.milestone) {
+              missing.push("❌ **Milestone**: Not set (required: v1-mvp, v1.1, or v2)");
+            } else {
+              missing.push("✅ Milestone: `" + issue.milestone.title + "`");
+            }
+            
+            // Check project association
+            let hasProject = false;
+            try {
+              const projects = await github.graphql(`
+                query($owner:String!, $repo:String!, $issueNumber:Int!) {
+                  repository(owner:$owner, name:$repo) {
+                    issue(number:$issueNumber) {
+                      projectsV2(first:10) {
+                        nodes {
+                          title
+                        }
+                      }
+                    }
+                  }
+                }
+              `, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issueNumber: issue.number
+              });
+              
+              const projectNodes = projects.repository.issue.projectsV2.nodes;
+              if (projectNodes && projectNodes.length > 0) {
+                hasProject = true;
+                missing.push("✅ Project: " + projectNodes.map(p => `\`${p.title}\``).join(", "));
+              } else {
+                missing.push("❌ **Project**: Not added to CloudRadar project");
+              }
+            } catch (error) {
+              console.log("Could not check project association");
+              missing.push("⚠️ **Project**: Could not verify (manual check needed)");
+            }
+            
+            // Determine if needs attention
+            const needsAttention = !issue.assignees || issue.assignees.length === 0 || 
+                                  !issue.labels || issue.labels.length === 0 || 
+                                  !issue.milestone || !hasProject;
+            
+            if (needsAttention) {
+              // Check if already labeled
+              const hasMetadataLabel = issue.labels && issue.labels.some(l => l.name === "needs-metadata");
+              
+              if (!hasMetadataLabel) {
+                // Add label
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: ["needs-metadata"]
+                });
+              }
+              
+              // Post comment
+              const comment = `⚠️ **Metadata Check**\n\n${missing.join("\n")}\n\n**Required metadata:**\n- Assignee (usually yourself)\n- Labels: \`area/*\` + version (\`v1-mvp\`, \`v1.1\`, or \`v2\`)\n- Milestone: \`v1-mvp\`, \`v1.1\`, or \`v2\`\n- Project: Add to **CloudRadar** project board\n\nPlease update to complete this issue.`;
+              
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: comment
+              });
+            } else {
+              console.log("✅ All metadata present");
+              console.log(missing.join("\n"));
+              
+              // Remove needs-metadata label if present
+              if (issue.labels && issue.labels.some(l => l.name === "needs-metadata")) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: "needs-metadata"
+                });
+              }
+            }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 **Technical Overview:** Terraform provisions AWS (k3s on EC2, IAM, S3, VPC). GitHub Actions runs infra CI; ArgoCD syncs `k8s/apps`. Prometheus/Grafana observability and GHCR app publishing are planned.
 
 **Project Management:**
-All features and fixes are tracked as GitHub Issues and delivered through an iterative, issue-driven workflow. Progress is managed using a GitHub Projects Kanban board, following lightweight agile-inspired practices adapted for a solo project.
+Issues and PRs are tracked in GitHub Projects (Kanban board) using lightweight agile practices adapted for solo development. Templates enforce metadata standards (assignees, labels, milestones, project), and an automated workflow ensures consistency and quality across all tickets and PRs.
 
 **Why this project exists:** provide a concrete, end-to-end DevOps/Cloud Architecture portfolio with real IaC, CI/CD, GitOps, and cost trade-offs.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,18 @@ For agent guidance, see [AGENTS.md](../AGENTS.md) (project management & workflow
 
 ## 📍 Where to Find What
 
+### 💻 **GitHub Workflow & Project Management**
+
+If you're creating issues or PRs, start here:
+
+- **[GitHub Workflow Guide](runbooks/github-workflow.md)** — Issue/PR templates, metadata requirements, automated checks
+  - How to create issues and PRs correctly
+  - What metadata is required and why
+  - How the automated metadata verification workflow works
+  - Best practices and complete examples
+
+---
+
 ### 🏗️ **Understanding the Architecture**
 
 Start here if you're new to the project or want to understand how components fit together:

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -2,6 +2,13 @@
 
 This page is the entry point for all runbooks and describes the recommended execution order.
 
+## 0) GitHub Workflow & Project Management (foundational)
+
+Purpose: understand issue/PR templates, metadata requirements, and automated checks.
+
+- Reference: `docs/runbooks/github-workflow.md`
+- Covers: templates, automated metadata verification, best practices for issues and PRs
+
 ## 1) AWS account bootstrap (required)
 
 Purpose: establish IAM baseline, MFA, budgets, and the GitHub OIDC provider + Terraform role.

--- a/docs/runbooks/github-workflow.md
+++ b/docs/runbooks/github-workflow.md
@@ -1,0 +1,376 @@
+# GitHub Workflow & Project Management
+
+> Complete guide to issues, PRs, templates, and automated checks in CloudRadar.
+
+## Table of Contents
+1. [Issue Workflow](#issue-workflow)
+2. [PR Workflow](#pr-workflow)
+3. [Templates Overview](#templates-overview)
+4. [Automated Checks](#automated-checks)
+5. [Metadata Requirements](#metadata-requirements)
+6. [Best Practices](#best-practices)
+
+---
+
+## Issue Workflow
+
+### Creating an Issue
+
+1. Click **"New issue"** on GitHub
+2. Choose a template:
+   - **Feature Request** → `feat(scope): description`
+   - **Bug Report** → `fix(scope): description`
+   - **Documentation** → `docs(scope): description`
+
+3. Fill in the required sections (title, problem, solution, DoD)
+4. Add metadata **before** or **after** submission:
+   - **Assignee** (usually yourself)
+   - **Labels** (area + version, e.g., `area/k8s` + `v1-mvp`)
+   - **Milestone** (`v1-mvp`, `v1.1`, or `v2`)
+   - **Project** (add to **CloudRadar** project board)
+
+### Metadata Verification
+
+When you **create or edit** an issue, a GitHub Actions workflow runs automatically:
+
+```
+on:
+  issues:
+    types: [opened, edited]
+```
+
+**What it checks:**
+- ✅ Assignee set
+- ✅ Labels present
+- ✅ Milestone set
+- ✅ Project association
+
+**If metadata is missing:**
+- 🏷️ Adds label `needs-metadata` (red flag)
+- 💬 Posts a helpful comment listing what's missing
+- Shows exact format for required metadata
+
+**If metadata is complete:**
+- ✅ Removes `needs-metadata` label if present
+- Silent success (no comment)
+
+### Example
+
+**Issue #182 created without metadata:**
+```
+Title: feat(k8s): add prometheus scrape config
+Assignee: ❌ Not set
+Labels: ❌ Not set
+Milestone: ❌ Not set
+Project: ❌ Not added
+```
+
+**Workflow triggers:**
+- Adds label `needs-metadata`
+- Posts comment with checklist and instructions
+
+**After you update the issue:**
+```
+Title: feat(k8s): add prometheus scrape config
+Assignee: ✅ @you
+Labels: ✅ area/k8s, area/observability, v1-mvp, p1
+Milestone: ✅ v1-mvp
+Project: ✅ CloudRadar (status: Ready)
+```
+
+**Workflow re-runs:**
+- Removes `needs-metadata` label
+- Issue is now complete and ready to work on
+
+---
+
+## PR Workflow
+
+### Creating a PR
+
+1. Create a branch linked to your issue: `feat/123-short-desc`
+2. Make your changes and commit with format: `type(scope): message`
+3. Open a PR with the PR template (auto-filled)
+4. Fill in:
+   - **What Changed** (brief summary)
+   - **Why** (link issue with `Closes #XXX` or `Fixes #XXX`)
+   - **Files Affected** (list key files)
+   - **Notes** (any breaking changes, deployment notes)
+
+5. Ensure:
+   - Title follows `type(scope): description`
+   - All CI checks pass
+   - No conflicts with `main`
+   - Documentation updated (if applicable)
+
+### PR Structure
+
+**Keep short:** 3-5 sections max (from AGENTS.md)
+- "PR is a progress report, not a deep justification"
+- Avoid re-explaining the entire problem from the issue
+
+**Linking issues:**
+- Use `Closes #XXX` for features (auto-closes issue on merge)
+- Use `Fixes #XXX` for bugs (auto-closes issue on merge)
+- Use `Refs #XXX` for related work (no auto-close)
+
+### Example PR
+
+```markdown
+## What Changed
+- Added Prometheus scrape config for ingester metrics
+- Updated kustomization.yaml to include new ConfigMap
+
+## Why
+Closes #123
+
+## Files Affected
+- k8s/apps/monitoring/prometheus-config.yaml
+- k8s/apps/monitoring/kustomization.yaml
+
+## Notes
+Config syncs via ArgoCD; no manual apply needed.
+
+---
+- [x] Title follows `type(scope): description`
+- [x] All CI checks pass
+- [x] Documentation updated
+```
+
+---
+
+## Templates Overview
+
+### Issue Templates
+
+| Template | Type | Scope | Metadata |
+| --- | --- | --- | --- |
+| **feature.md** | `feat` | infra, k8s, app, obs, edge, meta, adr, agents | enhancement label |
+| **bug.md** | `fix` | (same) | bug label |
+| **documentation.md** | `docs` | infra, k8s, app, obs, meta, adr, agents | documentation label |
+
+**Template Structure:**
+- `config.yml`: Enforces template selection (disables blank issues)
+- Each template includes:
+  - Pre-filled title format: `type(scope): description`
+  - Guided sections (problem, solution, files, DoD)
+  - Final checklist reminding metadata requirements
+
+**Example title in template:**
+```
+feat(infra|k8s|app|obs|edge|meta|adr|agents): brief description
+```
+→ User chooses their scope from the list
+
+### PR Template
+
+Single global template: `.github/pull_request_template.md`
+
+**Sections:**
+- What Changed
+- Why (with `Closes #XXX` / `Fixes #XXX` placeholder)
+- Files Affected
+- Notes
+- Pre-merge checklist
+
+---
+
+## Automated Checks
+
+### GitHub Actions Workflow: `verify-issue-metadata.yml`
+
+**File:** `.github/workflows/verify-issue-metadata.yml`
+
+**Trigger:**
+```yaml
+on:
+  issues:
+    types: [opened, edited]
+```
+
+**Steps:**
+1. Extract issue data (assignees, labels, milestone)
+2. Query GraphQL to check project association
+3. Determine if metadata is complete
+4. If incomplete:
+   - Add `needs-metadata` label
+   - Post comment with missing items and instructions
+5. If complete:
+   - Remove `needs-metadata` label (if present)
+   - Silent success
+
+**Permissions:** `issues: write` (can modify labels and post comments)
+
+**Example Automated Comment:**
+```
+⚠️ **Metadata Check**
+
+❌ **Assignee**: Not assigned
+✅ Labels: `area/k8s`, `v1-mvp`
+❌ **Milestone**: Not set (required: v1-mvp, v1.1, or v2)
+❌ **Project**: Not added to CloudRadar project
+
+**Required metadata:**
+- Assignee (usually yourself)
+- Labels: `area/*` + version (`v1-mvp`, `v1.1`, or `v2`)
+- Milestone: `v1-mvp`, `v1.1`, or `v2`
+- Project: Add to **CloudRadar** project board
+
+Please update to complete this issue.
+```
+
+---
+
+## Metadata Requirements
+
+All issues **must** have (from AGENTS.md section 4.4):
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| **Assignee** | ✅ | Usually yourself; identifies who works on it |
+| **Labels** | ✅ | `area/*` (k8s, infra, app, obs, data, docs) + version label |
+| **Milestone** | ✅ Except tooling | `v1-mvp`, `v1.1`, or `v2` |
+| **Project** | ✅ | Add to **CloudRadar** project board in UI |
+| **Project Status** | ✅ | Set status in project (Ready, In progress, etc.) |
+
+### Label Conventions
+
+**Area labels** (choose one or more):
+- `area/k8s` - Kubernetes/container orchestration
+- `area/infra` - AWS/Terraform infrastructure
+- `area/app` - Application code (Java services)
+- `area/observability` - Prometheus/Grafana metrics
+- `area/data` - Data pipeline, storage, backups
+- `area/docs` - Documentation
+
+**Version labels** (choose one):
+- `v1-mvp` - Current MVP sprint
+- `v1.1` - Post-MVP enhancements
+- `v2` - Future/major refactor
+
+**Priority labels** (optional):
+- `p0` - Critical (e.g., security, outage)
+- `p1` - High (blocking other work)
+- `p2` - Medium
+- `p3` - Low
+
+**Type labels**:
+- `enhancement` - New feature
+- `bug` - Defect
+- `documentation` - Docs-only
+- `skill` - Tooling/process improvements
+
+**Special labels**:
+- `needs-metadata` - Automated flag for incomplete metadata
+- `kind/ci` - CI/CD infrastructure
+- `kind/maintenance` - Maintenance tasks
+
+---
+
+## Best Practices
+
+### For Issues
+
+✅ **Do:**
+- Use templates when creating issues
+- Fill all required sections (problem, solution, DoD)
+- Add assignee and labels immediately (before or after creation)
+- Add milestone matching your sprint
+- Add to project board and set status
+- Reference related issues/PRs in the description
+- Link ADRs or runbooks if relevant
+
+❌ **Don't:**
+- Create issues without metadata (workflow will flag it)
+- Leave `needs-metadata` label unresolved
+- Mix multiple scopes in one issue
+- Leave issues unassigned
+
+### For PRs
+
+✅ **Do:**
+- Use title format: `type(scope): description`
+- Link issue with `Closes #XXX` (features) or `Fixes #XXX` (bugs)
+- Keep description short and focused (3-5 bullets)
+- List files affected explicitly
+- Run local tests/validation before submitting
+- Wait for CI to pass before merging
+
+❌ **Don't:**
+- Re-explain the entire problem from the issue (reference it instead)
+- Create PR without linked issue
+- Merge with unresolved conflicts or failed CI
+- Mix multiple issue scopes in one PR
+
+### Workflow Rules (from AGENTS.md)
+
+- **One branch per issue:** `type/123-short-title`
+- **One commit per logical change:** Use `type(scope): message` format
+- **Link commits:** Include `Refs #issue` or `Fixes #issue` in commit body
+- **Keep branches short-lived:** Merge daily; rebase if stale (>7 days)
+- **No direct push to `main`:** All changes via PR
+- **User merges non-AGENTS.md PRs:** Agent creates PR, user approves and merges
+
+---
+
+## Examples
+
+### Complete Issue Flow
+
+```
+1. Create issue from "feature" template
+   Title: feat(k8s): add prometheus persistent storage
+
+2. Workflow runs (on: opened)
+   Result: ⚠️ needs-metadata label added + comment posted
+
+3. You update the issue:
+   - Assignee: @yourself
+   - Labels: area/k8s, area/observability, v1-mvp, p1
+   - Milestone: v1-mvp
+   - Project: CloudRadar > Ready
+
+4. Workflow runs (on: edited)
+   Result: ✅ needs-metadata label removed
+
+5. You create a branch: git checkout -b feat/180-prometheus-storage
+
+6. You commit: git commit -m "feat(k8s): add prometheus persistent storage
+   
+   - Updated prometheus-deployment.yaml with PVC
+   - Updated kustomization.yaml for new volume
+   
+   Closes #180"
+
+7. You push and open PR with template auto-filled
+
+8. CI runs, PR passes all checks
+
+9. You merge PR → issue #180 auto-closes
+```
+
+### Quick Checklist Before Submitting
+
+**Issue:**
+- [ ] Used correct template (feat/fix/docs)
+- [ ] Title format correct: `type(scope): description`
+- [ ] Problem statement is clear
+- [ ] Definition of Done listed
+- [ ] Will add metadata immediately after creation
+
+**PR:**
+- [ ] Title format correct: `type(scope): description`
+- [ ] Linked issue: `Closes #XXX` or `Fixes #XXX`
+- [ ] Files affected listed
+- [ ] Local tests pass
+- [ ] CI will pass (linting, Terraform fmt, etc.)
+- [ ] No conflicts with `main`
+
+---
+
+## References
+
+- **AGENTS.md** → [Project conventions and metadata standards](../AGENTS.md)
+- **GitHub Projects** → [CloudRadar project board](https://github.com/ClementV78/CloudRadar/projects)
+- **ADRs** → [Architecture decisions](../architecture/decisions/)
+- **Runbooks** → [Operational procedures](./README.md)


### PR DESCRIPTION
## What Changed
- Issue templates (feature.md, bug.md, documentation.md) with guided sections and metadata checklists
- PR template with short, focused format (3-5 sections per AGENTS.md)
- GitHub Actions workflow to verify metadata: assignees, labels, milestone, project association
- Auto-labels incomplete issues with 'needs-metadata' and posts helpful comments
- Comprehensive GitHub workflow guide with examples and best practices

## Why
Refs #57

## Files Affected
- .github/ISSUE_TEMPLATE/ (3 templates + config)
- .github/pull_request_template.md
- .github/workflows/verify-issue-metadata.yml
- docs/runbooks/github-workflow.md
- README.md, docs/README.md, docs/runbooks/README.md

## Notes
Templates enforce AGENTS.md conventions. Workflow uses GraphQL to check project association and JavaScript to verify metadata on every issue open/edit event.

---
- [x] All files created/updated
- [x] Documentation complete
- [x] CI will pass (no code changes)
- [x] Refs meta issue #57