### PR TITLE
feat(infra): codify control-plane taint

### DIFF
--- a/docs/runbooks/bootstrap/argocd-bootstrap.md
+++ b/docs/runbooks/bootstrap/argocd-bootstrap.md
@@ -4,6 +4,7 @@ Purpose: install ArgoCD in the k3s cluster so GitOps can manage k8s apps.
 
 ## Prerequisites
 - k3s server is running and reachable via SSM.
+- Control-plane taint is enforced (`dedicated=control-plane:NoSchedule`) so only platform pods (ArgoCD/ESO/kube-system) schedule on the server.
 - AWS CLI configured with permissions to run SSM commands:
   - `ssm:SendCommand`
   - `ssm:GetCommandInvocation`
@@ -95,6 +96,7 @@ Troubleshooting:
 - Step 2 runs the Helm-based install:
   - install Helm if missing
   - `helm upgrade --install` ArgoCD (optionally pinned chart version)
+  - apply tolerations/nodeSelector so ArgoCD can run on the tainted control-plane
   - wait for Application CRD to be established
   - wait for `argocd-server` deployment
   - list pods for quick verification

--- a/docs/runbooks/external-secrets-operator.md
+++ b/docs/runbooks/external-secrets-operator.md
@@ -152,6 +152,13 @@ spec:
         serviceAccount:
           create: true
           name: external-secrets-sa
+        nodeSelector:
+          node-role.kubernetes.io/control-plane: "true"
+        tolerations:
+          - key: "dedicated"
+            operator: "Equal"
+            value: "control-plane"
+            effect: "NoSchedule"
   destination:
     server: https://kubernetes.default.svc
     namespace: external-secrets

--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -4,6 +4,12 @@ This log tracks incidents and fixes in reverse chronological order. Use it for d
 
 ## 2026-01-30
 
+### [infra/k3s] Control-plane taint missing → workloads scheduled on server (OOM/SSM black screen)
+- **Severity:** High
+- **Impact:** App pods (Java) and Redis scheduled on the k3s server; repeated OOM kills; SSM Session Manager showed a black screen; cluster became unstable.
+- **Analysis:** The control-plane node had **no taints** (`Taints: <none>`). The taint was applied manually previously and **not codified** in IaC. After infra rebuild, the new server booted without a taint, so regular workloads were eligible to run on it.
+- **Resolution:** Re-applied taint `dedicated=control-plane:NoSchedule` and deleted app/redis/ESO pods so they rescheduled to the worker. **Follow-up:** codify the taint in k3s server install (e.g., `K3S_NODE_TAINT` / `--node-taint`) and document the expected taints. (Refs: issue #203)
+
 ### [gitops/argocd] External Secrets sync failed (CRD missing)
 - **Severity:** High
 - **Impact:** ESO Application stuck in retry; SecretStore rejected (CRD absent); no secrets synced or pods deployed.

--- a/infra/aws/live/dev/terraform.tfvars
+++ b/infra/aws/live/dev/terraform.tfvars
@@ -15,6 +15,7 @@ k3s_worker_min_size      = 1
 k3s_worker_desired       = 1
 k3s_worker_max_size      = 3
 k3s_root_volume_size     = 40
+k3s_server_extra_args    = ["--node-taint=dedicated=control-plane:NoSchedule"]
 
 edge_instance_type = "t3.micro"
 # edge_ami_id                        = "ami-xxxxxxxxxxxxxxxxx"

--- a/infra/aws/live/dev/terraform.tfvars.example
+++ b/infra/aws/live/dev/terraform.tfvars.example
@@ -15,6 +15,7 @@ k3s_worker_min_size       = 1
 k3s_worker_desired        = 1
 k3s_worker_max_size       = 3
 k3s_root_volume_size      = 40
+k3s_server_extra_args     = ["--node-taint=dedicated=control-plane:NoSchedule"]
 
 # Optional: additional k3s flags.
 # k3s_server_extra_args = ["--tls-san=example.com"]

--- a/k8s/platform/external-secrets/helmrelease.yaml
+++ b/k8s/platform/external-secrets/helmrelease.yaml
@@ -19,6 +19,13 @@ spec:
           name: external-secrets-sa
         metrics:
           enabled: true
+        nodeSelector:
+          node-role.kubernetes.io/control-plane: "true"
+        tolerations:
+          - key: "dedicated"
+            operator: "Equal"
+            value: "control-plane"
+            effect: "NoSchedule"
   destination:
     server: https://kubernetes.default.svc
     namespace: external-secrets

--- a/scripts/bootstrap-argocd.sh
+++ b/scripts/bootstrap-argocd.sh
@@ -148,7 +148,7 @@ commands=(
   "sudo --preserve-env=KUBECONFIG helm repo add argo https://argoproj.github.io/argo-helm --force-update"
   "sudo --preserve-env=KUBECONFIG helm repo update"
   # Install or upgrade ArgoCD into its namespace.
-  "sudo --preserve-env=KUBECONFIG helm upgrade --install argocd argo/argo-cd --namespace ${ARGOCD_NAMESPACE} --create-namespace ${HELM_VERSION_FLAG}"
+  "sudo --preserve-env=KUBECONFIG helm upgrade --install argocd argo/argo-cd --namespace ${ARGOCD_NAMESPACE} --create-namespace ${HELM_VERSION_FLAG} --set global.nodeSelector.node-role\\.kubernetes\\.io/control-plane=true --set global.tolerations[0].key=dedicated --set global.tolerations[0].operator=Equal --set global.tolerations[0].value=control-plane --set global.tolerations[0].effect=NoSchedule"
   # Wait for CRDs and ArgoCD server to be ready before creating the Application.
   "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=120s --request-timeout=5s"
   "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n ${ARGOCD_NAMESPACE} wait --for=condition=Available deployment/argocd-server --timeout=300s --request-timeout=5s"


### PR DESCRIPTION
## What Changed
- Codified control-plane taint in k3s server extra args (dev + example)
- Added ArgoCD global tolerations/nodeSelector in bootstrap script
- Added ESO tolerations/nodeSelector in the ArgoCD Application values
- Documented the incident and taint expectations in runbooks

## Why
Fixes #203

## Files Affected
- infra/aws/live/dev/terraform.tfvars
- infra/aws/live/dev/terraform.tfvars.example
- scripts/bootstrap-argocd.sh
- k8s/platform/external-secrets/helmrelease.yaml
- docs/runbooks/bootstrap/argocd-bootstrap.md
- docs/runbooks/external-secrets-operator.md
- docs/runbooks/troubleshooting/issue-log.md

## Notes
- Taint applies on next k3s server rebuild (cloud-init).
- ArgoCD tolerations apply on next bootstrap/helm upgrade.

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [x] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [x] Documentation updated (if applicable)
