### PR TITLE
fix(ci): escape crd in argocd app wait

### DIFF
--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -4,6 +4,12 @@ This log tracks incidents and fixes in reverse chronological order. Use it for d
 
 ## 2026-02-03
 
+### [ci/infra] argocd-platform job failed (unbound variable)
+- **Severity:** Medium
+- **Impact:** `ci-infra` failed during `argocd-platform` with `crd: unbound variable`, blocking bootstrap flow.
+- **Analysis:** `bootstrap-argocd-app.sh` interpolated `${crd}` locally with `set -u`, so the SSM command failed before execution.
+- **Resolution:** Escape `$crd` in the SSM command so it evaluates on the instance.
+
 ### [gitops/argocd] Root app sync failed (ESO CRDs missing)
 - **Severity:** High
 - **Impact:** `cloudradar` Application sync failed with `SyncError`; namespaces/apps were not created.

--- a/scripts/bootstrap-argocd-app.sh
+++ b/scripts/bootstrap-argocd-app.sh
@@ -150,7 +150,7 @@ commands=(
 if [[ -n "${WAIT_CRDS}" ]]; then
   wait_list="${WAIT_CRDS//,/ }"
   commands+=(
-    "for crd in ${wait_list}; do echo \"Waiting for CRD ${crd}...\"; sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl wait --for=condition=Established crd/${crd} --timeout=300s --request-timeout=5s; done"
+    "for crd in ${wait_list}; do echo \"Waiting for CRD \\${crd}...\"; sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl wait --for=condition=Established crd/\\${crd} --timeout=300s --request-timeout=5s; done"
   )
 fi
 


### PR DESCRIPTION
## Summary
- escape `$crd` in SSM loop so wait runs on instance
- log incident in troubleshooting issue log

## Testing
- not run (CI workflow change only)

Fixes #260
