### PR TITLE
fix(k8s): add readyz probes for healthz

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## 📌 Project Overview
 
-**CloudRadar** is a **DevOps & Cloud Architecture showcase**: a lightweight AWS platform that runs a **queue-driven telemetry pipeline** (ingester → Redis list → consumers) on a minimal k3s stack. It emphasizes cost-efficient infrastructure choices, GitOps delivery, and operational readiness.
+**CloudRadar** is a **DevOps & Cloud Architecture showcase**: a lightweight AWS platform that runs a **queue-driven telemetry pipeline** (ingester → Redis list → consumers) on a minimal k3s stack. It focuses on cost-efficient infrastructure choices, GitOps delivery, and operational readiness.
 
 **Functional Overview:** Ingest live flight telemetry from OpenSky, aggregate events, and expose data for a map dashboard with alertable zones.
 
@@ -124,7 +124,7 @@ ArgoCD syncs everything under `k8s/apps` automatically.
 
 | App | Role | Namespace | Status |
 | --- | --- | --- | --- |
-| `health` | Minimal `/healthz` endpoint | `cloudradar` | Implemented |
+| `health` | Minimal `/healthz` endpoint + `/readyz` probe | `cloudradar` | Implemented |
 | `redis` | Event buffer | `data` | Implemented |
 | `ingester` | OpenSky ingestion | `cloudradar` | Implemented |
 | `processor` | Redis aggregates | `cloudradar` | Implemented |

--- a/docs/architecture/application-architecture.md
+++ b/docs/architecture/application-architecture.md
@@ -265,7 +265,7 @@ Lightweight health check endpoint for the edge load balancer and general cluster
 ```mermaid
 flowchart LR
     Client["Edge Nginx<br/>(load balancer)"]
-    HealthApp["Health Endpoint<br/>(:8080/healthz)"]
+    HealthApp["Health Endpoint<br/>(:8080/healthz, /readyz)"]
     K8sAPI["k3s API Server<br/>(authenticated)"]
     
     Client -->|GET /healthz| HealthApp
@@ -277,8 +277,8 @@ flowchart LR
 
 | Endpoint | Method | Response | Purpose |
 |----------|--------|----------|---------|
-| `/healthz` | GET | 200 OK (if cluster healthy) | General health status |
-| `/health` | GET | JSON health details | Extended health info |
+| `/readyz` | GET | 200 OK | Process readiness for probes |
+| `/healthz` | GET | 200 OK (if cluster healthy) | Cluster health status |
 
 ### Configuration (Environment Variables)
 
@@ -475,7 +475,7 @@ k8s/apps/
 
 Each service:
 - Runs in the `cloudradar` namespace (by default)
-- Exposes `/healthz` for liveness probes
+- Exposes `/healthz` for health checks; the health app also exposes `/readyz` for probes
 - Exposes `/metrics` or `/metrics/prometheus` for Prometheus scraping
 - Has defined resource requests/limits (CPU, memory)
 

--- a/docs/runbooks/operations/health-endpoint.md
+++ b/docs/runbooks/operations/health-endpoint.md
@@ -1,6 +1,6 @@
 # Health Endpoint (edge -> k3s)
 
-Purpose: expose a `/healthz` endpoint through the edge Nginx to validate end-to-end connectivity and return non-sensitive cluster aggregates.
+Purpose: expose a `/healthz` endpoint through the edge Nginx to validate end-to-end connectivity and return non-sensitive cluster aggregates. The pod also exposes `/readyz` for liveness/readiness probes.
 
 ## Prerequisites
 - ArgoCD is installed and synced.
@@ -82,6 +82,7 @@ flowchart LR
 - If the Kubernetes API is unreachable, the endpoint returns `status=degraded` with error details.
 - If Metrics Server is missing, health stays `ok` but `metrics.available=false`.
 - The service is designed for **end-to-end validation** (edge → k3s → API) rather than deep diagnostics.
+- Liveness/readiness probes use `/readyz` so cluster slowness does not crash the pod.
 
 ## Notes
 - `/healthz` is protected by the edge Basic Auth.

--- a/k8s/apps/health/deployment.yaml
+++ b/k8s/apps/health/deployment.yaml
@@ -28,12 +28,20 @@ spec:
               name: http
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 2
+            periodSeconds: 10
+            failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 2
+            periodSeconds: 10
+            failureThreshold: 3
           resources:
             requests:
               cpu: 50m

--- a/src/health/app.py
+++ b/src/health/app.py
@@ -127,6 +127,20 @@ def collect_cluster_status():
 
 class HealthHandler(BaseHTTPRequestHandler):
   def do_GET(self):  # noqa: N802
+    if self.path == "/readyz":
+      payload = {
+        "status": "ready",
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+      }
+      body = json.dumps(payload).encode("utf-8")
+
+      self.send_response(200)
+      self.send_header("Content-Type", "application/json")
+      self.send_header("Content-Length", str(len(body)))
+      self.end_headers()
+      self.wfile.write(body)
+      return
+
     if self.path != "/healthz":
       self.send_response(404)
       self.end_headers()


### PR DESCRIPTION
## Summary
- add `/readyz` endpoint for health service readiness
- switch healthz probes to `/readyz` with initial delays/timeouts
- update README, architecture notes, health runbook, and issue log

## Testing
- Not run (k8s/healthz rollout pending)

Fixes #227
