### PR TITLE
fix(obs): migrate Grafana chart repo

### DIFF
--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -2,6 +2,17 @@
 
 This log tracks incidents and fixes in reverse chronological order. Use it for debugging patterns and onboarding.
 
+## 2026-02-02
+
+### [obs/monitoring] Grafana chart repo migration (old chart version missing)
+- **Severity:** Medium
+- **Impact:** ArgoCD reported `ComparisonError` and failed to generate manifests for Grafana; app remained `Unknown` and sync stalled.
+- **Investigation (timeline):**
+  - `kubectl -n argocd describe application grafana` showed manifest generation failures.
+  - `argocd-repo-server` logs showed `helm pull ... grafana` failing for version `7.6.10` in `https://grafana.github.io/helm-charts`.
+- **Analysis:** The Grafana Helm chart moved to `grafana-community/helm-charts`. The old repo no longer served the pinned version.
+- **Resolution:** Switch `repoURL` to `https://grafana-community.github.io/helm-charts` and update `targetRevision` to a valid release (e.g., `10.5.15`).
+
 ## 2026-02-01
 
 ### [app/health] healthz CrashLoop blocks ArgoCD sync (probes coupled to cluster metrics)

--- a/k8s/apps/monitoring/grafana-app.yaml
+++ b/k8s/apps/monitoring/grafana-app.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://grafana.github.io/helm-charts
+    repoURL: https://grafana-community.github.io/helm-charts
     chart: grafana
-    targetRevision: "7.6.10"
+    targetRevision: "10.5.15"
     helm:
       values: |
         admin:


### PR DESCRIPTION
- Update Grafana ArgoCD app to use grafana-community Helm repo and a valid chart version.
- Restore ArgoCD manifest generation by removing the missing chart reference.
- Log the incident and resolution in the troubleshooting issue journal.

Fixes #238