### PR TITLE
fix(ci): escape crd in SSM wait loop

### DIFF
--- a/scripts/bootstrap-argocd-app.sh
+++ b/scripts/bootstrap-argocd-app.sh
@@ -150,7 +150,7 @@ commands=(
 if [[ -n "${WAIT_CRDS}" ]]; then
   wait_list="${WAIT_CRDS//,/ }"
   commands+=(
-    "for crd in ${wait_list}; do echo \"Waiting for CRD \\${crd}...\"; sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl wait --for=condition=Established crd/\\${crd} --timeout=300s --request-timeout=5s; done"
+    "for crd in ${wait_list}; do echo \"Waiting for CRD \${crd}...\"; sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl wait --for=condition=Established crd/\${crd} --timeout=300s --request-timeout=5s; done"
   )
 fi
 


### PR DESCRIPTION
## Summary
- escape `$crd` in SSM CRD wait loop so it evaluates on the instance

## Testing
- not run (CI workflow change only)

Fixes #262
