### PR TITLE
fix(app): create OpenSky secret in cloudradar namespace

### DIFF
--- a/k8s/apps/external-secrets/opensky-secret.yaml
+++ b/k8s/apps/external-secrets/opensky-secret.yaml
@@ -2,7 +2,8 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: opensky-credentials
-  namespace: default
+  # The ingester runs in the cloudradar namespace and expects this Secret there.
+  namespace: cloudradar
 spec:
   refreshInterval: 1h
   secretStoreRef:


### PR DESCRIPTION
## Why
Ingester runs in namespace `cloudradar` and expects Secret `opensky-secret` there.

The OpenSky `ExternalSecret` was created in namespace `default`, so the Secret was generated in the wrong namespace and the ingester Pod failed with:
`Error: secret "opensky-secret" not found`.

## What changed
- Move OpenSky `ExternalSecret` to namespace `cloudradar`.

## Evidence / DoD
- `kubectl -n cloudradar get secret opensky-secret` succeeds after ArgoCD sync.
- Scaling ingester to 1 results in a Running pod.

Fixes #333
