### PR TITLE
fix(dashboard): reduce map aircraft flicker with 3-batch continuity

### DIFF
--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -4,6 +4,17 @@ This log tracks incidents and fixes in reverse chronological order. Use it for d
 
 ## 2026-02-14
 
+### [dashboard/map] Aircraft flicker when OpenSky temporarily omits ICAO across two cycles
+- **Severity:** Medium
+- **Impact:** Aircraft markers could disappear/reappear between refreshes even when traffic was continuous.
+- **Signal:** UI snapshots showed abrupt aircraft drops between consecutive refreshes without consistent movement out of bbox.
+- **Analysis:** Continuity fallback in `GET /api/flights` kept only `latest + previous` OpenSky batches. When an ICAO was missing for two consecutive OpenSky responses, it was removed too early and reappeared later.
+- **Resolution:**
+  1. Extend continuity window to keep ICAO from `latest + 2 previous` batches.
+  2. Keep one event per ICAO by prioritizing the newest batch epoch, then `lastSeen` inside the same batch.
+  3. Add unit test coverage for three-batch continuity and epoch-priority selection.
+- **Guardrail:** Preserve short continuity only (3 batches) to reduce flicker while avoiding long-lived stale aircraft on the map.
+
 ### [frontend/map] Marker readability low + no labels toggle + unrealistic track jumps
 - **Severity:** Medium
 - **Impact:** Aircraft markers were hard to read at low zoom and lacked clear visual differentiation; city/place labels could not be toggled; track line could connect distant timestamps into unrealistic long diagonals.


### PR DESCRIPTION
## Summary
- Extended dashboard map continuity from `latest + previous` to `latest + 2 previous` OpenSky batches.
- Added per-ICAO candidate selection that prioritizes newest batch epoch before `lastSeen`.
- Added unit coverage for three-batch continuity and epoch-priority conflict resolution.
- Updated troubleshooting journal with incident analysis and guardrail.

## Validation
- `cd src/dashboard && mvn -q test`

Fixes #443