### PR TITLE
docs(runbooks): clarify traefik nodeport routing

### DIFF
--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -214,9 +214,10 @@ The legacy `/cloudradar/prometheus/auth-password` parameter is not used.
 
 ### Access Path (Prometheus / Grafana)
 - Public access goes through **edge Nginx (EC2)** which enforces Basic Auth (SSM: `/cloudradar/edge/basic-auth`).
-- Traffic is forwarded to K3s via NodePort; **Traefik** handles in-cluster routing by **host header**.
+- Traffic is forwarded to K3s via the **Traefik NodePort**; Traefik handles in-cluster routing by **host header**.
 - Edge Nginx rewrites the Host header to match the internal Ingress hosts (`grafana.cloudradar.local`, `prometheus.cloudradar.local`).
-- Edge upstream ports for Grafana/Prometheus should target the Traefik entrypoint (port 80) when using host-based Ingress routing.
+- Edge upstream ports for Grafana/Prometheus should target the Traefik **HTTP NodePort** (default `30353` in k3s) when using host-based Ingress routing.
+- Terraform inputs: `edge_grafana_nodeport` and `edge_prometheus_nodeport` must match the Traefik NodePort.
 - There is **no in-cluster proxy** for Prometheus or Grafana; keep a single auth layer at the edge.
 
 **URLs (edge):**


### PR DESCRIPTION
## What Changed
- Clarify Traefik NodePort routing for Grafana/Prometheus in observability runbook.

## Why
Refs #57

## Files Affected
- docs/runbooks/observability.md

## Notes
- Documents the Traefik HTTP NodePort and Terraform inputs.

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [ ] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [x] Documentation updated (if applicable)