### PR TITLE
feat(k8s/infra): Configure processor aircraft DB via ESO

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -279,6 +279,9 @@ jobs:
           set -euo pipefail
           BACKUP_BUCKET_NAME="${{ inputs.backup_bucket_name || env.TF_BACKUP_BUCKET_NAME }}"
           DNS_ZONE_NAME="${{ vars.DNS_ZONE_NAME }}"
+          PROCESSOR_AIRCRAFT_DB_ENABLED="${{ vars.PROCESSOR_AIRCRAFT_DB_ENABLED }}"
+          PROCESSOR_AIRCRAFT_DB_S3_URI="${{ vars.PROCESSOR_AIRCRAFT_DB_S3_URI }}"
+          PROCESSOR_AIRCRAFT_DB_SHA256="${{ vars.PROCESSOR_AIRCRAFT_DB_SHA256 }}"
           EXTRA_VARS=()
 
           if [[ "${{ inputs.environment }}" == "dev" && -n "${BACKUP_BUCKET_NAME}" ]]; then
@@ -302,6 +305,17 @@ jobs:
             EXTRA_VARS+=("-var=dns_zone_name=${DNS_ZONE_NAME}")
           elif [[ -n "${DNS_ZONE_NAME}" ]]; then
             EXTRA_VARS+=("-var=dns_zone_name=${DNS_ZONE_NAME}")
+          fi
+
+          # Optional: processor aircraft reference DB (SSM -> ESO -> env vars)
+          if [[ -n "${PROCESSOR_AIRCRAFT_DB_ENABLED}" ]]; then
+            EXTRA_VARS+=("-var=processor_aircraft_db_enabled=${PROCESSOR_AIRCRAFT_DB_ENABLED}")
+          fi
+          if [[ -n "${PROCESSOR_AIRCRAFT_DB_S3_URI}" ]]; then
+            EXTRA_VARS+=("-var=processor_aircraft_db_s3_uri=${PROCESSOR_AIRCRAFT_DB_S3_URI}")
+          fi
+          if [[ -n "${PROCESSOR_AIRCRAFT_DB_SHA256}" ]]; then
+            EXTRA_VARS+=("-var=processor_aircraft_db_sha256=${PROCESSOR_AIRCRAFT_DB_SHA256}")
           fi
 
           terraform -chdir="${{ needs.env-select.outputs.tf_dir }}" plan -input=false -no-color -var-file=terraform.tfvars \
@@ -356,6 +370,9 @@ jobs:
           set -euo pipefail
           BACKUP_BUCKET_NAME="${{ inputs.backup_bucket_name || env.TF_BACKUP_BUCKET_NAME }}"
           DNS_ZONE_NAME="${{ vars.DNS_ZONE_NAME }}"
+          PROCESSOR_AIRCRAFT_DB_ENABLED="${{ vars.PROCESSOR_AIRCRAFT_DB_ENABLED }}"
+          PROCESSOR_AIRCRAFT_DB_S3_URI="${{ vars.PROCESSOR_AIRCRAFT_DB_S3_URI }}"
+          PROCESSOR_AIRCRAFT_DB_SHA256="${{ vars.PROCESSOR_AIRCRAFT_DB_SHA256 }}"
           EXTRA_VARS=()
 
           if [[ "${{ inputs.environment }}" == "dev" && -n "${BACKUP_BUCKET_NAME}" ]]; then
@@ -379,6 +396,17 @@ jobs:
             EXTRA_VARS+=("-var=dns_zone_name=${DNS_ZONE_NAME}")
           elif [[ -n "${DNS_ZONE_NAME}" ]]; then
             EXTRA_VARS+=("-var=dns_zone_name=${DNS_ZONE_NAME}")
+          fi
+
+          # Optional: processor aircraft reference DB (SSM -> ESO -> env vars)
+          if [[ -n "${PROCESSOR_AIRCRAFT_DB_ENABLED}" ]]; then
+            EXTRA_VARS+=("-var=processor_aircraft_db_enabled=${PROCESSOR_AIRCRAFT_DB_ENABLED}")
+          fi
+          if [[ -n "${PROCESSOR_AIRCRAFT_DB_S3_URI}" ]]; then
+            EXTRA_VARS+=("-var=processor_aircraft_db_s3_uri=${PROCESSOR_AIRCRAFT_DB_S3_URI}")
+          fi
+          if [[ -n "${PROCESSOR_AIRCRAFT_DB_SHA256}" ]]; then
+            EXTRA_VARS+=("-var=processor_aircraft_db_sha256=${PROCESSOR_AIRCRAFT_DB_SHA256}")
           fi
 
           terraform -chdir="${{ needs.env-select.outputs.tf_dir }}" apply -input=false -auto-approve -var-file=terraform.tfvars \

--- a/docs/runbooks/ci-cd/ci-infra.md
+++ b/docs/runbooks/ci-cd/ci-infra.md
@@ -27,6 +27,9 @@ Jobs run in CI to validate Terraform safely (no apply):
 - `backup_bucket_name`: optional override for the dev SQLite backup bucket.
 - DNS delegation uses the `DNS_ZONE_NAME` GitHub Actions variable (e.g., `cloudradar.example.com`).
   Keep real domain values out of the repo.
+- Processor aircraft DB (optional) uses GitHub Actions Variables (environment-scoped):
+  - `PROCESSOR_AIRCRAFT_DB_ENABLED`, `PROCESSOR_AIRCRAFT_DB_S3_URI`, `PROCESSOR_AIRCRAFT_DB_SHA256`
+  - The workflow passes them as Terraform variables so Terraform writes `/cloudradar/processor/aircraft-db/*` SSM parameters for ESO.
 
 Notes:
 - When `backup_bucket_name` is empty, the workflow uses `TF_BACKUP_BUCKET_NAME` if set.
@@ -153,6 +156,9 @@ Use the dedicated destroy workflow when you need to tear down an environment.
 - `TF_STATE_BUCKET`
 - `TF_LOCK_TABLE_NAME`
 - `TF_BACKUP_BUCKET_NAME` (optional, used for SQLite and Redis backups)
+- `PROCESSOR_AIRCRAFT_DB_ENABLED` (optional, workflow_dispatch only; writes SSM for ESO)
+- `PROCESSOR_AIRCRAFT_DB_S3_URI` (optional, workflow_dispatch only; writes SSM for ESO)
+- `PROCESSOR_AIRCRAFT_DB_SHA256` (optional, workflow_dispatch only; writes SSM for ESO)
 
 ## Related files
 

--- a/docs/runbooks/external-secrets-operator.md
+++ b/docs/runbooks/external-secrets-operator.md
@@ -65,6 +65,12 @@ aws ssm put-parameter --name /cloudradar/opensky/token_url --value "https://open
 aws ssm put-parameter --name /cloudradar/grafana-admin-password --value "your-password" --type SecureString
 ```
 
+**Processor (aircraft reference DB, non-sensitive):**
+- Managed by Terraform (recommended) via `infra/aws/live/<env>`:
+  - `/cloudradar/processor/aircraft-db/enabled` (`true|false`)
+  - `/cloudradar/processor/aircraft-db/s3-uri` (`s3://.../aircraft.db`)
+  - `/cloudradar/processor/aircraft-db/sha256` (optional)
+
 **Prometheus**
 - Prometheus access is protected by **edge Basic Auth** (`/cloudradar/edge/basic-auth`).
 - No Prometheus-specific SSM parameters are required.

--- a/infra/aws/live/dev/processor.tf
+++ b/infra/aws/live/dev/processor.tf
@@ -1,0 +1,38 @@
+# Processor: aircraft reference DB configuration (SSM -> ESO -> K8s Secret -> env vars)
+
+resource "aws_ssm_parameter" "processor_aircraft_db_enabled" {
+  name        = "/cloudradar/processor/aircraft-db/enabled"
+  description = "Processor aircraft reference DB enabled flag (managed by Terraform; consumed via ESO)"
+  type        = "String"
+  value       = tostring(var.processor_aircraft_db_enabled)
+  overwrite   = true
+
+  tags = merge(local.tags, {
+    Name = "cloudradar-processor-aircraft-db-enabled"
+  })
+}
+
+resource "aws_ssm_parameter" "processor_aircraft_db_s3_uri" {
+  name        = "/cloudradar/processor/aircraft-db/s3-uri"
+  description = "Processor aircraft reference DB S3 URI (managed by Terraform; consumed via ESO)"
+  type        = "String"
+  value       = var.processor_aircraft_db_s3_uri
+  overwrite   = true
+
+  tags = merge(local.tags, {
+    Name = "cloudradar-processor-aircraft-db-s3-uri"
+  })
+}
+
+resource "aws_ssm_parameter" "processor_aircraft_db_sha256" {
+  name        = "/cloudradar/processor/aircraft-db/sha256"
+  description = "Processor aircraft reference DB artifact SHA256 (managed by Terraform; consumed via ESO)"
+  type        = "String"
+  value       = var.processor_aircraft_db_sha256
+  overwrite   = true
+
+  tags = merge(local.tags, {
+    Name = "cloudradar-processor-aircraft-db-sha256"
+  })
+}
+

--- a/infra/aws/live/dev/terraform.tfvars.example
+++ b/infra/aws/live/dev/terraform.tfvars.example
@@ -44,6 +44,12 @@ enable_grafana_cloudwatch_read = true
 # Optional: use the bootstrap-created aircraft reference data bucket.
 # aircraft_reference_bucket_name = "cloudradar-dev-<account-id>-reference-data"
 
+# Optional: configure aircraft reference DB enrichment in the processor.
+# Stored in SSM and injected into the processor via External Secrets Operator.
+# processor_aircraft_db_enabled = true
+# processor_aircraft_db_s3_uri  = "s3://<bucket>/aircraft-db/<version>/aircraft.db"
+# processor_aircraft_db_sha256  = "<sha256>"
+
 edge_instance_type       = "t3.micro"
 # edge_ami_id             = "ami-xxxxxxxxxxxxxxxxx"
 edge_root_volume_size    = 40

--- a/infra/aws/live/dev/variables.tf
+++ b/infra/aws/live/dev/variables.tf
@@ -117,6 +117,24 @@ variable "aircraft_reference_bucket_name" {
   default     = null
 }
 
+variable "processor_aircraft_db_enabled" {
+  description = "Whether to enable aircraft reference DB enrichment in the processor (stored in SSM and injected via ESO)."
+  type        = bool
+  default     = false
+}
+
+variable "processor_aircraft_db_s3_uri" {
+  description = "S3 URI to the aircraft reference SQLite artifact (stored in SSM and injected via ESO)."
+  type        = string
+  default     = ""
+}
+
+variable "processor_aircraft_db_sha256" {
+  description = "Optional SHA256 for the aircraft reference SQLite artifact (stored in SSM and injected via ESO)."
+  type        = string
+  default     = ""
+}
+
 variable "edge_instance_type" {
   description = "Instance type for the edge EC2 instance."
   type        = string

--- a/infra/aws/live/prod/processor.tf
+++ b/infra/aws/live/prod/processor.tf
@@ -1,0 +1,38 @@
+# Processor: aircraft reference DB configuration (SSM -> ESO -> K8s Secret -> env vars)
+
+resource "aws_ssm_parameter" "processor_aircraft_db_enabled" {
+  name        = "/cloudradar/processor/aircraft-db/enabled"
+  description = "Processor aircraft reference DB enabled flag (managed by Terraform; consumed via ESO)"
+  type        = "String"
+  value       = tostring(var.processor_aircraft_db_enabled)
+  overwrite   = true
+
+  tags = merge(local.tags, {
+    Name = "cloudradar-processor-aircraft-db-enabled"
+  })
+}
+
+resource "aws_ssm_parameter" "processor_aircraft_db_s3_uri" {
+  name        = "/cloudradar/processor/aircraft-db/s3-uri"
+  description = "Processor aircraft reference DB S3 URI (managed by Terraform; consumed via ESO)"
+  type        = "String"
+  value       = var.processor_aircraft_db_s3_uri
+  overwrite   = true
+
+  tags = merge(local.tags, {
+    Name = "cloudradar-processor-aircraft-db-s3-uri"
+  })
+}
+
+resource "aws_ssm_parameter" "processor_aircraft_db_sha256" {
+  name        = "/cloudradar/processor/aircraft-db/sha256"
+  description = "Processor aircraft reference DB artifact SHA256 (managed by Terraform; consumed via ESO)"
+  type        = "String"
+  value       = var.processor_aircraft_db_sha256
+  overwrite   = true
+
+  tags = merge(local.tags, {
+    Name = "cloudradar-processor-aircraft-db-sha256"
+  })
+}
+

--- a/infra/aws/live/prod/terraform.tfvars.example
+++ b/infra/aws/live/prod/terraform.tfvars.example
@@ -15,5 +15,11 @@ private_subnet_cidrs = ["10.1.101.0/24"]
 # Optional delegated subdomain managed in Route53 (leave empty to disable).
 dns_zone_name = "cloudradar.example.com"
 
+# Optional: configure aircraft reference DB enrichment in the processor.
+# Stored in SSM and injected into the processor via External Secrets Operator.
+# processor_aircraft_db_enabled = true
+# processor_aircraft_db_s3_uri  = "s3://<bucket>/aircraft-db/<version>/aircraft.db"
+# processor_aircraft_db_sha256  = "<sha256>"
+
 # Optional: only needed when a NAT instance is created.
 # private_route_nat_instance_id = "i-0123456789abcdef0"

--- a/infra/aws/live/prod/variables.tf
+++ b/infra/aws/live/prod/variables.tf
@@ -50,6 +50,24 @@ variable "dns_zone_name" {
   type        = string
   default     = ""
 }
+
+variable "processor_aircraft_db_enabled" {
+  description = "Whether to enable aircraft reference DB enrichment in the processor (stored in SSM and injected via ESO)."
+  type        = bool
+  default     = false
+}
+
+variable "processor_aircraft_db_s3_uri" {
+  description = "S3 URI to the aircraft reference SQLite artifact (stored in SSM and injected via ESO)."
+  type        = string
+  default     = ""
+}
+
+variable "processor_aircraft_db_sha256" {
+  description = "Optional SHA256 for the aircraft reference SQLite artifact (stored in SSM and injected via ESO)."
+  type        = string
+  default     = ""
+}
 variable "grafana_admin_password" {
   description = "Grafana admin password. If empty, a random one will be generated."
   type        = string

--- a/k8s/apps/external-secrets/kustomization.yaml
+++ b/k8s/apps/external-secrets/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - grafana-domain.yaml
   - grafana-secret.yaml
   - opensky-secret.yaml
+  - processor-aircraft-db.yaml

--- a/k8s/apps/external-secrets/processor-aircraft-db.yaml
+++ b/k8s/apps/external-secrets/processor-aircraft-db.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: processor-aircraft-db
+  namespace: cloudradar
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ssm-parameter-store
+    kind: ClusterSecretStore
+  target:
+    name: processor-aircraft-db
+    creationPolicy: Owner
+  data:
+    - secretKey: enabled
+      remoteRef:
+        key: /cloudradar/processor/aircraft-db/enabled
+    - secretKey: s3-uri
+      remoteRef:
+        key: /cloudradar/processor/aircraft-db/s3-uri
+    - secretKey: sha256
+      remoteRef:
+        key: /cloudradar/processor/aircraft-db/sha256
+

--- a/k8s/apps/processor/deployment.yaml
+++ b/k8s/apps/processor/deployment.yaml
@@ -44,9 +44,17 @@ spec:
             - name: AWS_REGION
               value: us-east-1
             - name: AIRCRAFT_DB_S3_URI
-              value: ""
+              valueFrom:
+                secretKeyRef:
+                  name: processor-aircraft-db
+                  key: s3-uri
+                  optional: true
             - name: AIRCRAFT_DB_SHA256
-              value: ""
+              valueFrom:
+                secretKeyRef:
+                  name: processor-aircraft-db
+                  key: sha256
+                  optional: true
           volumeMounts:
             - name: aircraft-refdata
               mountPath: /refdata
@@ -70,7 +78,11 @@ spec:
             - name: PROCESSOR_TRACK_LENGTH
               value: "180"
             - name: PROCESSOR_AIRCRAFT_DB_ENABLED
-              value: "false"
+              valueFrom:
+                secretKeyRef:
+                  name: processor-aircraft-db
+                  key: enabled
+                  optional: true
             - name: PROCESSOR_AIRCRAFT_DB_PATH
               value: /refdata/aircraft.db
           ports:


### PR DESCRIPTION
Closes #373

## What changed
- Terraform writes processor aircraft DB config to SSM (`/cloudradar/processor/aircraft-db/*`).
- ESO syncs those params into a `processor-aircraft-db` Secret in the `cloudradar` namespace.
- Processor reads env vars from that Secret (initContainer + app container) to avoid env-specific values in manifests.
- `ci-infra` optionally passes GitHub Actions Variables to Terraform on workflow_dispatch.
- Updated runbooks (processor ops, ESO, ci-infra).

## Validation
- `terraform -chdir=infra/aws/live/dev init -backend=false && terraform validate`
- `terraform -chdir=infra/aws/live/prod init -backend=false && terraform validate`
- `actionlint -oneline .github/workflows/ci-infra.yml`
- `kubectl kustomize k8s/apps/external-secrets` / `kubectl kustomize k8s/apps/processor`