### PR TITLE
fix(k8s): align app images to v0.1.4

### DIFF
--- a/k8s/apps/admin-scale/deployment.yaml
+++ b/k8s/apps/admin-scale/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: admin-scale
-          image: ghcr.io/clementv78/cloudradar/admin-scale:0.1.0
+          image: ghcr.io/clementv78/cloudradar/admin-scale:0.1.4
           imagePullPolicy: IfNotPresent
           env:
             - name: ADMIN_TOKEN_SSM_NAME

--- a/k8s/apps/health/deployment.yaml
+++ b/k8s/apps/health/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: healthz
-          image: ghcr.io/clementv78/cloudradar/health:0.1.1
+          image: ghcr.io/clementv78/cloudradar/health:0.1.4
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/k8s/apps/processor/deployment.yaml
+++ b/k8s/apps/processor/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: processor
-          image: ghcr.io/clementv78/cloudradar/processor:0.1.0
+          image: ghcr.io/clementv78/cloudradar/processor:0.1.4
           imagePullPolicy: IfNotPresent
           env:
             - name: REDIS_HOST


### PR DESCRIPTION
## Summary
- align admin-scale/health/processor images to v0.1.4

## Testing
- not run (manifest change only)

Fixes #275
