### PR TITLE
fix(k8s): apply dashboards ConfigMap with SSA

### DIFF
--- a/k8s/apps/monitoring/dashboards/kustomization.yaml
+++ b/k8s/apps/monitoring/dashboards/kustomization.yaml
@@ -5,6 +5,10 @@ namespace: monitoring
 
 generatorOptions:
   disableNameSuffixHash: true
+  # The generated dashboards ConfigMap is large and may exceed the 256KiB annotation limit
+  # if applied with client-side apply (last-applied-configuration). Force SSA for this resource.
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
 
 configMapGenerator:
   - name: grafana-dashboards-default


### PR DESCRIPTION
## What Changed
- Forced ArgoCD to use Server-Side Apply for the generated `grafana-dashboards-default` ConfigMap via `argocd.argoproj.io/sync-options: ServerSideApply=true`.

## Why
Fixes #327

## Files Affected
- k8s/apps/monitoring/dashboards/kustomization.yaml

## Notes
- The dashboards ConfigMap is large; client-side apply can exceed the 256KiB annotation limit.