### PR TITLE
fix(infra): make DNS upserts and Flow Logs creation CI-safe

### DIFF
--- a/docs/runbooks/bootstrap/aws-account-bootstrap.md
+++ b/docs/runbooks/bootstrap/aws-account-bootstrap.md
@@ -565,6 +565,10 @@ Notes:
 - **Step 6 (policy)**: attaches a minimal inline policy for S3 state and DynamoDB lock creation.
 - **Step 7 (outputs)**: prints the account ID, OIDC provider ARN, and CI role ARN.
 
+Note:
+- As the platform evolves, CI may require additional permissions beyond backend bootstrap.
+- Example: VPC Flow Logs to CloudWatch Logs requires `logs:CreateLogGroup` / retention management on `/cloudradar/*` log groups.
+
 ### Script inputs
 - `AWS_REGION` (default `us-east-1`)
 - `ROLE_NAME` (default `CloudRadarTerraformRole`)

--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -2,6 +2,22 @@
 
 This log tracks incidents and fixes in reverse chronological order. Use it for debugging patterns and onboarding.
 
+## 2026-02-08
+
+### [infra/dns] Terraform apply failed creating Route 53 records (record already exists)
+- **Severity:** Medium
+- **Impact:** `terraform apply` failed when creating `aws_route53_record` for the delegated zone because the record set already existed (state drift / partial destroy).
+- **Signal:** `InvalidChangeBatch: Tried to create resource record set ... but it already exists`.
+- **Resolution:** Set `allow_overwrite = true` on the Route 53 record resource to upsert instead of failing.
+- **Refs:** issue #341, PR #342, issue #317 / PR #344
+
+### [infra/obs] Terraform apply failed creating CloudWatch Log Group (missing IAM permissions)
+- **Severity:** High
+- **Impact:** VPC Flow Logs provisioning failed because CI role lacked `logs:CreateLogGroup` (and related) permissions.
+- **Signal:** `AccessDeniedException: ... is not authorized to perform: logs:CreateLogGroup`.
+- **Resolution:** Extend the CI role inline policy created by `scripts/bootstrap-aws.sh` to allow managing `/cloudradar/*` log groups, then re-run the script to update the role policy.
+- **Refs:** issue #317 / PR #344
+
 ## 2026-02-07
 
 ### [infra/dns] Terraform destroy failed (Route53 HostedZoneNotEmpty)

--- a/infra/aws/live/dev/dns.tf
+++ b/infra/aws/live/dev/dns.tf
@@ -32,6 +32,9 @@ resource "aws_route53_record" "edge_a" {
   type    = "A"
   ttl     = 60
   records = [each.value]
+
+  # Avoid create failures when the record already exists (e.g., state drift or partial destroy).
+  allow_overwrite = true
 }
 
 resource "aws_ssm_parameter" "grafana_domain" {

--- a/scripts/bootstrap-aws.sh
+++ b/scripts/bootstrap-aws.sh
@@ -86,6 +86,8 @@ else
 fi
 
 # Minimal inline policy for backend bootstrap (S3 + DynamoDB).
+# Note: This role is also used by CI for Terraform plan/apply. Keep policies additive
+# and scoped to CloudRadar-owned resources when possible.
 inline_policy="$(mktemp)"
 cat > "${inline_policy}" <<EOF
 {
@@ -117,6 +119,22 @@ cat > "${inline_policy}" <<EOF
         "dynamodb:TagResource"
       ],
       "Resource": "arn:aws:dynamodb:${AWS_REGION}:${account_id}:table/${LOCK_TABLE_NAME}"
+    }
+    ,
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:DeleteLogGroup",
+        "logs:PutRetentionPolicy",
+        "logs:TagResource",
+        "logs:UntagResource",
+        "logs:DescribeLogGroups"
+      ],
+      "Resource": [
+        "arn:aws:logs:${AWS_REGION}:${account_id}:log-group:/cloudradar/*",
+        "arn:aws:logs:${AWS_REGION}:${account_id}:log-group:/cloudradar/*:log-stream:*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fixes #345

## What changed
- Route 53 records: use `allow_overwrite = true` so apply upserts instead of failing when recordsets already exist (drift / partial destroy).
- CI role bootstrap: extend `scripts/bootstrap-aws.sh` inline policy to allow managing `/cloudradar/*` CloudWatch Log Groups (create/delete/retention/tag).
- Docs: note the extra CloudWatch Logs perms in the AWS account bootstrap runbook.
- Troubleshooting: log the incident in `docs/runbooks/troubleshooting/issue-log.md`.

## Why this is compliant with #341
- We keep the public hosted zone lifecycle out of the env state (env roots only *read* the zone via `data aws_route53_zone`, and manage records).
- This prevents `HostedZoneNotEmpty` destroys and avoids any out-of-band DNS mutation.

## DoD evidence (local)
- `terraform -chdir=infra/aws/live/dev validate`
- `terraform -chdir=infra/aws/live/prod validate`

## Follow-up required (ops)
Re-run `scripts/bootstrap-aws.sh` with bootstrap credentials to update the existing `CloudRadarTerraformRole` inline policy in AWS.

Refs: #341, #317, PR #344
