### PR TITLE
fix(obs): run node-exporter on control-plane

### DIFF
--- a/k8s/apps/monitoring/prometheus-app.yaml
+++ b/k8s/apps/monitoring/prometheus-app.yaml
@@ -45,22 +45,29 @@ spec:
                 memory: 1Gi
             serviceMonitorSelectorNilUsesHelmValues: false
             podMonitorSelectorNilUsesHelmValues: false
-        
+
         prometheus-node-exporter:
           enabled: true
-        
+          tolerations:
+            - key: "node-role.kubernetes.io/control-plane"
+              operator: "Exists"
+              effect: "NoSchedule"
+            - key: "node-role.kubernetes.io/master"
+              operator: "Exists"
+              effect: "NoSchedule"
+
         kube-state-metrics:
           enabled: true
-        
+
         # Basic auth via ESO-managed secret
         grafana:
           enabled: false
         # Exposure: handled at edge (EC2 nginx) + Traefik Ingress; no in-cluster proxy
-  
+
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring
-  
+
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Summary:
- Add tolerations so prometheus-node-exporter schedules on control-plane/master nodes.

Why:
- Control plane RootFS/CPU/RAM panels need node_exporter metrics; without this, node_filesystem_* is missing on control-plane and panels show N/A.

Validation:
- yamllint on k8s/apps/monitoring/prometheus-app.yaml

How to verify after merge:
- ArgoCD sync prometheus app
- PromQL: count by (instance) (node_filesystem_size_bytes{mountpoint="/"}) should include the control-plane instance (e.g. 10.0.101.31:9100)

Refs: (no issue)