### PR TITLE
docs(meta): ignore auto tfvars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 *.tfstate
 *.tfstate.backup
 *.tfvars
+*.auto.tfvars
+*.auto.tfvars.json
 !infra/aws/live/**/terraform.tfvars
 infra/aws/live/**/backend.hcl
 

--- a/docs/runbooks/ci-cd/ci-infra.md
+++ b/docs/runbooks/ci-cd/ci-infra.md
@@ -28,6 +28,7 @@ Jobs run in CI to validate Terraform safely (no apply):
 Notes:
 - When `backup_bucket_name` is empty, the workflow uses `TF_BACKUP_BUCKET_NAME` if set.
 - If neither is provided, Terraform derives the default bucket name in `infra/aws/live/dev`.
+- Local-only overrides can live in `local.donotcommit.auto.tfvars` inside the env folder (auto-loaded by Terraform, ignored by Git).
 
 ### Which environment is targeted in CI?
 


### PR DESCRIPTION
## What Changed
- ignore `*.auto.tfvars` and `*.auto.tfvars.json`
- document local override pattern for Terraform vars

## Why
Refs #311

## Files Affected
- .gitignore
- docs/runbooks/ci-cd/ci-infra.md

## Notes
- Keeps local secrets out of git while remaining auto-loaded

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [ ] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [x] Documentation updated (if applicable)
