### PR TITLE
fix(k8s): sync grafana admin secret

### DIFF
--- a/k8s/apps/external-secrets/grafana-secret.yaml
+++ b/k8s/apps/external-secrets/grafana-secret.yaml
@@ -2,16 +2,19 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: grafana-admin
-  namespace: default
+  namespace: monitoring
 spec:
   refreshInterval: 1h
   secretStoreRef:
     name: ssm-parameter-store
     kind: ClusterSecretStore
   target:
-    name: grafana-secret
+    name: grafana-admin
     creationPolicy: Owner
   data:
+    - secretKey: admin-user
+      remoteRef:
+        key: /cloudradar/grafana-admin-user
     - secretKey: password
       remoteRef:
         key: /cloudradar/grafana-admin-password


### PR DESCRIPTION
## What Changed
- Move the Grafana ExternalSecret to the monitoring namespace.
- Align target secret name with Grafana chart expectations.
- Add admin-user from SSM so the secret contains both required keys.

## Why
Fixes #244

## Files Affected
- k8s/apps/external-secrets/grafana-secret.yaml

## Notes
- Requires SSM param `/cloudradar/grafana-admin-user` to exist.

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [x] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [x] Documentation updated (if applicable)