### PR TITLE
docs(meta): add issue metadata reminder to context template

### DIFF
--- a/docs/context-template.md
+++ b/docs/context-template.md
@@ -11,6 +11,10 @@ Generated: YYYY-MM-DD hh:mm
 ## Project management
 - 
 
+## Issue metadata reminders (UI)
+- After each issue creation, update Project + Project Status in the GitHub UI (required; no API/CLI).
+- List any issues still missing Project/Status here.
+
 ## Branching & environments
 - 
 


### PR DESCRIPTION
- Add a dedicated section for issue metadata reminders in `docs/context-template.md`
- Keeps Project/Status reminders visible in every session export

Refs #57