### PR TITLE
fix(infra): pin traefik nodeports via correct keys

### DIFF
--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -13,8 +13,8 @@ This log tracks incidents and fixes in reverse chronological order. Use it for d
 ### [infra/edge] Edge 502 after rebuild (Traefik NodePort drift)
 - **Severity:** High
 - **Impact:** `/grafana` and `/prometheus` returned 502 from the edge even though monitoring pods were healthy.
-- **Analysis:** After a destroy/recreate, Traefik NodePorts changed (e.g., web `30382`), while Terraform edge config still targeted the old NodePort (`30353`), so Nginx proxied to a closed port.
-- **Resolution:** Pin Traefik NodePorts via k3s HelmChartConfig (web `30080`, websecure `30443`) and align edge `edge_grafana_nodeport` / `edge_prometheus_nodeport` to `30080`. (Refs: issue #286)
+- **Analysis:** The k3s HelmChartConfig used `service.spec.ports`, which the Traefik chart ignores. NodePort pinning never applied, so NodePorts drifted after rebuilds and the edge still targeted the old port.
+- **Resolution:** Fix HelmChartConfig keys to `ports.web.nodePort` and `ports.websecure.nodePort` and keep edge `edge_grafana_nodeport` / `edge_prometheus_nodeport` aligned to `30080`. (Refs: issue #286, #294)
 
 ### [obs/monitoring] Prometheus sync failed (annotations too long)
 - **Severity:** High

--- a/infra/aws/modules/k3s/templates/cloud-init-server.yaml
+++ b/infra/aws/modules/k3s/templates/cloud-init-server.yaml
@@ -31,14 +31,10 @@ runcmd:
         namespace: kube-system
       spec:
         valuesContent: |
-          service:
-            spec:
-              ports:
-                - name: web
-                  port: 80
-                  nodePort: 30080
-                - name: websecure
-                  port: 443
-                  nodePort: 30443
+          ports:
+            web:
+              nodePort: 30080
+            websecure:
+              nodePort: 30443
       EOF
   - curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --secrets-encryption${server_args}" K3S_TOKEN="${k3s_token}" sh -


### PR DESCRIPTION
## What Changed
- switch Traefik HelmChartConfig values to `ports.web.nodePort` and `ports.websecure.nodePort`
- keep NodePort pins at 30080/30443 and record the key mismatch in the issue log

## Why
Fixes #294

## Files Affected
- infra/aws/modules/k3s/templates/cloud-init-server.yaml
- docs/runbooks/troubleshooting/issue-log.md

## Notes
- not run (infra change)

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [x] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [x] Documentation updated (if applicable)
