### PR TITLE
fix(infra): allow node-exporter scrape on 9100

### DIFF
--- a/infra/aws/modules/k3s/main.tf
+++ b/infra/aws/modules/k3s/main.tf
@@ -268,6 +268,16 @@ resource "aws_security_group_rule" "k3s_flannel_vxlan" {
   description              = "flannel VXLAN"
 }
 
+resource "aws_security_group_rule" "node_exporter" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.k3s_nodes.id
+  from_port                = 9100
+  to_port                  = 9100
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.k3s_nodes.id
+  description              = "node-exporter metrics"
+}
+
 resource "aws_security_group_rule" "k3s_egress" {
   type              = "egress"
   security_group_id = aws_security_group.k3s_nodes.id


### PR DESCRIPTION
Summary:
- Add SG self-ingress rule for TCP/9100 on k3s nodes SG.

Why:
- Prometheus target for control-plane node-exporter is DOWN with context deadline exceeded.
- Control-plane node-exporter pod is running, but traffic to 10.0.101.31:9100 times out from worker pods.

Validation (local):
- terraform fmt
- terraform -chdir=infra/aws/live/dev init -backend=false
- terraform -chdir=infra/aws/live/dev validate

After merge (manual apply):
- terraform plan/apply in live env
- Prometheus Targets: both node-exporter instances should be UP

Refs: (no issue)