### PR TITLE
fix(k8s): deploy ESO Helm chart before SecretStore

### DIFF
--- a/k8s/platform/kustomization.yaml
+++ b/k8s/platform/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - external-secrets/secretstore.yaml
   - external-secrets/helmrelease.yaml
+  - external-secrets/secretstore.yaml


### PR DESCRIPTION
The kustomization must deploy the Application (helmrelease) first to install CRDs, then deploy SecretStore. Otherwise ArgoCD fails trying to create SecretStore when the CRD doesn't exist yet.