### PR TITLE
fix(ci): prevent runner set -u expansion in ci-infra-destroy

### DIFF
--- a/.github/workflows/ci-infra-destroy.yml
+++ b/.github/workflows/ci-infra-destroy.yml
@@ -148,7 +148,7 @@ jobs:
 
           # Stop writes (best effort).
           params="$(jq -n \
-            --arg c0 "i=0; while [ \\$i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo \"Waiting for kubectl...\"; sleep 10; i=\\$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo \"kubectl not found after 300s\"; exit 1; fi" \
+            --arg c0 'i=0; while [ $i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo "Waiting for kubectl..."; sleep 10; i=$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo "kubectl not found after 300s"; exit 1; fi' \
             --arg c1 "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" \
             --arg c2 "sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n cloudradar scale deploy/ingester --replicas=0 || true" \
             '{commands:[$c0,$c1,$c2]}')"
@@ -170,7 +170,7 @@ jobs:
           # Backup.
           BACKUP_B64="$(base64 -w0 scripts/redis-backup.sh)"
           params="$(jq -n \
-            --arg c0 "i=0; while [ \\$i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo \"Waiting for kubectl...\"; sleep 10; i=\\$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo \"kubectl not found after 300s\"; exit 1; fi" \
+            --arg c0 'i=0; while [ $i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo "Waiting for kubectl..."; sleep 10; i=$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo "kubectl not found after 300s"; exit 1; fi' \
             --arg c1 "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml" \
             --arg c2 "echo '${BACKUP_B64}' | base64 -d > /tmp/redis-backup.sh && chmod +x /tmp/redis-backup.sh" \
             --arg c3 "/tmp/redis-backup.sh --kubeconfig /etc/rancher/k3s/k3s.yaml --kubectl /usr/local/bin/kubectl --s3-bucket ${BACKUP_BUCKET} --s3-prefix ${S3_PREFIX} --region ${AWS_REGION}" \

--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -2,6 +2,16 @@
 
 This log tracks incidents and fixes in reverse chronological order. Use it for debugging patterns and onboarding.
 
+## 2026-02-09
+
+### [ci/infra] ci-infra-destroy failed (unbound variable in Redis backup step)
+- **Severity:** High
+- **Impact:** `ci-infra-destroy` failed before destroy, so infra teardown was blocked.
+- **Signal:** `/home/runner/...sh: line 64: i: unbound variable` in step `Backup Redis + rotate (dev only)`.
+- **Analysis:** The workflow step runs with `set -u` and builds SSM command payloads via `jq --arg`. A `$i` loop inside the payload was expanded on the runner instead of on the instance.
+- **Resolution:** Pass the `$i` loop payload via single quotes to prevent runner expansion (SSM executes it on the instance).
+- **Refs:** issue #369
+
 ## 2026-02-08
 
 ### [infra/dns] Terraform apply failed creating Route 53 records (record already exists)


### PR DESCRIPTION
- Fixes runner crash `i: unbound variable` in `ci-infra-destroy` Redis backup/rotation step.
- Adjusts SSM jq payload quoting so `$i` expands on the instance, not on the runner.
- Logs the incident in the troubleshooting journal.

Fixes #369.