### PR TITLE
fix(ci): make redis_backup_restore a boolean input

### DIFF
--- a/.github/workflows/ci-infra-destroy.yml
+++ b/.github/workflows/ci-infra-destroy.yml
@@ -13,11 +13,8 @@ on:
       redis_backup_restore:
         description: "Run Redis backup + rotation before destroy (dev only)"
         required: true
-        type: choice
-        default: "yes"
-        options:
-          - yes
-          - no
+        type: boolean
+        default: true
       confirm_destroy:
         description: "Type DESTROY to confirm"
         required: true
@@ -93,7 +90,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "${{ inputs.redis_backup_restore }}" != "yes" ]]; then
+          if [[ "${{ inputs.redis_backup_restore }}" != "true" ]]; then
             echo "::notice title=Redis backup::redis_backup_restore=${{ inputs.redis_backup_restore }}; skipping Redis backup/rotation."
             exit 0
           fi

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -21,11 +21,8 @@ on:
       redis_backup_restore:
         description: "Restore Redis from latest backup after deploy (dev only)"
         required: true
-        type: choice
-        default: "yes"
-        options:
-          - yes
-          - no
+        type: boolean
+        default: true
       auto_approve:
         description: "Set to true to run apply"
         required: true
@@ -766,7 +763,7 @@ jobs:
         run: scripts/bootstrap-argocd-app.sh "${{ needs.tf-outputs.outputs.k3s_server_instance_id }}" "${AWS_REGION}"
 
   redis-restore:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'dev' && inputs.redis_backup_restore == 'yes' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'dev' && inputs.redis_backup_restore }}
     runs-on: ubuntu-latest
     needs:
       - argocd-apps

--- a/docs/runbooks/ci-cd/ci-infra.md
+++ b/docs/runbooks/ci-cd/ci-infra.md
@@ -21,7 +21,7 @@ Jobs run in CI to validate Terraform safely (no apply):
 ## Manual apply inputs (workflow_dispatch)
 
 - `environment`: target env (`dev` or `prod`).
-- `redis_backup_restore`: when `yes` (default, dev only), restores Redis from the latest backup after apps are bootstrapped.
+- `redis_backup_restore`: when `true` (default, dev only), restores Redis from the latest backup after apps are bootstrapped.
 - `auto_approve`: must be `true` to run apply.
 - `run_smoke_tests`: when `true`, runs post-apply readiness and health checks (k3s, ArgoCD, healthz).
 - `backup_bucket_name`: optional override for the dev SQLite backup bucket.
@@ -54,7 +54,7 @@ The manual dispatch runs a chained set of jobs (visible in the Actions graph):
 5. `tf-outputs` (dev only): load Terraform outputs for SSM/edge checks.
 6. `k3s-ready-check` (dev): wait for k3s nodes via SSM.
 7. `argocd-bootstrap` (dev): bootstrap ArgoCD via SSM after k3s readiness.
-8. `redis-restore` (dev): restore Redis from the latest backup (guarded: only runs when `redis_backup_restore=yes`, and only restores when Redis `/data` is empty).
+8. `redis-restore` (dev): restore Redis from the latest backup (guarded: only runs when `redis_backup_restore=true`, and only restores when Redis `/data` is empty).
 9. `smoke-tests` (dev + smoke): wait for ArgoCD sync, healthz rollout, and curl `/healthz`.
 
 ## Workflow diagram (Mermaid)
@@ -141,7 +141,7 @@ This keeps SSH password auth disabled while allowing Serial Console login.
 Use the dedicated destroy workflow when you need to tear down an environment.
 
 - Select `environment` (`dev` or `prod`).
-- `redis_backup_restore`: when `yes` (default, dev only), backs up Redis to S3 and rotates backups (keeps last 3) before Terraform destroy.
+- `redis_backup_restore`: when `true` (default, dev only), backs up Redis to S3 and rotates backups (keeps last 3) before Terraform destroy.
 - Set `confirm_destroy=DESTROY` to allow destruction.
 - Uses the same S3/DynamoDB backend and the OIDC role.
 - The workflow validates the selected root before destroying.


### PR DESCRIPTION
Fixes #361

- Switched `redis_backup_restore` from `choice (yes/no)` to `boolean (true/false)` in `ci-infra` and `ci-infra-destroy` to match GitHub UI.
- Updated workflow conditions to use boolean semantics.
- Updated runbook to document the boolean input.

DoD:
- YAML parsed locally (PyYAML safe_load)
