### PR TITLE
fix(k8s): Pin valid aws-cli tag for processor initContainer

### DIFF
--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -18,9 +18,9 @@ This log tracks incidents and fixes in reverse chronological order. Use it for d
 - **Severity:** Medium
 - **Impact:** `processor` rollout blocked; aircraft reference DB download initContainer never started.
 - **Signal:** `Failed to pull image "amazon/aws-cli:2" ... docker.io/amazon/aws-cli:2: not found` and `ImagePullBackOff`.
-- **Analysis:** `amazon/aws-cli:2` is not available on Docker Hub. The initContainer image reference was invalid.
-- **Resolution:** Use the ECR Public AWS CLI image `public.ecr.aws/aws-cli/aws-cli:2` in `k8s/apps/processor/deployment.yaml`.
-- **Refs:** issue #377, PR #378
+- **Analysis:** The initContainer image reference used an invalid tag (`:2`) and later an unavailable ECR Public tag. Both resulted in `...: not found` pulls.
+- **Resolution:** Pin a concrete Docker Hub AWS CLI tag, e.g. `amazon/aws-cli:<major.minor.patch>`, in `k8s/apps/processor/deployment.yaml`.
+- **Refs:** issue #377, PR #378, issue #379
 
 ## 2026-02-08
 

--- a/k8s/apps/processor/deployment.yaml
+++ b/k8s/apps/processor/deployment.yaml
@@ -20,8 +20,10 @@ spec:
         runAsUser: 10001
       initContainers:
         - name: aircraft-db-download
-          # ECR Public image; `amazon/aws-cli:2` on Docker Hub is not available.
-          image: public.ecr.aws/aws-cli/aws-cli:2
+          # Docker Hub `amazon/aws-cli` does not provide a major-only tag (e.g. `:2`).
+          # Pin a concrete version tag to avoid ImagePullBackOff.
+          # Verified available via `crictl pull` on the k3s node.
+          image: amazon/aws-cli:2.33.18
           imagePullPolicy: IfNotPresent
           command:
             - sh


### PR DESCRIPTION
Fixes #379

## What changed
- Pin the processor aircraft DB initContainer image to `amazon/aws-cli:2.33.18`.
- Update troubleshooting journal entry (ImagePullBackOff root cause).

## Evidence
- `crictl pull amazon/aws-cli:2.33.18` succeeded on the k3s node.
- The previous tags (`amazon/aws-cli:2` and `public.ecr.aws/aws-cli/aws-cli:2`) failed with `...: not found`.
