### PR TITLE
feat(obs): render military combined panel as lcd bargauge

### DIFF
--- a/k8s/apps/monitoring/dashboards/json/cloudradar-app-telemetry.json
+++ b/k8s/apps/monitoring/dashboards/json/cloudradar-app-telemetry.json
@@ -1242,7 +1242,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "continuous-GrYlRd"
           },
           "decimals": 2,
           "mappings": [],
@@ -1259,7 +1259,7 @@
       },
       "id": 115,
       "options": {
-        "displayMode": "basic",
+        "displayMode": "lcd",
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
@@ -1268,7 +1268,7 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": false,
+        "showUnfilled": true,
         "valueMode": "color"
       },
       "targets": [


### PR DESCRIPTION
## What Changed
- Updated `Military Activity (Share + Index)` panel rendering to use Grafana `bargauge` LCD style.
- Kept existing queries and layout unchanged.

## Why
Closes #416

## Files Affected
- k8s/apps/monitoring/dashboards/json/cloudradar-app-telemetry.json

## Notes
- Visual-only change for better readability.
- Dashboard JSON remains valid.

---

**Before submitting:**
- [x] Title follows format: `type(scope): description`
- [x] Uses `Closes #XXX` (features) or `Fixes #XXX` (bugs)
- [ ] All CI checks pass
- [x] Documentation updated (if applicable)
