### PR TITLE
fix(ci): keep ssm command id clean

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -473,7 +473,7 @@ jobs:
             local sleep_seconds=10
 
             while [ "${attempt}" -le "${max_attempts}" ]; do
-              echo "SSM send-command attempt ${attempt}/${max_attempts}"
+              echo "SSM send-command attempt ${attempt}/${max_attempts}" >&2
               local response
               response="$(aws ssm send-command \
                 --instance-ids "${instance_id}" \
@@ -488,9 +488,9 @@ jobs:
                 return 0
               fi
 
-              echo "SendCommand failed: ${response}"
+              echo "SendCommand failed: ${response}" >&2
               if [ "${attempt}" -lt "${max_attempts}" ]; then
-                echo "Retrying in ${sleep_seconds}s..."
+                echo "Retrying in ${sleep_seconds}s..." >&2
                 sleep "${sleep_seconds}"
                 sleep_seconds=$((sleep_seconds + 5))
               fi
@@ -655,7 +655,7 @@ jobs:
             local sleep_seconds=10
 
             while [ "${attempt}" -le "${max_attempts}" ]; do
-              echo "SSM send-command attempt ${attempt}/${max_attempts}"
+              echo "SSM send-command attempt ${attempt}/${max_attempts}" >&2
               local response
               response="$(aws ssm send-command \
                 --instance-ids "${instance_id}" \
@@ -670,9 +670,9 @@ jobs:
                 return 0
               fi
 
-              echo "SendCommand failed: ${response}"
+              echo "SendCommand failed: ${response}" >&2
               if [ "${attempt}" -lt "${max_attempts}" ]; then
-                echo "Retrying in ${sleep_seconds}s..."
+                echo "Retrying in ${sleep_seconds}s..." >&2
                 sleep "${sleep_seconds}"
                 sleep_seconds=$((sleep_seconds + 5))
               fi
@@ -785,7 +785,7 @@ jobs:
             local sleep_seconds=10
 
             while [ "${attempt}" -le "${max_attempts}" ]; do
-              echo "SSM send-command attempt ${attempt}/${max_attempts}"
+              echo "SSM send-command attempt ${attempt}/${max_attempts}" >&2
               local response
               response="$(aws ssm send-command \
                 --instance-ids "${instance_id}" \
@@ -800,9 +800,9 @@ jobs:
                 return 0
               fi
 
-              echo "SendCommand failed: ${response}"
+              echo "SendCommand failed: ${response}" >&2
               if [ "${attempt}" -lt "${max_attempts}" ]; then
-                echo "Retrying in ${sleep_seconds}s..."
+                echo "Retrying in ${sleep_seconds}s..." >&2
                 sleep "${sleep_seconds}"
                 sleep_seconds=$((sleep_seconds + 5))
               fi

--- a/docs/runbooks/ci-cd/ci-infra.md
+++ b/docs/runbooks/ci-cd/ci-infra.md
@@ -101,6 +101,7 @@ flowchart TB
 - The smoke test verifies edge Nginx via SSM (3 retries with 10s delay) before running the external `/healthz` curl.
   - On failure, it prints `systemctl status nginx`, recent `journalctl` logs, and the 443 listen check to speed up diagnostics.
 - The workflow now waits for **SSM PingStatus=Online** before sending commands, and retries `send-command` on transient `InvalidInstanceId` errors.
+- SSM retry logs are sent to stderr so only the command ID is parsed.
 
 ## Post-apply smoke tests (optional)
 


### PR DESCRIPTION
## What Changed
- Send SSM retry logs to stderr so stdout only returns the CommandId
- Keeps command parsing valid for `get-command-invocation`

## Why
Fixes #210

## Files Affected
- .github/workflows/ci-infra.yml
- docs/runbooks/ci-cd/ci-infra.md

## Notes
- Follow-up fix after PR #208 merged

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [x] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [x] Documentation updated (if applicable)
