### PR TITLE
fix(ci): switch to repo-scoped GHCR images

### DIFF
--- a/docs/runbooks/ci-cd/ci-app.md
+++ b/docs/runbooks/ci-cd/ci-app.md
@@ -66,8 +66,8 @@ Tags are **explicit and context-aware** for clarity and traceability.
 #### On pull requests
 
 ```
-ghcr.io/clementv78/cloudradar-ingester:pr-173
-ghcr.io/clementv78/cloudradar-ingester:85591c6
+ghcr.io/clementv78/CloudRadar/ingester:pr-173
+ghcr.io/clementv78/CloudRadar/ingester:85591c6
 ```
 
 **Use case**: Test image from a specific PR without affecting main.
@@ -75,8 +75,8 @@ ghcr.io/clementv78/cloudradar-ingester:85591c6
 #### On branches (e.g., `feature/prometheus-exporter`)
 
 ```
-ghcr.io/clementv78/cloudradar-ingester:feature-prometheus-exporter
-ghcr.io/clementv78/cloudradar-ingester:feature-prometheus-exporter-85591c6
+ghcr.io/clementv78/CloudRadar/ingester:feature-prometheus-exporter
+ghcr.io/clementv78/CloudRadar/ingester:feature-prometheus-exporter-85591c6
 ```
 
 **Use case**: Build and test from feature branches before merge.
@@ -84,9 +84,9 @@ ghcr.io/clementv78/cloudradar-ingester:feature-prometheus-exporter-85591c6
 #### On main (default branch)
 
 ```
-ghcr.io/clementv78/cloudradar-ingester:main
-ghcr.io/clementv78/cloudradar-ingester:latest
-ghcr.io/clementv78/cloudradar-ingester:main-85591c6
+ghcr.io/clementv78/CloudRadar/ingester:main
+ghcr.io/clementv78/CloudRadar/ingester:latest
+ghcr.io/clementv78/CloudRadar/ingester:main-85591c6
 ```
 
 **Use case**: Stable release images; `latest` points to main.
@@ -94,8 +94,8 @@ ghcr.io/clementv78/cloudradar-ingester:main-85591c6
 #### On tags (e.g., `v1.0.0`)
 
 ```
-ghcr.io/clementv78/cloudradar-ingester:1.0.0
-ghcr.io/clementv78/cloudradar-ingester:85591c6
+ghcr.io/clementv78/CloudRadar/ingester:1.0.0
+ghcr.io/clementv78/CloudRadar/ingester:85591c6
 ```
 
 **Use case**: Release-pinned versions.
@@ -107,14 +107,14 @@ ghcr.io/clementv78/cloudradar-ingester:85591c6
 All images are pushed to **GitHub Container Registry (GHCR)**:
 
 ```
-ghcr.io/{owner}/cloudradar-{service}:{tag}
+ghcr.io/{owner}/{repo}/{service}:{tag}
 ```
 
 Example:
 ```
-ghcr.io/clementv78/cloudradar-ingester:latest
-ghcr.io/clementv78/cloudradar-ingester:main-5f3a2c1d
-ghcr.io/clementv78/cloudradar-processor:1.0.0
+ghcr.io/clementv78/CloudRadar/ingester:latest
+ghcr.io/clementv78/CloudRadar/ingester:main-5f3a2c1d
+ghcr.io/clementv78/CloudRadar/processor:1.0.0
 ```
 
 ## Accessing GHCR images
@@ -124,12 +124,12 @@ After images are pushed:
 1. **List packages**: [GHCR packages](https://github.com/ClementV78?tab=packages)
 2. **Pull an image**:
    ```bash
-   docker pull ghcr.io/clementv78/cloudradar/ingester:latest
+   docker pull ghcr.io/clementv78/CloudRadar/ingester:latest
    ```
 3. **Authentication** (if image is private):
    ```bash
    echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-   docker pull ghcr.io/clementv78/cloudradar/ingester:latest
+   docker pull ghcr.io/clementv78/CloudRadar/ingester:latest
    ```
 
 ## Workflow diagram (Mermaid)

--- a/k8s/apps/admin-scale/deployment.yaml
+++ b/k8s/apps/admin-scale/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: admin-scale
-          image: ghcr.io/clementv78/cloudradar-admin-scale:0.1.0
+          image: ghcr.io/clementv78/CloudRadar/admin-scale:0.1.0
           imagePullPolicy: IfNotPresent
           env:
             - name: ADMIN_TOKEN_SSM_NAME

--- a/k8s/apps/health/deployment.yaml
+++ b/k8s/apps/health/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: healthz
-          image: ghcr.io/clementv78/cloudradar-health:0.1.1
+          image: ghcr.io/clementv78/CloudRadar/health:0.1.1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/k8s/apps/ingester/deployment.yaml
+++ b/k8s/apps/ingester/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: ingester
-          image: ghcr.io/clementv78/cloudradar-ingester:0.1.4
+          image: ghcr.io/clementv78/CloudRadar/ingester:0.1.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/k8s/apps/processor/deployment.yaml
+++ b/k8s/apps/processor/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: processor
-          image: ghcr.io/clementv78/cloudradar-processor:0.1.0
+          image: ghcr.io/clementv78/CloudRadar/processor:0.1.0
           imagePullPolicy: IfNotPresent
           env:
             - name: REDIS_HOST


### PR DESCRIPTION
## Summary
- publish images to repo-scoped GHCR paths (`ghcr.io/<owner>/<repo>/<service>`) to avoid user-scoped write_package errors
- add semver tag output (vX.Y.Z -> X.Y.Z)
- update k8s manifests and CI runbook examples accordingly

## Testing
- Not run (CI builds/pushes on merge or tag)

Fixes #233
