### PR TITLE
fix(k8s): apply external-secrets manifests

### DIFF
--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
+  - external-secrets
   - ebs-csi-application.yaml
   - admin-scale
   - health


### PR DESCRIPTION
## What Changed
- Add external-secrets to the k8s/apps kustomization so ESO resources are applied.

## Why
Fixes #242

## Files Affected
- k8s/apps/kustomization.yaml

## Notes
- Enables ExternalSecret/SecretStore creation (grafana-admin secret generation).

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [x] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [x] Documentation updated (if applicable)