### PR TITLE
feat(ci): automate Redis backup/restore in infra workflows

### DIFF
--- a/.github/workflows/ci-infra-destroy.yml
+++ b/.github/workflows/ci-infra-destroy.yml
@@ -10,6 +10,14 @@ on:
         options:
           - dev
           - prod
+      redis_backup_restore:
+        description: "Run Redis backup + rotation before destroy (dev only)"
+        required: true
+        type: choice
+        default: "yes"
+        options:
+          - yes
+          - no
       confirm_destroy:
         description: "Type DESTROY to confirm"
         required: true
@@ -24,6 +32,7 @@ env:
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
   TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
   TF_LOCK_TABLE_NAME: ${{ vars.TF_LOCK_TABLE_NAME }}
+  TF_BACKUP_BUCKET_NAME: ${{ vars.TF_BACKUP_BUCKET_NAME }}
   TF_ROLE_ARN: ${{ vars.AWS_TERRAFORM_ROLE_ARN }}
 
 jobs:
@@ -75,6 +84,135 @@ jobs:
 
       - name: Terraform validate
         run: terraform -chdir="${TF_DIR}" validate
+
+      - name: Backup Redis + rotate (dev only)
+        if: ${{ inputs.environment == 'dev' }}
+        shell: bash
+        env:
+          BACKUP_BUCKET: ${{ env.TF_BACKUP_BUCKET_NAME }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ inputs.redis_backup_restore }}" != "yes" ]]; then
+            echo "::notice title=Redis backup::redis_backup_restore=${{ inputs.redis_backup_restore }}; skipping Redis backup/rotation."
+            exit 0
+          fi
+
+          if [[ -z "${BACKUP_BUCKET}" ]]; then
+            echo "::notice title=Redis backup::TF_BACKUP_BUCKET_NAME not set; skipping Redis backup/rotation."
+            exit 0
+          fi
+
+          echo "Loading k3s_server_instance_id from Terraform outputs..."
+          K3S_SERVER_INSTANCE_ID="$(terraform -chdir="${TF_DIR}" output -raw k3s_server_instance_id)"
+          if [[ -z "${K3S_SERVER_INSTANCE_ID}" ]]; then
+            echo "ERROR: k3s_server_instance_id is empty" >&2
+            exit 1
+          fi
+
+          echo "Waiting for SSM instance readiness..."
+          instance_id="${K3S_SERVER_INSTANCE_ID}"
+          max_attempts=12
+          attempt=1
+          sleep_seconds=10
+
+          while [ "${attempt}" -le "${max_attempts}" ]; do
+            state="$(aws ec2 describe-instance-status \
+              --instance-ids "${instance_id}" \
+              --include-all-instances \
+              --query "InstanceStatuses[0].InstanceState.Name" \
+              --output text 2>/dev/null || true)"
+
+            ping="$(aws ssm describe-instance-information \
+              --filters "Key=InstanceIds,Values=${instance_id}" \
+              --query "InstanceInformationList[0].PingStatus" \
+              --output text 2>/dev/null || true)"
+
+            if [ "${state}" = "running" ] && [ "${ping}" = "Online" ]; then
+              echo "SSM instance is online."
+              break
+            fi
+
+            echo "Waiting for SSM instance readiness (state=${state:-unknown} ping=${ping:-unknown})..."
+            sleep "${sleep_seconds}"
+            attempt=$((attempt + 1))
+            sleep_seconds=$((sleep_seconds + 5))
+          done
+
+          if [ "${attempt}" -gt "${max_attempts}" ]; then
+            echo "SSM instance not ready after ${max_attempts} attempts."
+            exit 1
+          fi
+
+          TS="$(date -u +%Y%m%dT%H%M%SZ)"
+          S3_PREFIX="redis-backups/${TS}"
+          echo "Backup timestamp: ${TS}"
+          echo "Backup destination: s3://${BACKUP_BUCKET}/${S3_PREFIX}/"
+
+          # Stop writes (best effort).
+          params="$(jq -n \
+            --arg c0 "i=0; while [ \\$i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo \"Waiting for kubectl...\"; sleep 10; i=\\$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo \"kubectl not found after 300s\"; exit 1; fi" \
+            --arg c1 "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" \
+            --arg c2 "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n cloudradar scale deploy/ingester --replicas=0 || true" \
+            '{commands:[$c0,$c1,$c2]}')"
+
+          stop_cmd_id="$(aws ssm send-command \
+            --instance-ids "${K3S_SERVER_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "${params}" \
+            --timeout-seconds 300 \
+            --query "Command.CommandId" \
+            --output text)"
+
+          echo "::notice title=SSM::Stop ingester command_id=${stop_cmd_id}"
+          if ! aws ssm wait command-executed --command-id "${stop_cmd_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}"; then
+            aws ssm get-command-invocation --command-id "${stop_cmd_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}" || true
+            echo "WARN: Failed to scale ingester to 0; continuing with backup."
+          fi
+
+          # Backup.
+          BACKUP_B64="$(base64 -w0 scripts/redis-backup.sh)"
+          params="$(jq -n \
+            --arg c0 "i=0; while [ \\$i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo \"Waiting for kubectl...\"; sleep 10; i=\\$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo \"kubectl not found after 300s\"; exit 1; fi" \
+            --arg c1 "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" \
+            --arg c2 "echo '${BACKUP_B64}' | base64 -d > /tmp/redis-backup.sh && chmod +x /tmp/redis-backup.sh" \
+            --arg c3 "/tmp/redis-backup.sh --kubeconfig /etc/rancher/k3s/k3s.yaml --kubectl /usr/local/bin/kubectl --s3-bucket ${BACKUP_BUCKET} --s3-prefix ${S3_PREFIX} --region ${AWS_REGION}" \
+            '{commands:[$c0,$c1,$c2,$c3]}')"
+
+          backup_cmd_id="$(aws ssm send-command \
+            --instance-ids "${K3S_SERVER_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "${params}" \
+            --timeout-seconds 900 \
+            --query "Command.CommandId" \
+            --output text)"
+
+          echo "::notice title=SSM::Redis backup command_id=${backup_cmd_id}"
+          if ! aws ssm wait command-executed --command-id "${backup_cmd_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}"; then
+            aws ssm get-command-invocation --command-id "${backup_cmd_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}" || true
+            exit 1
+          fi
+
+          # Rotate backups (keep last 3).
+          echo "Rotating Redis backups in s3://${BACKUP_BUCKET}/redis-backups/ (keep last 3)..."
+          mapfile -t prefixes < <(aws s3api list-objects-v2 \
+            --bucket "${BACKUP_BUCKET}" \
+            --prefix "redis-backups/" \
+            --delimiter "/" \
+            --query "CommonPrefixes[].Prefix" \
+            --output text | tr '\t' '\n' | sed '/^$/d' || true)
+
+          if (( ${#prefixes[@]} <= 3 )); then
+            echo "Found ${#prefixes[@]} backups; nothing to rotate."
+            exit 0
+          fi
+
+          mapfile -t sorted < <(printf "%s\n" "${prefixes[@]}" | sort)
+          delete_count=$(( ${#sorted[@]} - 3 ))
+          for ((i=0; i<delete_count; i++)); do
+            echo "Deleting old backup prefix: s3://${BACKUP_BUCKET}/${sorted[$i]}"
+            aws s3 rm "s3://${BACKUP_BUCKET}/${sorted[$i]}" --recursive
+          done
 
       - name: Terraform destroy
         run: terraform -chdir="${TF_DIR}" destroy -input=false -auto-approve -var-file=terraform.tfvars

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -18,6 +18,14 @@ on:
         options:
           - dev
           - prod
+      redis_backup_restore:
+        description: "Restore Redis from latest backup after deploy (dev only)"
+        required: true
+        type: choice
+        default: "yes"
+        options:
+          - yes
+          - no
       auto_approve:
         description: "Set to true to run apply"
         required: true
@@ -757,11 +765,199 @@ jobs:
           ARGOCD_APP_PATH: k8s/apps
         run: scripts/bootstrap-argocd-app.sh "${{ needs.tf-outputs.outputs.k3s_server_instance_id }}" "${AWS_REGION}"
 
+  redis-restore:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'dev' && inputs.redis_backup_restore == 'yes' }}
+    runs-on: ubuntu-latest
+    needs:
+      - argocd-apps
+      - tf-outputs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.TF_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Guard Redis backup bucket (dev only)
+        shell: bash
+        env:
+          K3S_SERVER_INSTANCE_ID: ${{ needs.tf-outputs.outputs.k3s_server_instance_id }}
+          BACKUP_BUCKET: ${{ env.TF_BACKUP_BUCKET_NAME }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${BACKUP_BUCKET}" ]]; then
+            echo "::notice title=Redis restore::TF_BACKUP_BUCKET_NAME not set; skipping Redis restore."
+            echo "SKIP_REDIS_RESTORE=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          echo "SKIP_REDIS_RESTORE=false" >> "$GITHUB_ENV"
+          echo "BACKUP_BUCKET=${BACKUP_BUCKET}" >> "$GITHUB_ENV"
+
+      - name: Find latest Redis backup (dev only)
+        if: ${{ env.SKIP_REDIS_RESTORE != 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Looking up latest Redis backup in s3://${BACKUP_BUCKET}/redis-backups/ ..."
+          latest_prefix="$(aws s3api list-objects-v2 \
+            --bucket "${BACKUP_BUCKET}" \
+            --prefix "redis-backups/" \
+            --delimiter "/" \
+            --query "CommonPrefixes[].Prefix" \
+            --output text | tr '\t' '\n' | sed '/^$/d' | sort | tail -n 1 || true)"
+
+          if [[ -z "${latest_prefix}" ]]; then
+            echo "::notice title=Redis restore::No Redis backups found; skipping restore."
+            echo "SKIP_REDIS_RESTORE=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          latest_key="$(aws s3api list-objects-v2 \
+            --bucket "${BACKUP_BUCKET}" \
+            --prefix "${latest_prefix}" \
+            --query "Contents[?ends_with(Key, \`.tgz\`)].Key | [0]" \
+            --output text || true)"
+
+          if [[ -z "${latest_key}" || "${latest_key}" == "None" ]]; then
+            echo "ERROR: Could not find tgz object under prefix: ${latest_prefix}" >&2
+            exit 1
+          fi
+
+          S3_URI="s3://${BACKUP_BUCKET}/${latest_key}"
+          echo "Latest backup: ${S3_URI}"
+          echo "S3_URI=${S3_URI}" >> "$GITHUB_ENV"
+
+      - name: Wait for SSM instance readiness (dev only)
+        if: ${{ env.SKIP_REDIS_RESTORE != 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          instance_id="${K3S_SERVER_INSTANCE_ID}"
+          max_attempts=12
+          attempt=1
+          sleep_seconds=10
+
+          while [ "${attempt}" -le "${max_attempts}" ]; do
+            state="$(aws ec2 describe-instance-status \
+              --instance-ids "${instance_id}" \
+              --include-all-instances \
+              --query "InstanceStatuses[0].InstanceState.Name" \
+              --output text 2>/dev/null || true)"
+
+            ping="$(aws ssm describe-instance-information \
+              --filters "Key=InstanceIds,Values=${instance_id}" \
+              --query "InstanceInformationList[0].PingStatus" \
+              --output text 2>/dev/null || true)"
+
+            if [ "${state}" = "running" ] && [ "${ping}" = "Online" ]; then
+              echo "SSM instance is online."
+              exit 0
+            fi
+
+            echo "Waiting for SSM instance readiness (state=${state:-unknown} ping=${ping:-unknown})..."
+            sleep "${sleep_seconds}"
+            attempt=$((attempt + 1))
+            sleep_seconds=$((sleep_seconds + 5))
+          done
+
+          echo "SSM instance not ready after ${max_attempts} attempts."
+          exit 1
+
+      - name: "SSM: wait Redis Ready (dev only)"
+        if: ${{ env.SKIP_REDIS_RESTORE != 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          params="$(jq -n \
+            --arg c0 "i=0; while [ \\$i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo \"Waiting for kubectl...\"; sleep 10; i=\\$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo \"kubectl not found after 300s\"; exit 1; fi" \
+            --arg c1 "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" \
+            --arg c2 "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n data rollout status statefulset/redis --timeout=300s" \
+            '{commands:[$c0,$c1,$c2]}')"
+
+          command_id="$(aws ssm send-command \
+            --instance-ids "${K3S_SERVER_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "${params}" \
+            --timeout-seconds 600 \
+            --query "Command.CommandId" \
+            --output text)"
+
+          echo "::notice title=SSM::Wait Redis Ready command_id=${command_id}"
+          if ! aws ssm wait command-executed --command-id "${command_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}"; then
+            aws ssm get-command-invocation --command-id "${command_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}" || true
+            exit 1
+          fi
+
+      - name: "SSM: check Redis /data emptiness (dev only)"
+        if: ${{ env.SKIP_REDIS_RESTORE != 'true' }}
+        id: redis_fresh
+        shell: bash
+        run: |
+          set -euo pipefail
+          params="$(jq -n \
+            --arg c0 "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" \
+            --arg c1 "if sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n data exec statefulset/redis -c redis -- sh -lc 'test -z \"\\$(ls -A /data 2>/dev/null)\"'; then echo \"fresh=true\"; else echo \"fresh=false\"; fi" \
+            '{commands:[$c0,$c1]}')"
+
+          command_id="$(aws ssm send-command \
+            --instance-ids "${K3S_SERVER_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "${params}" \
+            --timeout-seconds 120 \
+            --query "Command.CommandId" \
+            --output text)"
+
+          aws ssm wait command-executed --command-id "${command_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}"
+          out="$(aws ssm get-command-invocation --command-id "${command_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}" --query "StandardOutputContent" --output text || true)"
+          echo "SSM output: ${out}"
+          if echo "${out}" | grep -q "fresh=true"; then
+            echo "fresh=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fresh=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip restore (Redis not fresh) (dev only)
+        if: ${{ env.SKIP_REDIS_RESTORE != 'true' && steps.redis_fresh.outputs.fresh != 'true' }}
+        run: |
+          echo "::notice title=Redis restore::Redis /data is not empty; skipping restore to avoid data loss."
+
+      - name: "SSM: restore Redis from S3 (dev only)"
+        if: ${{ env.SKIP_REDIS_RESTORE != 'true' && steps.redis_fresh.outputs.fresh == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          RESTORE_B64="$(base64 -w0 scripts/redis-restore.sh)"
+          params="$(jq -n \
+            --arg c0 "i=0; while [ \\$i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo \"Waiting for kubectl...\"; sleep 10; i=\\$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo \"kubectl not found after 300s\"; exit 1; fi" \
+            --arg c1 "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" \
+            --arg c2 "echo '${RESTORE_B64}' | base64 -d > /tmp/redis-restore.sh && chmod +x /tmp/redis-restore.sh" \
+            --arg c3 "/tmp/redis-restore.sh --force --s3-uri ${S3_URI} --kubeconfig /etc/rancher/k3s/k3s.yaml --kubectl /usr/local/bin/kubectl --region ${AWS_REGION}" \
+            '{commands:[$c0,$c1,$c2,$c3]}')"
+
+          command_id="$(aws ssm send-command \
+            --instance-ids "${K3S_SERVER_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "${params}" \
+            --timeout-seconds 900 \
+            --query "Command.CommandId" \
+            --output text)"
+
+          echo "::notice title=SSM::Redis restore command_id=${command_id}"
+          if ! aws ssm wait command-executed --command-id "${command_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}"; then
+            aws ssm get-command-invocation --command-id "${command_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}" || true
+            exit 1
+          fi
+
   smoke-tests:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'dev' && inputs.run_smoke_tests == 'true' }}
     runs-on: ubuntu-latest
     needs:
       - argocd-apps
+      - redis-restore
       - tf-outputs
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
Closes #358

- Added `redis_backup_restore` input (default yes) to `ci-infra` and `ci-infra-destroy`.
- `ci-infra-destroy` (dev): single visible step to backup Redis to S3 and rotate backups (keep 3) before Terraform destroy (after scaling ingester to 0 best-effort).
- `ci-infra` (dev): restore latest Redis backup after apps bootstrap, guarded (only when `/data` is empty).
- Updated runbook `docs/runbooks/ci-cd/ci-infra.md` to document the new behavior and input.

DoD:
- YAML parsed locally (PyYAML safe_load)
