### PR TITLE
fix(infra): bump k3s server to t3a.medium

### DIFF
--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -160,10 +160,12 @@ Values come from `infra/aws/live/dev/terraform.tfvars` unless overridden per env
 
 | Component | Default instance type | Notes |
 | --- | --- | --- |
-| k3s server | `t3.small` | Private subnet (dev). |
+| k3s server | `t3a.medium` | Private subnet (dev). Increased headroom to avoid API timeouts during large CRD applies. |
 | k3s workers | `t3a.medium` | Auto Scaling Group (dev). |
 | edge | `t3.micro` | Public subnet (dev). |
 | NAT instance | `t3.nano` | Public subnet (dev). |
+
+Cost note: `t3a.medium` increases control-plane cost versus `t3.small`, but reduces API timeouts during bootstrap.
 
 Prod values are currently aligned with module defaults and may be overridden later in `infra/aws/live/prod`.
 - ArgoCD deployed on k3s (bootstrapped via SSM from CI).

--- a/infra/aws/live/dev/terraform.tfvars
+++ b/infra/aws/live/dev/terraform.tfvars
@@ -9,7 +9,7 @@ private_subnet_cidrs = ["10.0.101.0/24"]
 nat_instance_type    = "t3.nano"
 nat_root_volume_size = 8
 
-k3s_server_instance_type = "t3.small"
+k3s_server_instance_type = "t3a.medium"
 k3s_worker_instance_type = "t3a.medium"
 k3s_worker_min_size      = 1
 k3s_worker_desired       = 1

--- a/infra/aws/live/dev/terraform.tfvars.example
+++ b/infra/aws/live/dev/terraform.tfvars.example
@@ -9,7 +9,7 @@ private_subnet_cidrs = ["10.0.101.0/24"]
 nat_instance_type    = "t3.nano"
 nat_root_volume_size = 8
 
-k3s_server_instance_type = "t3.small"
+k3s_server_instance_type = "t3a.medium"
 k3s_worker_instance_type = "t3a.medium"
 k3s_worker_min_size       = 1
 k3s_worker_desired        = 1

--- a/infra/aws/live/dev/variables.tf
+++ b/infra/aws/live/dev/variables.tf
@@ -54,7 +54,7 @@ variable "nat_root_volume_size" {
 variable "k3s_server_instance_type" {
   description = "Instance type for the k3s server."
   type        = string
-  default     = "t3.small"
+  default     = "t3a.medium"
 }
 
 variable "k3s_worker_instance_type" {

--- a/infra/aws/modules/k3s/variables.tf
+++ b/infra/aws/modules/k3s/variables.tf
@@ -22,7 +22,7 @@ variable "k3s_server_subnet_id" {
 variable "server_instance_type" {
   description = "Instance type for the k3s server."
   type        = string
-  default     = "t3.small"
+  default     = "t3a.medium"
 }
 
 variable "worker_instance_type" {


### PR DESCRIPTION
## Summary
- set k3s server default instance type to `t3a.medium`
- updated dev tfvars (real + example)
- documented cost/headroom change

## Testing
- not run (infra config change)

Fixes #298
