### PR TITLE
fix(obs): Grafana Prometheus datasource uses /prometheus routePrefix

### DIFF
--- a/k8s/apps/monitoring/grafana-app.yaml
+++ b/k8s/apps/monitoring/grafana-app.yaml
@@ -32,7 +32,9 @@ spec:
             - name: Prometheus
               uid: prometheus
               type: prometheus
-              url: http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
+              # Prometheus is configured with --web.route-prefix=/prometheus in kube-prometheus-stack.
+              # Grafana must include the prefix, otherwise queries hit /api/v1/* and return 404.
+              url: http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090/prometheus
               access: proxy
               isDefault: true
         


### PR DESCRIPTION
## Why
Prometheus is configured with `routePrefix: /prometheus` in `k8s/apps/monitoring/prometheus-app.yaml`. Grafana datasource must include the same prefix, otherwise it queries `/api/v1/*` and gets 404.

## What changed
- Update Grafana Prometheus datasource URL to include `/prometheus`.

## Evidence / DoD
- After ArgoCD sync, open Grafana -> a dashboard (e.g. Node Exporter Full) should show data.
- Optional: in Grafana Explore, run `up` query and confirm non-empty results.

Refs #316
