### PR TITLE
fix(infra): align control-plane taint

### DIFF
--- a/docs/runbooks/bootstrap/argocd-bootstrap.md
+++ b/docs/runbooks/bootstrap/argocd-bootstrap.md
@@ -4,7 +4,7 @@ Purpose: install ArgoCD in the k3s cluster so GitOps can manage k8s apps.
 
 ## Prerequisites
 - k3s server is running and reachable via SSM.
-- Control-plane taint is enforced (`dedicated=control-plane:NoSchedule`) so only platform pods (ArgoCD/ESO/kube-system) schedule on the server.
+- Control-plane taint is enforced (`node-role.kubernetes.io/control-plane:NoSchedule`) so only platform pods (ArgoCD/ESO/kube-system) schedule on the server.
 - AWS CLI configured with permissions to run SSM commands:
   - `ssm:SendCommand`
   - `ssm:GetCommandInvocation`

--- a/docs/runbooks/external-secrets-operator.md
+++ b/docs/runbooks/external-secrets-operator.md
@@ -155,9 +155,8 @@ spec:
         nodeSelector:
           node-role.kubernetes.io/control-plane: "true"
         tolerations:
-          - key: "dedicated"
-            operator: "Equal"
-            value: "control-plane"
+          - key: "node-role.kubernetes.io/control-plane"
+            operator: "Exists"
             effect: "NoSchedule"
   destination:
     server: https://kubernetes.default.svc

--- a/infra/aws/live/dev/terraform.tfvars
+++ b/infra/aws/live/dev/terraform.tfvars
@@ -15,7 +15,7 @@ k3s_worker_min_size      = 1
 k3s_worker_desired       = 1
 k3s_worker_max_size      = 3
 k3s_root_volume_size     = 40
-k3s_server_extra_args    = ["--node-taint=dedicated=control-plane:NoSchedule"]
+k3s_server_extra_args    = ["--node-taint=node-role.kubernetes.io/control-plane:NoSchedule"]
 
 edge_instance_type = "t3.micro"
 # edge_ami_id                        = "ami-xxxxxxxxxxxxxxxxx"

--- a/infra/aws/live/dev/terraform.tfvars.example
+++ b/infra/aws/live/dev/terraform.tfvars.example
@@ -15,7 +15,7 @@ k3s_worker_min_size       = 1
 k3s_worker_desired        = 1
 k3s_worker_max_size       = 3
 k3s_root_volume_size      = 40
-k3s_server_extra_args     = ["--node-taint=dedicated=control-plane:NoSchedule"]
+k3s_server_extra_args     = ["--node-taint=node-role.kubernetes.io/control-plane:NoSchedule"]
 
 # Optional: additional k3s flags.
 # k3s_server_extra_args = ["--tls-san=example.com"]

--- a/k8s/platform/external-secrets/helmrelease.yaml
+++ b/k8s/platform/external-secrets/helmrelease.yaml
@@ -22,9 +22,8 @@ spec:
         nodeSelector:
           node-role.kubernetes.io/control-plane: "true"
         tolerations:
-          - key: "dedicated"
-            operator: "Equal"
-            value: "control-plane"
+          - key: "node-role.kubernetes.io/control-plane"
+            operator: "Exists"
             effect: "NoSchedule"
   destination:
     server: https://kubernetes.default.svc

--- a/scripts/bootstrap-argocd-install.sh
+++ b/scripts/bootstrap-argocd-install.sh
@@ -114,7 +114,7 @@ EOF"
   "sudo --preserve-env=KUBECONFIG helm repo add argo https://argoproj.github.io/argo-helm --force-update"
   "sudo --preserve-env=KUBECONFIG helm repo update"
   # Install or upgrade ArgoCD into its namespace.
-  "sudo --preserve-env=KUBECONFIG helm upgrade --install argocd argo/argo-cd --namespace ${ARGOCD_NAMESPACE} --create-namespace ${HELM_VERSION_FLAG} --values /tmp/argocd-values.yaml --set-json 'global.nodeSelector={\"node-role.kubernetes.io/control-plane\":\"true\"}' --set-json 'global.tolerations=[{\"key\":\"dedicated\",\"operator\":\"Equal\",\"value\":\"control-plane\",\"effect\":\"NoSchedule\"}]'"
+  "sudo --preserve-env=KUBECONFIG helm upgrade --install argocd argo/argo-cd --namespace ${ARGOCD_NAMESPACE} --create-namespace ${HELM_VERSION_FLAG} --values /tmp/argocd-values.yaml --set-json 'global.nodeSelector={\"node-role.kubernetes.io/control-plane\":\"true\"}' --set-json 'global.tolerations=[{\"key\":\"node-role.kubernetes.io/control-plane\",\"operator\":\"Exists\",\"effect\":\"NoSchedule\"}]'"
   # Wait for CRDs and ArgoCD server to be ready.
   "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=120s --request-timeout=5s"
   "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n ${ARGOCD_NAMESPACE} wait --for=condition=Available deployment/argocd-server --timeout=300s --request-timeout=5s"


### PR DESCRIPTION
## What Changed
- Switched k3s server taint to the official control-plane taint in dev tfvars.
- Updated ArgoCD/ESO tolerations to match the official taint.
- Updated bootstrap + troubleshooting docs for the new taint and CoreDNS incident.

## Why
Fixes #290

## Files Affected
- infra/aws/live/dev/terraform.tfvars
- infra/aws/live/dev/terraform.tfvars.example
- scripts/bootstrap-argocd-install.sh
- k8s/platform/external-secrets/helmrelease.yaml
- docs/runbooks/bootstrap/argocd-bootstrap.md
- docs/runbooks/external-secrets-operator.md
- docs/runbooks/troubleshooting/issue-log.md
- docs/runbooks/troubleshooting/troubleshooting-guide.md

## Notes
- Includes docs in the same PR per user request.