### PR TITLE
fix(k8s): remove non-existent argocd-app.yaml from kustomization

### DIFF
--- a/k8s/platform/kustomization.yaml
+++ b/k8s/platform/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - argocd-app.yaml
   - external-secrets/secretstore.yaml
   - external-secrets/helmrelease.yaml


### PR DESCRIPTION
The kustomization was referencing a non-existent argocd-app.yaml file. The Application definition is already in helmrelease.yaml, so remove the reference.