### PR TITLE
fix(infra): harden SSM command id handling

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -483,7 +483,7 @@ jobs:
                 --query "Command.CommandId" \
                 --output text 2>&1 || true)"
 
-              if [ -n "${response}" ] && [ "${response}" != "None" ] && ! echo "${response}" | grep -qi "InvalidInstanceId"; then
+              if echo "${response}" | grep -Eq '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'; then
                 echo "${response}"
                 return 0
               fi
@@ -498,6 +498,10 @@ jobs:
             done
 
             return 1
+          }
+
+          is_uuid() {
+            echo "$1" | grep -Eq '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'
           }
 
           params="$(jq -cn \
@@ -555,6 +559,17 @@ jobs:
             echo "k3s-ready-check attempt ${attempt}/${max_attempts}"
 
             command_id="$(send_ssm_command "${K3S_SERVER_INSTANCE_ID}" "${params}" 600)"
+
+            if ! is_uuid "${command_id}"; then
+              echo "Invalid SSM command id: ${command_id:-empty}" >&2
+              if [ "${attempt}" -lt "${max_attempts}" ]; then
+                echo "Retrying in ${sleep_seconds}s..." >&2
+                sleep "${sleep_seconds}"
+              fi
+              attempt=$((attempt + 1))
+              sleep_seconds=$((sleep_seconds + 5))
+              continue
+            fi
 
             echo "::notice title=SSM::k3s readiness command_id=${command_id} attempt=${attempt}"
 
@@ -665,7 +680,7 @@ jobs:
                 --query "Command.CommandId" \
                 --output text 2>&1 || true)"
 
-              if [ -n "${response}" ] && [ "${response}" != "None" ] && ! echo "${response}" | grep -qi "InvalidInstanceId"; then
+              if echo "${response}" | grep -Eq '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'; then
                 echo "${response}"
                 return 0
               fi
@@ -680,6 +695,10 @@ jobs:
             done
 
             return 1
+          }
+
+          is_uuid() {
+            echo "$1" | grep -Eq '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'
           }
 
           params="$(jq -cn \
@@ -729,6 +748,11 @@ jobs:
 
           wait_for_instance_ready "${K3S_SERVER_INSTANCE_ID}"
           command_id="$(send_ssm_command "${K3S_SERVER_INSTANCE_ID}" "${params}" 600)"
+
+          if ! is_uuid "${command_id}"; then
+            echo "Invalid SSM command id: ${command_id:-empty}" >&2
+            exit 1
+          fi
 
           echo "::notice title=SSM::argocd app sync command_id=${command_id}"
 
@@ -795,7 +819,7 @@ jobs:
                 --query "Command.CommandId" \
                 --output text 2>&1 || true)"
 
-              if [ -n "${response}" ] && [ "${response}" != "None" ] && ! echo "${response}" | grep -qi "InvalidInstanceId"; then
+              if echo "${response}" | grep -Eq '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'; then
                 echo "${response}"
                 return 0
               fi
@@ -810,6 +834,10 @@ jobs:
             done
 
             return 1
+          }
+
+          is_uuid() {
+            echo "$1" | grep -Eq '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'
           }
 
           params="$(jq -cn \
@@ -859,6 +887,11 @@ jobs:
 
           wait_for_instance_ready "${K3S_SERVER_INSTANCE_ID}"
           command_id="$(send_ssm_command "${K3S_SERVER_INSTANCE_ID}" "${params}" 600)"
+
+          if ! is_uuid "${command_id}"; then
+            echo "Invalid SSM command id: ${command_id:-empty}" >&2
+            exit 1
+          fi
 
           echo "::notice title=SSM::healthz rollout command_id=${command_id}"
 
@@ -915,7 +948,7 @@ jobs:
             local sleep_seconds=10
 
             while [ "${attempt}" -le "${max_attempts}" ]; do
-              echo "SSM send-command attempt ${attempt}/${max_attempts}"
+              echo "SSM send-command attempt ${attempt}/${max_attempts}" >&2
               local response
               response="$(aws ssm send-command \
                 --instance-ids "${instance_id}" \
@@ -925,14 +958,14 @@ jobs:
                 --query "Command.CommandId" \
                 --output text 2>&1 || true)"
 
-              if [ -n "${response}" ] && [ "${response}" != "None" ] && ! echo "${response}" | grep -qi "InvalidInstanceId"; then
+              if echo "${response}" | grep -Eq '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'; then
                 echo "${response}"
                 return 0
               fi
 
-              echo "SendCommand failed: ${response}"
+              echo "SendCommand failed: ${response}" >&2
               if [ "${attempt}" -lt "${max_attempts}" ]; then
-                echo "Retrying in ${sleep_seconds}s..."
+                echo "Retrying in ${sleep_seconds}s..." >&2
                 sleep "${sleep_seconds}"
                 sleep_seconds=$((sleep_seconds + 5))
               fi
@@ -940,6 +973,10 @@ jobs:
             done
 
             return 1
+          }
+
+          is_uuid() {
+            echo "$1" | grep -Eq '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'
           }
 
           params="$(jq -cn \
@@ -992,6 +1029,18 @@ jobs:
           i=0
           while [ $i -lt 3 ]; do
             command_id="$(send_ssm_command "${EDGE_INSTANCE_ID}" "${params}" 120)"
+
+            if ! is_uuid "${command_id}"; then
+              echo "Invalid SSM command id: ${command_id:-empty}" >&2
+              i=$((i+1))
+              if [ $i -lt 3 ]; then
+                echo "Edge nginx check retrying in 10s..." >&2
+                sleep 10
+                continue
+              fi
+              echo "Edge nginx check failed due to invalid command id." >&2
+              exit 1
+            fi
 
             echo "::notice title=SSM::edge nginx check attempt=$((i+1)) command_id=${command_id}"
 

--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -7,8 +7,8 @@ This log tracks incidents and fixes in reverse chronological order. Use it for d
 ### [ci/infra] SSM SendCommand intermittently fails (InvalidInstanceId)
 - **Severity:** Low
 - **Impact:** `ci-infra` k3s-ready-check failed once with `InvalidInstanceId`; rerun succeeded.
-- **Analysis:** SSM SendCommand can be issued before the instance transitions to a valid/managed state.
-- **Resolution:** Add preflight SSM PingStatus check and retry SendCommand with backoff in ci-infra workflow. (Refs: issue #205)
+- **Analysis:** SSM SendCommand can be issued before the instance transitions to a valid/managed state. A second failure mode was identified later: a `send_ssm_command` log line printed to stdout, which polluted the returned CommandId and caused `ValidationException` on `GetCommandInvocation`.
+- **Resolution:** Add preflight SSM PingStatus check and retry SendCommand with backoff in ci-infra workflow. Route all send-command logs to stderr and validate the CommandId against UUID format before polling. (Refs: issue #205, issue #210)
 
 ### [gitops/argocd] Bootstrap failed (Helm nodeSelector parsed as string)
 - **Severity:** Medium


### PR DESCRIPTION
## What Changed
- Routed all send-command logs to stderr to avoid contaminating CommandId output
- Validated CommandId as UUID before polling, with explicit retry/fail paths
- Logged the root cause and fix in issue log

## Why
Fixes #212

## Files Affected
- .github/workflows/ci-infra.yml
- docs/runbooks/troubleshooting/issue-log.md

## Notes
- This prevents ValidationException caused by polluted command IDs while preserving log visibility.

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [x] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [x] Documentation updated (if applicable)
