### PR TITLE
ci(k8s): lowercase GHCR repo in build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set lowercase repository name
+        run: echo "REPO_LOWER=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -61,7 +64,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.service }}
+          images: ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/${{ matrix.service }}
           tags: |
             type=ref,event=pr
             type=ref,event=branch
@@ -84,6 +87,6 @@ jobs:
         run: |
           echo "✅ Image built and pushed for ${{ matrix.service }}"
           echo "Registry: ${{ env.REGISTRY }}"
-          echo "Repository: ${{ github.repository }}"
+          echo "Repository: ${{ env.REPO_LOWER }}"
           echo "Tags:"
           echo "${{ steps.meta.outputs.tags }}" | tr ',' '\n' | sed 's/^/  - /'

--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -4,6 +4,12 @@ This log tracks incidents and fixes in reverse chronological order. Use it for d
 
 ## 2026-02-03
 
+### [ci/registry] ImagePullBackOff (GHCR tags missing)
+- **Severity:** High
+- **Impact:** app pods stayed Pending/BackOff because images under `ghcr.io/clementv78/cloudradar/*` were missing.
+- **Analysis:** build workflow pushed images using the mixed-case repo name; manifests reference lowercase GHCR paths, so tags were not found.
+- **Resolution:** Update build-and-push workflow to use lowercase repo and rebuild/push images.
+
 ### [app/k8s] Pods fail with InvalidImageName (GHCR uppercase)
 - **Severity:** High
 - **Impact:** `admin-scale`, `healthz`, and `processor` pods failed to start; app health stayed `Progressing`.


### PR DESCRIPTION
## Summary
- compute lowercase repo name for GHCR tags in build-and-push
- log incident in troubleshooting issue log

## Testing
- not run (workflow change only)

Fixes #271
