### PR TITLE
fix(k8s): split ArgoCD bootstrap into platform/apps

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -590,7 +590,7 @@ jobs:
           echo "k3s-ready-check failed after ${max_attempts} attempts"
           exit 1
 
-  argocd-bootstrap:
+  argocd-install:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'dev' }}
     runs-on: ubuntu-latest
     needs:
@@ -606,14 +606,62 @@ jobs:
           role-to-assume: ${{ env.TF_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Bootstrap ArgoCD via SSM
-        run: scripts/bootstrap-argocd.sh "${{ needs.tf-outputs.outputs.k3s_server_instance_id }}" "${AWS_REGION}"
+      - name: Install ArgoCD via SSM
+        run: scripts/bootstrap-argocd-install.sh "${{ needs.tf-outputs.outputs.k3s_server_instance_id }}" "${AWS_REGION}"
+
+  argocd-platform:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'dev' }}
+    runs-on: ubuntu-latest
+    needs:
+      - argocd-install
+      - tf-outputs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.TF_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Bootstrap platform app via SSM
+        env:
+          WAIT_CRDS: externalsecrets.external-secrets.io,clustersecretstores.external-secrets.io,secretstores.external-secrets.io
+          ARGOCD_APP_NAME: cloudradar-platform
+          ARGOCD_APP_NAMESPACE: argocd
+          ARGOCD_APP_PATH: k8s/platform
+        run: scripts/bootstrap-argocd-app.sh "${{ needs.tf-outputs.outputs.k3s_server_instance_id }}" "${AWS_REGION}"
+
+  argocd-apps:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'dev' }}
+    runs-on: ubuntu-latest
+    needs:
+      - argocd-platform
+      - tf-outputs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.TF_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Bootstrap apps app via SSM
+        env:
+          IGNORE_INGESTER_REPLICAS: "true"
+          ARGOCD_APP_NAME: cloudradar
+          ARGOCD_APP_NAMESPACE: cloudradar
+          ARGOCD_APP_PATH: k8s/apps
+        run: scripts/bootstrap-argocd-app.sh "${{ needs.tf-outputs.outputs.k3s_server_instance_id }}" "${AWS_REGION}"
 
   smoke-tests:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'dev' && inputs.run_smoke_tests == 'true' }}
     runs-on: ubuntu-latest
     needs:
-      - argocd-bootstrap
+      - argocd-apps
       - tf-outputs
     steps:
       - name: Configure AWS credentials

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -19,9 +19,9 @@ Prometheus scrapes metrics from all k3s services. Grafana provides dashboards fo
    - Outputs passwords for display/use
    - **Does NOT create K8s Secrets** (cluster access happens after bootstrap)
 
-2. **Bootstrap ArgoCD Phase** (`scripts/bootstrap-argocd.sh`)
+2. **Bootstrap ArgoCD Phase** (`scripts/bootstrap-argocd-install.sh` + `scripts/bootstrap-argocd-app.sh`)
    - Installs ArgoCD on k3s server
-   - Sets up GitOps root Application pointing to `k8s/apps`
+   - Creates `cloudradar-platform` (k8s/platform) then `cloudradar` (k8s/apps)
    - ArgoCD discovers monitoring Applications in `k8s/apps/monitoring/`
    - **Waits for K8s Secrets before syncing Grafana**
 
@@ -108,7 +108,7 @@ kubectl rollout status statefulset/prometheus-kube-prometheus-prometheus -n moni
 
 In Sprint 2, consider:
 - Using External Secrets Operator to auto-sync SSM → K8s Secrets
-- Creating a post-bootstrap hook in bootstrap-argocd.sh
+- Creating a post-bootstrap hook in bootstrap-argocd-app.sh
 - Using ArgoCD pre-sync hooks to verify Secrets exist
 
 For now (MVP), the manual approach ensures we don't over-engineer the bootstrap flow.

--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -2,6 +2,18 @@
 
 This log tracks incidents and fixes in reverse chronological order. Use it for debugging patterns and onboarding.
 
+## 2026-02-03
+
+### [gitops/argocd] Root app sync failed (ESO CRDs missing)
+- **Severity:** High
+- **Impact:** `cloudradar` Application sync failed with `SyncError`; namespaces/apps were not created.
+- **Investigation (timeline):**
+  - `kubectl -n argocd describe app cloudradar` showed `ExternalSecret`/`ClusterSecretStore` resources invalid.
+  - `kubectl get crd | grep -i external-secrets` returned empty.
+  - ESO Applications were not present, so CRDs never installed.
+- **Analysis:** ArgoCD root app synced `k8s/apps` before `k8s/platform`, so External Secrets resources applied before ESO CRDs existed.
+- **Resolution:** Split bootstrap into platform-first then apps, create separate root apps (`cloudradar-platform`, `cloudradar`), and remove `external-secrets` from `k8s/apps/kustomization.yaml`.
+
 ## 2026-02-02
 
 ### [obs/monitoring] Prometheus stuck OutOfSync (missing CRDs)

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,6 +1,6 @@
 # Kubernetes manifests layout
 
-This folder is split between **applications** and **platform** concerns. ArgoCD tracks both trees from the root Application created by the bootstrap script.
+This folder is split between **applications** and **platform** concerns. ArgoCD tracks both trees using two root Applications created by the bootstrap scripts.
 
 ## Structure (v1)
 ```
@@ -15,7 +15,7 @@ k8s/
 │   ├── processor/       # Java processor service
 │   ├── redis/           # Redis buffer
 │   ├── monitoring/      # Prometheus/Grafana Applications
-│   └── external-secrets/# SecretStore + ExternalSecrets (SSM -> K8s Secrets)
+│   └── external-secrets/# SecretStore + ExternalSecrets (SSM -> K8s Secrets, managed by platform app)
 └── platform/            # Shared platform components managed by ArgoCD
     ├── kustomization.yaml
     └── external-secrets/
@@ -24,7 +24,7 @@ k8s/
 ```
 
 ## Conventions
-- **ArgoCD root** (bootstrap) watches two sources: `k8s/apps` and `k8s/platform`.
+- **ArgoCD roots** (bootstrap) create two Applications: `cloudradar-platform` (k8s/platform) and `cloudradar` (k8s/apps).
 - **Apps tree**: business/observability workloads and their Applications. Each subfolder should have its own kustomization when it contains multiple resources. External Secrets manifests are managed via the `external-secrets-config` Application (platform), so the `external-secrets` folder is *not* referenced from `k8s/apps/kustomization.yaml`.
 - **Platform tree**: cluster-level operators or shared components (e.g., ESO). Use ArgoCD sync waves/dependsOn when CRDs are involved.
 - **Namespaces**: `apps` for workloads, `monitoring` for Prom/Grafana, `external-secrets` for ESO controllers; SecretStore is cluster-scoped, ExternalSecrets live in `default` unless specified.

--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
-  - external-secrets
   - ebs-csi-application.yaml
   - admin-scale
   - health

--- a/scripts/bootstrap-argocd-app.sh
+++ b/scripts/bootstrap-argocd-app.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create or update an ArgoCD Application via SSM and optionally wait for CRDs.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/bootstrap-argocd-common.sh
+source "${SCRIPT_DIR}/lib/bootstrap-argocd-common.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: bootstrap-argocd-app.sh [--env <env>] [--project <project>] [--region <region>] [<instance-id>]
+
+Example:
+  scripts/bootstrap-argocd-app.sh i-0123456789abcdef us-east-1
+  scripts/bootstrap-argocd-app.sh --env dev --project cloudradar --region us-east-1
+
+Environment overrides:
+  ARGOCD_NAMESPACE=argocd
+  ARGOCD_APP_NAME=cloudradar
+  ARGOCD_APP_NAMESPACE=cloudradar
+  ARGOCD_APP_REPO=https://github.com/ClementV78/CloudRadar.git
+  ARGOCD_APP_PATH=k8s/apps
+  ARGOCD_APP_REVISION=main
+  IGNORE_INGESTER_REPLICAS=false
+  WAIT_CRDS=externalsecrets.external-secrets.io,clustersecretstores.external-secrets.io,secretstores.external-secrets.io
+USAGE
+}
+
+ENVIRONMENT=""
+PROJECT=""
+INSTANCE_ID=""
+REGION_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)
+      ENVIRONMENT="${2:-}"
+      shift 2
+      ;;
+    --project)
+      PROJECT="${2:-}"
+      shift 2
+      ;;
+    --region)
+      REGION_OVERRIDE="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -* )
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -gt 0 ]]; then
+  if is_instance_id "$1"; then
+    INSTANCE_ID="$1"
+    shift
+  fi
+fi
+
+REGION="${REGION_OVERRIDE:-${AWS_REGION:-us-east-1}}"
+if [[ -z "${REGION_OVERRIDE}" && $# -gt 0 ]]; then
+  if is_region "$1"; then
+    REGION="$1"
+    shift
+  fi
+fi
+
+ARGOCD_NAMESPACE="${ARGOCD_NAMESPACE:-argocd}"
+ARGOCD_APP_NAME="${ARGOCD_APP_NAME:-cloudradar}"
+ARGOCD_APP_NAMESPACE="${ARGOCD_APP_NAMESPACE:-cloudradar}"
+ARGOCD_APP_REPO="${ARGOCD_APP_REPO:-https://github.com/ClementV78/CloudRadar.git}"
+ARGOCD_APP_PATH="${ARGOCD_APP_PATH:-k8s/apps}"
+ARGOCD_APP_REVISION="${ARGOCD_APP_REVISION:-main}"
+IGNORE_INGESTER_REPLICAS="${IGNORE_INGESTER_REPLICAS:-false}"
+WAIT_CRDS="${WAIT_CRDS:-}"
+
+require_cmd aws
+require_cmd jq
+
+INSTANCE_ID="$(ensure_instance_id "${REGION}" "${ENVIRONMENT}" "${PROJECT}" "${INSTANCE_ID}")"
+
+app_lines=(
+  "apiVersion: argoproj.io/v1alpha1"
+  "kind: Application"
+  "metadata:"
+  "  name: ${ARGOCD_APP_NAME}"
+  "  namespace: ${ARGOCD_NAMESPACE}"
+  "spec:"
+  "  project: default"
+  "  source:"
+  "    repoURL: ${ARGOCD_APP_REPO}"
+  "    targetRevision: ${ARGOCD_APP_REVISION}"
+  "    path: ${ARGOCD_APP_PATH}"
+  "  destination:"
+  "    server: https://kubernetes.default.svc"
+  "    namespace: ${ARGOCD_APP_NAMESPACE}"
+  "  syncPolicy:"
+  "    automated:"
+  "      prune: true"
+  "      selfHeal: true"
+  "    syncOptions:"
+  "      - CreateNamespace=true"
+)
+
+if [[ "${IGNORE_INGESTER_REPLICAS}" == "true" ]]; then
+  app_lines+=(
+    "  ignoreDifferences:"
+    "  - group: apps"
+    "    kind: Deployment"
+    "    name: ingester"
+    "    namespace: ${ARGOCD_APP_NAMESPACE}"
+    "    jsonPointers:"
+    "    - /spec/replicas"
+  )
+fi
+
+printf_cmd="printf '%s\\n'"
+for line in "${app_lines[@]}"; do
+  safe_line="${line//\'/\'\"\'\"\'}"
+  printf_cmd+=" '${safe_line}'"
+done
+printf_cmd+=" | sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl apply -f -"
+
+commands=(
+  # SSM runs commands via /bin/sh; keep syntax POSIX-compatible.
+  "set -eu"
+  # Wait for kubectl to be installed by k3s (SSM may run before cloud-init finishes).
+  "i=0; while [ \$i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo \"Waiting for kubectl...\"; sleep 10; i=\$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo \"kubectl not found after 300s\"; exit 1; fi"
+  # Point kubectl to the k3s kubeconfig on the instance.
+  "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml"
+  # Apply the Application manifest.
+  "${printf_cmd}"
+)
+
+if [[ -n "${WAIT_CRDS}" ]]; then
+  wait_list="${WAIT_CRDS//,/ }"
+  commands+=(
+    "for crd in ${wait_list}; do echo \"Waiting for CRD ${crd}...\"; sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl wait --for=condition=Established crd/${crd} --timeout=300s --request-timeout=5s; done"
+  )
+fi
+
+ssm_run_commands "${REGION}" "${INSTANCE_ID}" 900 "argocd app ${ARGOCD_APP_NAME}" commands

--- a/scripts/bootstrap-argocd-install.sh
+++ b/scripts/bootstrap-argocd-install.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install/upgrade ArgoCD on the k3s server via SSM.
+# Steps: resolve target instance, install Helm + ArgoCD, wait for readiness.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/bootstrap-argocd-common.sh
+source "${SCRIPT_DIR}/lib/bootstrap-argocd-common.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: bootstrap-argocd-install.sh [--env <env>] [--project <project>] [--region <region>] [<instance-id>] [argocd-chart-version]
+
+Example:
+  scripts/bootstrap-argocd-install.sh i-0123456789abcdef us-east-1
+  scripts/bootstrap-argocd-install.sh --env dev --project cloudradar --region us-east-1
+
+Environment overrides:
+  ARGOCD_NAMESPACE=argocd
+  ARGOCD_CHART_VERSION=9.3.4
+USAGE
+}
+
+ENVIRONMENT=""
+PROJECT=""
+INSTANCE_ID=""
+REGION_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)
+      ENVIRONMENT="${2:-}"
+      shift 2
+      ;;
+    --project)
+      PROJECT="${2:-}"
+      shift 2
+      ;;
+    --region)
+      REGION_OVERRIDE="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -* )
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -gt 0 ]]; then
+  if is_instance_id "$1"; then
+    INSTANCE_ID="$1"
+    shift
+  fi
+fi
+
+REGION="${REGION_OVERRIDE:-${AWS_REGION:-us-east-1}}"
+if [[ -z "${REGION_OVERRIDE}" && $# -gt 0 ]]; then
+  if is_region "$1"; then
+    REGION="$1"
+    shift
+  fi
+fi
+
+ARGOCD_CHART_VERSION="${1:-${ARGOCD_CHART_VERSION:-9.3.4}}"
+ARGOCD_NAMESPACE="${ARGOCD_NAMESPACE:-argocd}"
+ARGOCD_VALUES_FILE="${SCRIPT_DIR}/argocd-values.yaml"
+ARGOCD_VALUES_CONTENT=""
+HELM_VERSION_FLAG=""
+
+if [[ -n "${ARGOCD_CHART_VERSION}" ]]; then
+  HELM_VERSION_FLAG="--version ${ARGOCD_CHART_VERSION}"
+fi
+
+require_cmd aws
+require_cmd jq
+
+if [[ -f "${ARGOCD_VALUES_FILE}" ]]; then
+  ARGOCD_VALUES_CONTENT="$(cat "${ARGOCD_VALUES_FILE}")"
+else
+  echo "Missing ${ARGOCD_VALUES_FILE}. Run from the repo root." >&2
+  exit 1
+fi
+
+INSTANCE_ID="$(ensure_instance_id "${REGION}" "${ENVIRONMENT}" "${PROJECT}" "${INSTANCE_ID}")"
+
+commands=(
+  # SSM runs commands via /bin/sh; keep syntax POSIX-compatible.
+  "set -eu"
+  # Wait for kubectl to be installed by k3s (SSM may run before cloud-init finishes).
+  "i=0; while [ \$i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo \"Waiting for kubectl...\"; sleep 10; i=\$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo \"kubectl not found after 300s\"; exit 1; fi"
+  # Write repo-server tuning values to a local file on the instance (SSM doesn't have the repo).
+  "cat <<'EOF' >/tmp/argocd-values.yaml
+${ARGOCD_VALUES_CONTENT}
+EOF"
+  # Point kubectl/helm to the k3s kubeconfig on the instance.
+  "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml"
+  # Install Helm if missing (k3s AMIs might not include it).
+  "command -v helm >/dev/null 2>&1 || curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | sudo bash"
+  # Add/update Argo Helm repo so the chart is available.
+  "sudo --preserve-env=KUBECONFIG helm repo add argo https://argoproj.github.io/argo-helm --force-update"
+  "sudo --preserve-env=KUBECONFIG helm repo update"
+  # Install or upgrade ArgoCD into its namespace.
+  "sudo --preserve-env=KUBECONFIG helm upgrade --install argocd argo/argo-cd --namespace ${ARGOCD_NAMESPACE} --create-namespace ${HELM_VERSION_FLAG} --values /tmp/argocd-values.yaml --set-json 'global.nodeSelector={\"node-role.kubernetes.io/control-plane\":\"true\"}' --set-json 'global.tolerations=[{\"key\":\"dedicated\",\"operator\":\"Equal\",\"value\":\"control-plane\",\"effect\":\"NoSchedule\"}]'"
+  # Wait for CRDs and ArgoCD server to be ready.
+  "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=120s --request-timeout=5s"
+  "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n ${ARGOCD_NAMESPACE} wait --for=condition=Available deployment/argocd-server --timeout=300s --request-timeout=5s"
+  "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n ${ARGOCD_NAMESPACE} get pods -o wide --request-timeout=5s"
+)
+
+ssm_run_commands "${REGION}" "${INSTANCE_ID}" 1200 "argocd install" commands

--- a/scripts/bootstrap-argocd.sh
+++ b/scripts/bootstrap-argocd.sh
@@ -1,244 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Bootstrap ArgoCD on the k3s server via SSM, then create the root GitOps Application.
-# Steps: resolve target instance, install Helm + ArgoCD, wait for readiness, apply the Application manifest.
+# Compatibility wrapper for the ArgoCD bootstrap flow.
+# Prefer using bootstrap-argocd-install.sh + bootstrap-argocd-app.sh directly.
 
-usage() {
-  cat <<'USAGE'
-Usage: bootstrap-argocd.sh [--env <env>] [--project <project>] [--region <region>] [<instance-id>] [argocd-chart-version]
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-Example:
-  scripts/bootstrap-argocd.sh i-0123456789abcdef us-east-1
-  scripts/bootstrap-argocd.sh --env dev --project cloudradar --region us-east-1
+cat <<'NOTICE' >&2
+NOTICE: scripts/bootstrap-argocd.sh is now a wrapper.
+- install: scripts/bootstrap-argocd-install.sh
+- apps:    scripts/bootstrap-argocd-app.sh (platform/apps)
+NOTICE
 
-Environment overrides:
-  ARGOCD_NAMESPACE=argocd
-  ARGOCD_APP_NAME=cloudradar
-  ARGOCD_APP_NAMESPACE=cloudradar
-  ARGOCD_APP_REPO=https://github.com/ClementV78/CloudRadar.git
-  ARGOCD_APP_PATH=k8s/apps
-  ARGOCD_APP_REVISION=main
-  ARGOCD_CHART_VERSION=9.3.4
-USAGE
-}
+"${SCRIPT_DIR}/bootstrap-argocd-install.sh" "$@"
 
-ENVIRONMENT=""
-PROJECT=""
-INSTANCE_ID=""
-REGION_OVERRIDE=""
+WAIT_CRDS="${WAIT_CRDS:-externalsecrets.external-secrets.io,clustersecretstores.external-secrets.io,secretstores.external-secrets.io}" \
+ARGOCD_APP_NAME="${ARGOCD_PLATFORM_APP_NAME:-cloudradar-platform}" \
+ARGOCD_APP_NAMESPACE="${ARGOCD_PLATFORM_APP_NAMESPACE:-argocd}" \
+ARGOCD_APP_PATH="${ARGOCD_PLATFORM_APP_PATH:-k8s/platform}" \
+"${SCRIPT_DIR}/bootstrap-argocd-app.sh" "$@"
 
-is_instance_id() {
-  [[ "$1" =~ ^i-[0-9a-f]{8}([0-9a-f]{9})?$ || "$1" =~ ^mi-[0-9a-f]{17}$ ]]
-}
-
-is_region() {
-  [[ "$1" =~ ^[a-z]{2}-[a-z]+-[0-9]+$ ]]
-}
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --env)
-      ENVIRONMENT="${2:-}"
-      shift 2
-      ;;
-    --project)
-      PROJECT="${2:-}"
-      shift 2
-      ;;
-    --region)
-      REGION_OVERRIDE="${2:-}"
-      shift 2
-      ;;
-    --help|-h)
-      usage
-      exit 0
-      ;;
-    --)
-      shift
-      break
-      ;;
-    -*)
-      echo "Unknown option: $1" >&2
-      usage
-      exit 1
-      ;;
-    *)
-      break
-      ;;
-  esac
-done
-
-if [[ $# -gt 0 ]]; then
-  if is_instance_id "$1"; then
-    INSTANCE_ID="$1"
-    shift
-  fi
-fi
-
-if [[ -z "${INSTANCE_ID}" && -z "${ENVIRONMENT}" ]]; then
-  usage
-  exit 1
-fi
-
-REGION="${REGION_OVERRIDE:-${AWS_REGION:-us-east-1}}"
-if [[ -z "${REGION_OVERRIDE}" && $# -gt 0 ]]; then
-  if is_region "$1"; then
-    REGION="$1"
-    shift
-  fi
-fi
-ARGOCD_CHART_VERSION="${1:-${ARGOCD_CHART_VERSION:-9.3.4}}"
-ARGOCD_NAMESPACE="${ARGOCD_NAMESPACE:-argocd}"
-ARGOCD_APP_NAME="${ARGOCD_APP_NAME:-cloudradar}"
-ARGOCD_APP_NAMESPACE="${ARGOCD_APP_NAMESPACE:-cloudradar}"
-ARGOCD_APP_REPO="${ARGOCD_APP_REPO:-https://github.com/ClementV78/CloudRadar.git}"
-ARGOCD_APP_PATH="${ARGOCD_APP_PATH:-k8s/apps}"
-ARGOCD_APP_REVISION="${ARGOCD_APP_REVISION:-main}"
-HELM_VERSION_FLAG=""
-ARGOCD_VALUES_FILE="$(dirname "$0")/argocd-values.yaml"
-ARGOCD_VALUES_CONTENT=""
-
-if [[ -n "${ARGOCD_CHART_VERSION}" ]]; then
-  HELM_VERSION_FLAG="--version ${ARGOCD_CHART_VERSION}"
-fi
-
-if ! command -v aws >/dev/null 2>&1; then
-  echo "aws CLI is required." >&2
-  exit 1
-fi
-
-if ! command -v jq >/dev/null 2>&1; then
-  echo "jq is required to build SSM parameters." >&2
-  exit 1
-fi
-
-if [[ -f "${ARGOCD_VALUES_FILE}" ]]; then
-  ARGOCD_VALUES_CONTENT="$(cat "${ARGOCD_VALUES_FILE}")"
-else
-  echo "Missing ${ARGOCD_VALUES_FILE}. Run from the repo root." >&2
-  exit 1
-fi
-
-if [[ -z "${INSTANCE_ID}" ]]; then
-  # Resolve the k3s server instance via tags when an explicit ID is not provided.
-  filters=(
-    "Name=tag:Role,Values=k3s-server"
-    "Name=tag:Environment,Values=${ENVIRONMENT}"
-    "Name=instance-state-name,Values=running"
-  )
-  if [[ -n "${PROJECT}" ]]; then
-    filters+=("Name=tag:Project,Values=${PROJECT}")
-  fi
-
-  INSTANCE_ID="$(aws ec2 describe-instances \
-    --region "${REGION}" \
-    --filters "${filters[@]}" \
-    --query "Reservations[].Instances[].InstanceId" \
-    --output text)"
-
-  if [[ -z "${INSTANCE_ID}" || "${INSTANCE_ID}" == "None" ]]; then
-    echo "No running k3s server instance found for env=${ENVIRONMENT} project=${PROJECT:-any}." >&2
-    exit 1
-  fi
-fi
-
-commands=(
-  # Summary: Install ArgoCD via Helm and create the GitOps Application manifest.
-  # SSM runs commands via /bin/sh; keep syntax POSIX-compatible.
-  "set -eu"
-  # Wait for kubectl to be installed by k3s (SSM may run before cloud-init finishes).
-  "i=0; while [ \$i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo \"Waiting for kubectl...\"; sleep 10; i=\$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo \"kubectl not found after 300s\"; exit 1; fi"
-  # Write the repo-server tuning values to a local file on the instance (SSM doesn't have the repo).
-  "cat <<'EOF' >/tmp/argocd-values.yaml
-${ARGOCD_VALUES_CONTENT}
-EOF"
-  # Point kubectl/helm to the k3s kubeconfig on the instance.
-  "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml"
-  # Install Helm if missing (k3s AMIs might not include it).
-  "command -v helm >/dev/null 2>&1 || curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | sudo bash"
-  # Add/update Argo Helm repo so the chart is available.
-  "sudo --preserve-env=KUBECONFIG helm repo add argo https://argoproj.github.io/argo-helm --force-update"
-  "sudo --preserve-env=KUBECONFIG helm repo update"
-  # Install or upgrade ArgoCD into its namespace.
-  "sudo --preserve-env=KUBECONFIG helm upgrade --install argocd argo/argo-cd --namespace ${ARGOCD_NAMESPACE} --create-namespace ${HELM_VERSION_FLAG} --values /tmp/argocd-values.yaml --set-json 'global.nodeSelector={\"node-role.kubernetes.io/control-plane\":\"true\"}' --set-json 'global.tolerations=[{\"key\":\"dedicated\",\"operator\":\"Equal\",\"value\":\"control-plane\",\"effect\":\"NoSchedule\"}]'"
-  # Wait for CRDs and ArgoCD server to be ready before creating the Application.
-  "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=120s --request-timeout=5s"
-  "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n ${ARGOCD_NAMESPACE} wait --for=condition=Available deployment/argocd-server --timeout=300s --request-timeout=5s"
-  "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n ${ARGOCD_NAMESPACE} get pods -o wide --request-timeout=5s"
-  # Apply the root Application for GitOps sync (auto-sync enabled).
-  # Note: uses 'sources' (plural) to monitor both k8s/apps and k8s/platform for ESO and other platform components.
-  "printf '%s\n' \"apiVersion: argoproj.io/v1alpha1\" \"kind: Application\" \"metadata:\" \"  name: ${ARGOCD_APP_NAME}\" \"  namespace: ${ARGOCD_NAMESPACE}\" \"spec:\" \"  project: default\" \"  sources:\" \"  - repoURL: ${ARGOCD_APP_REPO}\" \"    targetRevision: ${ARGOCD_APP_REVISION}\" \"    path: k8s/apps\" \"  - repoURL: ${ARGOCD_APP_REPO}\" \"    targetRevision: ${ARGOCD_APP_REVISION}\" \"    path: k8s/platform\" \"  destination:\" \"    server: https://kubernetes.default.svc\" \"    namespace: ${ARGOCD_APP_NAMESPACE}\" \"  syncPolicy:\" \"    automated:\" \"      prune: true\" \"      selfHeal: true\" \"    syncOptions:\" \"      - CreateNamespace=true\" \"  ignoreDifferences:\" \"  - group: apps\" \"    kind: Deployment\" \"    name: ingester\" \"    namespace: ${ARGOCD_APP_NAMESPACE}\" \"    jsonPointers:\" \"    - /spec/replicas\" | sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl apply -f -"
-)
-
-# Poll SSM command status with a hard timeout to avoid infinite waiting.
-wait_for_ssm_command() {
-  local region="$1"
-  local command_id="$2"
-  local instance_id="$3"
-  local max_wait_seconds="${4:-900}"
-  local sleep_seconds=10
-  local elapsed=0
-
-  while true; do
-    local status
-    status="$(aws ssm get-command-invocation \
-      --region "${region}" \
-      --command-id "${command_id}" \
-      --instance-id "${instance_id}" \
-      --query "Status" \
-      --output text 2>/dev/null || true)"
-
-    case "${status}" in
-      Success)
-        return 0
-        ;;
-      Failed|Cancelled|TimedOut|Cancelling)
-        aws ssm get-command-invocation \
-          --region "${region}" \
-          --command-id "${command_id}" \
-          --instance-id "${instance_id}"
-        return 1
-        ;;
-      Pending|InProgress|Delayed|"")
-        echo "Waiting for SSM command (status=${status:-unknown})..."
-        ;;
-      *)
-        echo "Unexpected SSM status: ${status}" >&2
-        ;;
-    esac
-
-    if [[ "${elapsed}" -ge "${max_wait_seconds}" ]]; then
-      echo "SSM command ${command_id} did not finish within ${max_wait_seconds}s." >&2
-      aws ssm get-command-invocation \
-        --region "${region}" \
-        --command-id "${command_id}" \
-        --instance-id "${instance_id}"
-      return 1
-    fi
-
-    sleep "${sleep_seconds}"
-    elapsed=$((elapsed + sleep_seconds))
-  done
-}
-
- # Encode commands for SSM RunShellScript.
-params_json="$(printf "%s\n" "${commands[@]}" | jq -Rn '{commands: [inputs]}')"
-
-command_id="$(aws ssm send-command \
-  --region "${REGION}" \
-  --instance-ids "${INSTANCE_ID}" \
-  --document-name "AWS-RunShellScript" \
-  --parameters "${params_json}" \
-  --timeout-seconds 1200 \
-  --query "Command.CommandId" \
-  --output text)"
-
-echo "::notice title=SSM::argocd bootstrap command_id=${command_id}"
-
-wait_for_ssm_command "${REGION}" "${command_id}" "${INSTANCE_ID}" 900
-
-aws ssm get-command-invocation \
-  --region "${REGION}" \
-  --command-id "${command_id}" \
-  --instance-id "${INSTANCE_ID}"
+IGNORE_INGESTER_REPLICAS=true \
+ARGOCD_APP_NAME="${ARGOCD_APPS_APP_NAME:-cloudradar}" \
+ARGOCD_APP_NAMESPACE="${ARGOCD_APPS_APP_NAMESPACE:-cloudradar}" \
+ARGOCD_APP_PATH="${ARGOCD_APPS_APP_PATH:-k8s/apps}" \
+"${SCRIPT_DIR}/bootstrap-argocd-app.sh" "$@"

--- a/scripts/lib/bootstrap-argocd-common.sh
+++ b/scripts/lib/bootstrap-argocd-common.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "${cmd} is required." >&2
+    exit 1
+  fi
+}
+
+is_instance_id() {
+  [[ "$1" =~ ^i-[0-9a-f]{8}([0-9a-f]{9})?$ || "$1" =~ ^mi-[0-9a-f]{17}$ ]]
+}
+
+is_region() {
+  [[ "$1" =~ ^[a-z]{2}-[a-z]+-[0-9]+$ ]]
+}
+
+resolve_instance_id() {
+  local region="$1"
+  local environment="$2"
+  local project="$3"
+
+  local -a filters
+  filters=(
+    "Name=tag:Role,Values=k3s-server"
+    "Name=tag:Environment,Values=${environment}"
+    "Name=instance-state-name,Values=running"
+  )
+
+  if [[ -n "${project}" ]]; then
+    filters+=("Name=tag:Project,Values=${project}")
+  fi
+
+  aws ec2 describe-instances \
+    --region "${region}" \
+    --filters "${filters[@]}" \
+    --query "Reservations[].Instances[].InstanceId" \
+    --output text
+}
+
+ensure_instance_id() {
+  local region="$1"
+  local environment="$2"
+  local project="$3"
+  local instance_id="$4"
+
+  if [[ -n "${instance_id}" ]]; then
+    echo "${instance_id}"
+    return 0
+  fi
+
+  if [[ -z "${environment}" ]]; then
+    echo "Either <instance-id> or --env is required." >&2
+    exit 1
+  fi
+
+  local resolved
+  resolved="$(resolve_instance_id "${region}" "${environment}" "${project}")"
+
+  if [[ -z "${resolved}" || "${resolved}" == "None" ]]; then
+    echo "No running k3s server instance found for env=${environment} project=${project:-any}." >&2
+    exit 1
+  fi
+
+  echo "${resolved}"
+}
+
+wait_for_ssm_command() {
+  local region="$1"
+  local command_id="$2"
+  local instance_id="$3"
+  local max_wait_seconds="${4:-900}"
+  local sleep_seconds=10
+  local elapsed=0
+
+  while true; do
+    local status
+    status="$(aws ssm get-command-invocation \
+      --region "${region}" \
+      --command-id "${command_id}" \
+      --instance-id "${instance_id}" \
+      --query "Status" \
+      --output text 2>/dev/null || true)"
+
+    case "${status}" in
+      Success)
+        return 0
+        ;;
+      Failed|Cancelled|TimedOut|Cancelling)
+        aws ssm get-command-invocation \
+          --region "${region}" \
+          --command-id "${command_id}" \
+          --instance-id "${instance_id}"
+        return 1
+        ;;
+      Pending|InProgress|Delayed|"")
+        echo "Waiting for SSM command (status=${status:-unknown})..."
+        ;;
+      *)
+        echo "Unexpected SSM status: ${status}" >&2
+        ;;
+    esac
+
+    if [[ "${elapsed}" -ge "${max_wait_seconds}" ]]; then
+      echo "SSM command ${command_id} did not finish within ${max_wait_seconds}s." >&2
+      aws ssm get-command-invocation \
+        --region "${region}" \
+        --command-id "${command_id}" \
+        --instance-id "${instance_id}"
+      return 1
+    fi
+
+    sleep "${sleep_seconds}"
+    elapsed=$((elapsed + sleep_seconds))
+  done
+}
+
+ssm_run_commands() {
+  local region="$1"
+  local instance_id="$2"
+  local timeout_seconds="$3"
+  local notice_title="$4"
+  local -n commands_ref="$5"
+
+  local params_json
+  params_json="$(printf "%s\n" "${commands_ref[@]}" | jq -Rn '{commands: [inputs]}')"
+
+  local command_id
+  command_id="$(aws ssm send-command \
+    --region "${region}" \
+    --instance-ids "${instance_id}" \
+    --document-name "AWS-RunShellScript" \
+    --parameters "${params_json}" \
+    --timeout-seconds "${timeout_seconds}" \
+    --query "Command.CommandId" \
+    --output text)"
+
+  echo "::notice title=SSM::${notice_title} command_id=${command_id}"
+
+  wait_for_ssm_command "${region}" "${command_id}" "${instance_id}" "${timeout_seconds}"
+
+  aws ssm get-command-invocation \
+    --region "${region}" \
+    --command-id "${command_id}" \
+    --instance-id "${instance_id}"
+}


### PR DESCRIPTION
## Summary
- split ArgoCD bootstrap into install + app stages via shared SSM lib
- add platform/apps root apps to enforce ESO CRD ordering
- update ci-infra workflow to run install/platform/apps jobs
- refresh runbooks and k8s README; remove external-secrets from apps kustomization

## Testing
- not run (CI workflow change only)

Closes #257
