### PR TITLE
fix(obs): disable prometheus CRD upgrade job

### DIFF
--- a/k8s/apps/monitoring/prometheus-app.yaml
+++ b/k8s/apps/monitoring/prometheus-app.yaml
@@ -15,7 +15,8 @@ spec:
         crds:
           enabled: true
           upgradeJob:
-            enabled: true
+            # Disabled to avoid oversized annotations in the CRD upgrade hook ConfigMap.
+            enabled: false
 
         prometheus:
           service:


### PR DESCRIPTION
- Désactive le hook CRD upgrade pour éviter les annotations trop longues
- Conserve `crds.enabled: true` pour installer les CRDs à l'installation
- Réduit les blocages ArgoCD sur le job `prometheus-crds-upgrade`

Closes #279