### PR TITLE
fix(infra): prevent empty processor aircraft-db SSM values

### DIFF
--- a/infra/aws/live/dev/processor.tf
+++ b/infra/aws/live/dev/processor.tf
@@ -1,4 +1,10 @@
 # Processor: aircraft reference DB configuration (SSM -> ESO -> K8s Secret -> env vars)
+locals {
+  # SSM String parameters cannot be empty.
+  # Use explicit sentinel values when enrichment is disabled or checksum is absent.
+  processor_aircraft_db_s3_uri_ssm = trimspace(var.processor_aircraft_db_s3_uri) != "" ? trimspace(var.processor_aircraft_db_s3_uri) : "__disabled__"
+  processor_aircraft_db_sha256_ssm = trimspace(var.processor_aircraft_db_sha256) != "" ? lower(trimspace(var.processor_aircraft_db_sha256)) : "__none__"
+}
 
 resource "aws_ssm_parameter" "processor_aircraft_db_enabled" {
   name        = "/cloudradar/processor/aircraft-db/enabled"
@@ -16,7 +22,7 @@ resource "aws_ssm_parameter" "processor_aircraft_db_s3_uri" {
   name        = "/cloudradar/processor/aircraft-db/s3-uri"
   description = "Processor aircraft reference DB S3 URI (managed by Terraform; consumed via ESO)"
   type        = "String"
-  value       = var.processor_aircraft_db_s3_uri
+  value       = local.processor_aircraft_db_s3_uri_ssm
   overwrite   = true
 
   tags = merge(local.tags, {
@@ -28,11 +34,10 @@ resource "aws_ssm_parameter" "processor_aircraft_db_sha256" {
   name        = "/cloudradar/processor/aircraft-db/sha256"
   description = "Processor aircraft reference DB artifact SHA256 (managed by Terraform; consumed via ESO)"
   type        = "String"
-  value       = var.processor_aircraft_db_sha256
+  value       = local.processor_aircraft_db_sha256_ssm
   overwrite   = true
 
   tags = merge(local.tags, {
     Name = "cloudradar-processor-aircraft-db-sha256"
   })
 }
-

--- a/infra/aws/live/dev/variables.tf
+++ b/infra/aws/live/dev/variables.tf
@@ -127,12 +127,22 @@ variable "processor_aircraft_db_s3_uri" {
   description = "S3 URI to the aircraft reference SQLite artifact (stored in SSM and injected via ESO)."
   type        = string
   default     = ""
+
+  validation {
+    condition     = !var.processor_aircraft_db_enabled || length(trimspace(var.processor_aircraft_db_s3_uri)) > 0
+    error_message = "processor_aircraft_db_s3_uri must be set when processor_aircraft_db_enabled is true."
+  }
 }
 
 variable "processor_aircraft_db_sha256" {
   description = "Optional SHA256 for the aircraft reference SQLite artifact (stored in SSM and injected via ESO)."
   type        = string
   default     = ""
+
+  validation {
+    condition     = trimspace(var.processor_aircraft_db_sha256) == "" || can(regex("^[A-Fa-f0-9]{64}$", trimspace(var.processor_aircraft_db_sha256)))
+    error_message = "processor_aircraft_db_sha256 must be empty or a 64-character hexadecimal SHA256."
+  }
 }
 
 variable "edge_instance_type" {

--- a/infra/aws/live/prod/processor.tf
+++ b/infra/aws/live/prod/processor.tf
@@ -1,4 +1,10 @@
 # Processor: aircraft reference DB configuration (SSM -> ESO -> K8s Secret -> env vars)
+locals {
+  # SSM String parameters cannot be empty.
+  # Use explicit sentinel values when enrichment is disabled or checksum is absent.
+  processor_aircraft_db_s3_uri_ssm = trimspace(var.processor_aircraft_db_s3_uri) != "" ? trimspace(var.processor_aircraft_db_s3_uri) : "__disabled__"
+  processor_aircraft_db_sha256_ssm = trimspace(var.processor_aircraft_db_sha256) != "" ? lower(trimspace(var.processor_aircraft_db_sha256)) : "__none__"
+}
 
 resource "aws_ssm_parameter" "processor_aircraft_db_enabled" {
   name        = "/cloudradar/processor/aircraft-db/enabled"
@@ -16,7 +22,7 @@ resource "aws_ssm_parameter" "processor_aircraft_db_s3_uri" {
   name        = "/cloudradar/processor/aircraft-db/s3-uri"
   description = "Processor aircraft reference DB S3 URI (managed by Terraform; consumed via ESO)"
   type        = "String"
-  value       = var.processor_aircraft_db_s3_uri
+  value       = local.processor_aircraft_db_s3_uri_ssm
   overwrite   = true
 
   tags = merge(local.tags, {
@@ -28,11 +34,10 @@ resource "aws_ssm_parameter" "processor_aircraft_db_sha256" {
   name        = "/cloudradar/processor/aircraft-db/sha256"
   description = "Processor aircraft reference DB artifact SHA256 (managed by Terraform; consumed via ESO)"
   type        = "String"
-  value       = var.processor_aircraft_db_sha256
+  value       = local.processor_aircraft_db_sha256_ssm
   overwrite   = true
 
   tags = merge(local.tags, {
     Name = "cloudradar-processor-aircraft-db-sha256"
   })
 }
-

--- a/infra/aws/live/prod/variables.tf
+++ b/infra/aws/live/prod/variables.tf
@@ -61,12 +61,22 @@ variable "processor_aircraft_db_s3_uri" {
   description = "S3 URI to the aircraft reference SQLite artifact (stored in SSM and injected via ESO)."
   type        = string
   default     = ""
+
+  validation {
+    condition     = !var.processor_aircraft_db_enabled || length(trimspace(var.processor_aircraft_db_s3_uri)) > 0
+    error_message = "processor_aircraft_db_s3_uri must be set when processor_aircraft_db_enabled is true."
+  }
 }
 
 variable "processor_aircraft_db_sha256" {
   description = "Optional SHA256 for the aircraft reference SQLite artifact (stored in SSM and injected via ESO)."
   type        = string
   default     = ""
+
+  validation {
+    condition     = trimspace(var.processor_aircraft_db_sha256) == "" || can(regex("^[A-Fa-f0-9]{64}$", trimspace(var.processor_aircraft_db_sha256)))
+    error_message = "processor_aircraft_db_sha256 must be empty or a 64-character hexadecimal SHA256."
+  }
 }
 variable "grafana_admin_password" {
   description = "Grafana admin password. If empty, a random one will be generated."

--- a/k8s/apps/processor/deployment.yaml
+++ b/k8s/apps/processor/deployment.yaml
@@ -29,15 +29,20 @@ spec:
             - sh
             - -ec
             - |
-              if [ -z "${AIRCRAFT_DB_S3_URI:-}" ]; then
-                echo "AIRCRAFT_DB_S3_URI is empty; skipping aircraft DB download"
+              if [ "${PROCESSOR_AIRCRAFT_DB_ENABLED:-false}" != "true" ]; then
+                echo "Aircraft DB enrichment disabled; skipping aircraft DB download"
+                exit 0
+              fi
+
+              if [ -z "${AIRCRAFT_DB_S3_URI:-}" ] || [ "${AIRCRAFT_DB_S3_URI}" = "__disabled__" ]; then
+                echo "AIRCRAFT_DB_S3_URI is not configured; skipping aircraft DB download"
                 exit 0
               fi
 
               echo "Downloading aircraft DB from ${AIRCRAFT_DB_S3_URI} ..."
               aws s3 cp "${AIRCRAFT_DB_S3_URI}" /refdata/aircraft.db
 
-              if command -v sha256sum >/dev/null 2>&1 && [ -n "${AIRCRAFT_DB_SHA256:-}" ]; then
+              if command -v sha256sum >/dev/null 2>&1 && echo "${AIRCRAFT_DB_SHA256:-}" | grep -Eq '^[A-Fa-f0-9]{64}$'; then
                 echo "${AIRCRAFT_DB_SHA256}  /refdata/aircraft.db" | sha256sum -c -
               fi
 
@@ -46,6 +51,12 @@ spec:
           env:
             - name: AWS_REGION
               value: us-east-1
+            - name: PROCESSOR_AIRCRAFT_DB_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: processor-aircraft-db
+                  key: enabled
+                  optional: true
             - name: AIRCRAFT_DB_S3_URI
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## What changed
- Prevented empty SSM String values for processor aircraft DB parameters in Terraform (dev + prod).
- Added variable validations:
  - `processor_aircraft_db_enabled=true` now requires non-empty `processor_aircraft_db_s3_uri`.
  - `processor_aircraft_db_sha256` must be empty or valid 64-hex SHA256.
- Hardened processor initContainer behavior:
  - Skip download unless `PROCESSOR_AIRCRAFT_DB_ENABLED=true`.
  - Skip when S3 URI is unset/sentinel.
  - Verify checksum only when SHA256 format is valid.

## Why
`ci-infra` failed with AWS SSM `ValidationException` because Terraform tried to write empty String values for:
- `/cloudradar/processor/aircraft-db/s3-uri`
- `/cloudradar/processor/aircraft-db/sha256`

## Validation
- `terraform -chdir=infra/aws/live/prod validate` ✅
- `terraform -chdir=infra/aws/live/dev validate` blocked locally by backend/state access (`403`), not by config syntax.

Fixes #388
