### PR TITLE
fix(obs): align prometheus storageclass

### DIFF
--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -2,6 +2,14 @@
 
 This log tracks incidents and fixes in reverse chronological order. Use it for debugging patterns and onboarding.
 
+## 2026-02-05
+
+### [obs/monitoring] Prometheus degraded (storageclass mismatch)
+- **Severity:** High
+- **Impact:** Prometheus StatefulSet never created; `/prometheus` smoke test failed after rebuild.
+- **Analysis:** Prometheus CR requested `storageClassName: gp3` but the cluster only provided `ebs-gp3`, so reconciliation failed with `storage class "gp3" does not exist`.
+- **Resolution:** Align Prometheus chart values to use `storageClassName: ebs-gp3`. (Refs: issue #304)
+
 ## 2026-02-04
 
 ### [obs/monitoring] Prometheus CRDs missing (server-side apply timeouts)

--- a/k8s/apps/monitoring/prometheus-app.yaml
+++ b/k8s/apps/monitoring/prometheus-app.yaml
@@ -33,7 +33,7 @@ spec:
                   resources:
                     requests:
                       storage: 5Gi
-                  storageClassName: gp3
+                  storageClassName: ebs-gp3
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
## What Changed
- updated Prometheus storageClassName to match the cluster SC
- logged the incident in the troubleshooting journal

## Why
Fixes #304

## Files Affected
- k8s/apps/monitoring/prometheus-app.yaml
- docs/runbooks/troubleshooting/issue-log.md

## Notes
- Prometheus CR was degraded because storage class `gp3` did not exist

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [x] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [x] Documentation updated (if applicable)
