### PR TITLE
fix(k8s): relax startup probes

### DIFF
--- a/k8s/apps/admin-scale/deployment.yaml
+++ b/k8s/apps/admin-scale/deployment.yaml
@@ -45,6 +45,12 @@ spec:
             httpGet:
               path: /healthz
               port: http
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            failureThreshold: 36
+            periodSeconds: 10
           resources:
             requests:
               cpu: 50m

--- a/k8s/apps/processor/deployment.yaml
+++ b/k8s/apps/processor/deployment.yaml
@@ -56,8 +56,8 @@ spec:
             httpGet:
               path: /healthz
               port: http
-            failureThreshold: 30
-            periodSeconds: 2
+            failureThreshold: 36
+            periodSeconds: 10
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
- Ajoute un startupProbe à admin-scale (360s)
- Assouplit le startupProbe du processor (360s)
- Réduit les redémarrages pendant le boot sur nodes modestes

Closes #277