### PR TITLE
fix(ops): tune argocd repo-server probes

### DIFF
--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -237,6 +237,7 @@ See [docs/runbooks/observability.md](../runbooks/observability.md) for operation
 - Implemented (IaC, dev): SSM/KMS interface endpoints are temporarily disabled to reduce cost; edge uses HTTPS egress for SSM.
 - Implemented (Platform): ArgoCD bootstrap via SSM/CI for GitOps delivery, Redis buffer in the data namespace, EBS CSI driver + `ebs-gp3` StorageClass.
 - Implemented (Observability): Prometheus + Grafana stack (7d retention, 5GB PVC, $0.50/month), auto-deployed via ArgoCD, manual K8s Secret setup.
+- Planned: migrate Redis PVC off `local-path` to resilient storage (`ebs-gp3`) to avoid node affinity lock-in (issue #221).
 - Planned: additional network hardening, AlertManager rules (Sprint 2).
 
 ## Notes

--- a/docs/runbooks/bootstrap/argocd-bootstrap.md
+++ b/docs/runbooks/bootstrap/argocd-bootstrap.md
@@ -10,6 +10,7 @@ Purpose: install ArgoCD in the k3s cluster so GitOps can manage k8s apps.
   - `ssm:GetCommandInvocation`
   - `ssm:DescribeInstanceInformation`
 - `scripts/bootstrap-argocd.sh` is executable.
+- Repo-server resources and probe timeouts are tuned via `scripts/argocd-values.yaml` (used by the bootstrap script).
 - If using `--env`, instances must be tagged with:
   - `Role=k3s-server`
   - `Environment=<env>`

--- a/scripts/argocd-values.yaml
+++ b/scripts/argocd-values.yaml
@@ -1,0 +1,14 @@
+repoServer:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1
+      memory: 1Gi
+  livenessProbe:
+    timeoutSeconds: 5
+    failureThreshold: 10
+  readinessProbe:
+    timeoutSeconds: 5
+    failureThreshold: 10

--- a/scripts/bootstrap-argocd.sh
+++ b/scripts/bootstrap-argocd.sh
@@ -148,7 +148,7 @@ commands=(
   "sudo --preserve-env=KUBECONFIG helm repo add argo https://argoproj.github.io/argo-helm --force-update"
   "sudo --preserve-env=KUBECONFIG helm repo update"
   # Install or upgrade ArgoCD into its namespace.
-  "sudo --preserve-env=KUBECONFIG helm upgrade --install argocd argo/argo-cd --namespace ${ARGOCD_NAMESPACE} --create-namespace ${HELM_VERSION_FLAG} --set-json 'global.nodeSelector={\"node-role.kubernetes.io/control-plane\":\"true\"}' --set-json 'global.tolerations=[{\"key\":\"dedicated\",\"operator\":\"Equal\",\"value\":\"control-plane\",\"effect\":\"NoSchedule\"}]'"
+  "sudo --preserve-env=KUBECONFIG helm upgrade --install argocd argo/argo-cd --namespace ${ARGOCD_NAMESPACE} --create-namespace ${HELM_VERSION_FLAG} --values scripts/argocd-values.yaml --set-json 'global.nodeSelector={\"node-role.kubernetes.io/control-plane\":\"true\"}' --set-json 'global.tolerations=[{\"key\":\"dedicated\",\"operator\":\"Equal\",\"value\":\"control-plane\",\"effect\":\"NoSchedule\"}]'"
   # Wait for CRDs and ArgoCD server to be ready before creating the Application.
   "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=120s --request-timeout=5s"
   "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n ${ARGOCD_NAMESPACE} wait --for=condition=Available deployment/argocd-server --timeout=300s --request-timeout=5s"


### PR DESCRIPTION
## Summary
- Added ArgoCD repo-server values file to tune probes and resource requests/limits
- Wired bootstrap script to apply 
- Documented the tuning in the ArgoCD bootstrap runbook
- Logged Redis local-path PVC incident + planned migration note in infra docs

## Why
- Repo-server liveness/readiness were timing out on small nodes due to default probe timeout=1s and no resources, causing CrashLoop
- Redis local-path PVC pinned to a dead node caused Pending state; documenting the incident + follow-up task

## Testing
- Not run (docs/config change)
