### PR TITLE
feat(infra): bump k3s worker size to t3a.medium

### DIFF
--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -161,7 +161,7 @@ Values come from `infra/aws/live/dev/terraform.tfvars` unless overridden per env
 | Component | Default instance type | Notes |
 | --- | --- | --- |
 | k3s server | `t3.small` | Private subnet (dev). |
-| k3s workers | `t3.micro` | Auto Scaling Group (dev). |
+| k3s workers | `t3a.medium` | Auto Scaling Group (dev). |
 | edge | `t3.micro` | Public subnet (dev). |
 | NAT instance | `t3.nano` | Public subnet (dev). |
 

--- a/infra/aws/live/dev/terraform.tfvars
+++ b/infra/aws/live/dev/terraform.tfvars
@@ -10,7 +10,7 @@ nat_instance_type    = "t3.nano"
 nat_root_volume_size = 8
 
 k3s_server_instance_type = "t3.small"
-k3s_worker_instance_type = "t3.micro"
+k3s_worker_instance_type = "t3a.medium"
 k3s_worker_min_size      = 1
 k3s_worker_desired       = 1
 k3s_worker_max_size      = 3

--- a/infra/aws/live/dev/terraform.tfvars.example
+++ b/infra/aws/live/dev/terraform.tfvars.example
@@ -10,7 +10,7 @@ nat_instance_type    = "t3.nano"
 nat_root_volume_size = 8
 
 k3s_server_instance_type = "t3.small"
-k3s_worker_instance_type = "t3.micro"
+k3s_worker_instance_type = "t3a.medium"
 k3s_worker_min_size       = 1
 k3s_worker_desired        = 1
 k3s_worker_max_size       = 3


### PR DESCRIPTION
## What Changed
- Updated k3s worker instance type to `t3a.medium` in dev tfvars (and example).
- Refreshed infra doc defaults to match the new worker type.

## Why
Closes #217

## Files Affected
- infra/aws/live/dev/terraform.tfvars
- infra/aws/live/dev/terraform.tfvars.example
- docs/architecture/infrastructure.md

## Notes
- Change is x86-only (no ARM/AMI switch).
- Requires ASG instance refresh on next apply.