### PR TITLE
fix(ci): export K3S_SERVER_INSTANCE_ID for redis restore

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -768,6 +768,9 @@ jobs:
     needs:
       - argocd-apps
       - tf-outputs
+    env:
+      # Required across multiple steps; avoid "unbound variable" with `set -u`.
+      K3S_SERVER_INSTANCE_ID: ${{ needs.tf-outputs.outputs.k3s_server_instance_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -781,7 +784,6 @@ jobs:
       - name: Guard Redis backup bucket (dev only)
         shell: bash
         env:
-          K3S_SERVER_INSTANCE_ID: ${{ needs.tf-outputs.outputs.k3s_server_instance_id }}
           BACKUP_BUCKET: ${{ env.TF_BACKUP_BUCKET_NAME }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Fixes #363

- Set `K3S_SERVER_INSTANCE_ID` at the `redis-restore` job level so every step sees it (avoids `set -u` unbound variable failures).

DoD:
- YAML parsed locally (PyYAML safe_load)
