### PR TITLE
fix(k8s): align grafana secret key

### DIFF
--- a/k8s/apps/external-secrets/grafana-secret.yaml
+++ b/k8s/apps/external-secrets/grafana-secret.yaml
@@ -15,6 +15,6 @@ spec:
     - secretKey: admin-user
       remoteRef:
         key: /cloudradar/grafana-admin-user
-    - secretKey: password
+    - secretKey: admin-password
       remoteRef:
         key: /cloudradar/grafana-admin-password


### PR DESCRIPTION
## What Changed
- Align ExternalSecret key name with Grafana chart expectations.

## Why
Fixes #244

## Files Affected
- k8s/apps/external-secrets/grafana-secret.yaml

## Notes
- No other behavior changes.

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [x] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [ ] Documentation updated (if applicable)