### PR TITLE
docs(meta): add dashboard technical architecture and deduplicate docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,13 @@ Start here if you're new to the project or want to understand how components fit
    - ArgoCD deployment model
    - Terraform module organization
 
-3. **[Architecture Decision Records (ADRs)](architecture/decisions/)** (Technical choices)
+3. **[Frontend Dashboard Technical Architecture](architecture/frontend-dashboard-technical-architecture.md)** (Dashboard internals)
+   - Redis snapshot selection and short continuity policy (`latest + 2 previous`)
+   - on-read metadata enrichment with local SQLite
+   - SSE refresh stream model (`/api/flights/stream`)
+   - performance and known limits
+
+4. **[Architecture Decision Records (ADRs)](architecture/decisions/)** (Technical choices)
    - 18+ ADRs documenting all major decisions
    - Technology selections, cost implications, trade-offs
    - **See [ADR Index](#adr-index) below for quick reference**

--- a/docs/api/dashboard-api.md
+++ b/docs/api/dashboard-api.md
@@ -3,6 +3,9 @@
 Base path: `/api/flights`  
 Audience: frontend dashboard map + detail panel + KPI cards.
 
+Implementation internals are documented in `docs/architecture/frontend-dashboard-technical-architecture.md`.
+Service-level runtime notes are in `src/dashboard/README.md`.
+
 ## `GET /api/flights`
 
 Returns a lightweight list for map rendering.

--- a/docs/architecture/frontend-dashboard-technical-architecture.md
+++ b/docs/architecture/frontend-dashboard-technical-architecture.md
@@ -1,0 +1,144 @@
+# Frontend Dashboard Technical Architecture
+
+Technical internals for the CloudRadar dashboard path:
+
+- Frontend app (`src/frontend`) rendering map, markers, tracks, KPIs.
+- Dashboard API (`src/dashboard`) serving read-model endpoints from Redis + optional SQLite enrichment.
+
+## 1. Runtime Topology
+
+```mermaid
+flowchart LR
+  subgraph Browser["User Browser"]
+    UI["React + Leaflet UI"]
+  end
+
+  subgraph API["Dashboard Service (Spring Boot)"]
+    CTRL["DashboardController"]
+    QUERY["FlightQueryService"]
+    STREAM["FlightUpdateStreamService"]
+    META["SqliteAircraftMetadataRepository"]
+  end
+
+  REDIS[("Redis\ncloudradar:aircraft:last\ncloudradar:aircraft:track:*")]
+  SQLITE[("Local SQLite\n/refdata/aircraft.db")]
+
+  UI -->|"GET /api/flights"| CTRL
+  UI -->|"GET /api/flights/:icao24"| CTRL
+  UI -->|"GET /api/flights/metrics"| CTRL
+  UI -->|"SSE /api/flights/stream"| STREAM
+
+  CTRL --> QUERY
+  QUERY --> REDIS
+  QUERY --> META
+  META --> SQLITE
+  STREAM --> REDIS
+```
+
+## 2. Main Components
+
+- `DashboardController`
+  - HTTP routes under `/api/flights`.
+- `FlightQueryService`
+  - map/detail/metrics query orchestration.
+- `FlightUpdateStreamService`
+  - SSE emitter management and batch-change detection.
+- `SqliteAircraftMetadataRepository` (optional bean)
+  - on-read metadata lookup with in-process LRU cache.
+
+## 3. Data Sources
+
+Redis keys:
+
+- `cloudradar:aircraft:last` (Hash): latest telemetry payload per `icao24`.
+- `cloudradar:aircraft:track:<icao24>` (List): bounded recent trajectory points.
+
+Telemetry payload includes `opensky_fetch_epoch`, used as batch boundary.
+
+## 4. Map Endpoint Internals (`GET /api/flights`)
+
+Goal: stable map snapshot with low-latency reads.
+
+```mermaid
+flowchart LR
+  A["Parse query"] --> B["Scan Redis last hash"]
+  B --> C["Normalize ICAO24"]
+  C --> D["Detect batch N and N-1/N-2"]
+  D --> E["Continuity merge"]
+  E --> F["Optional metadata enrich"]
+  F --> G["Filter sort limit"]
+  G --> H["Return DTO payload"]
+```
+
+Why latest + short fallback window:
+
+- latest batch stays the primary source of truth,
+- fallback to the previous two batches reduces flicker when OpenSky temporarily omits ICAO,
+- no long historical blending.
+
+## 5. Detail Endpoint Internals (`GET /api/flights/{icao24}`)
+
+1. Read current aircraft payload from `cloudradar:aircraft:last`.
+2. Optionally load track list from `cloudradar:aircraft:track:<icao24>`.
+3. Optionally enrich with SQLite metadata.
+4. Return merged DTO.
+
+Track rendering note (frontend): large timestamp gaps should split the polyline into multiple segments to avoid fake straight lines across unrelated itineraries.
+
+## 6. Metrics Endpoint Internals (`GET /api/flights/metrics`)
+
+1. Reuse snapshot loading logic.
+2. Aggregate active aircraft, density, military share, fleet/type/size mix, and activity series.
+3. Return low-cardinality payload for KPI cards and compact charts.
+
+## 7. Push Refresh Model (`GET /api/flights/stream`)
+
+`FlightUpdateStreamService` maintains active `SseEmitter` clients.
+
+```mermaid
+sequenceDiagram
+  participant FE as Frontend (EventSource)
+  participant API as Dashboard API
+  participant R as Redis
+
+  FE->>API: GET /api/flights/stream
+  API-->>FE: event: connected
+  loop every poll interval
+    API->>R: read latest opensky_fetch_epoch
+    alt epoch changed
+      API-->>FE: event: batch-update
+      FE->>API: GET /api/flights + GET /api/flights/metrics
+      API-->>FE: refreshed payloads
+    else no change
+      API-->>FE: event: heartbeat
+    end
+  end
+```
+
+Frontend keeps a low-frequency polling fallback if SSE disconnects.
+
+## 8. Validation and Safety
+
+- strict query parsing (`BadRequestException`) for malformed params,
+- `NotFoundException` for unknown `icao24`,
+- in-memory rate limiting on `/api/**`,
+- read-only API surface (`GET` only).
+
+## 9. Performance Notes
+
+- Redis hash scan is O(n) on active aircraft count.
+- SQLite lookups are local and cached to reduce repeated I/O.
+- DTO payloads are intentionally compact for frequent refresh cycles.
+- SSE avoids blind high-frequency polling.
+
+## 10. Known Limits
+
+- SSE stream is process-local (single instance friendly; multi-instance needs sticky sessions or pub/sub coordination for strict ordering).
+- Snapshot consistency depends on processor update timeliness.
+- Continuity window is intentionally limited to latest + two previous OpenSky batches.
+
+## 11. Related References
+
+- API contract: `docs/api/dashboard-api.md`
+- Service README: `src/dashboard/README.md`
+- Metadata ADR: `docs/architecture/decisions/ADR-0019-2026-02-10-aircraft-metadata-enrichment-for-ui.md`

--- a/src/dashboard/README.md
+++ b/src/dashboard/README.md
@@ -1,78 +1,129 @@
-# CloudRadar Dashboard API
+# CloudRadar Dashboard Service
 
-Java 17 / Spring Boot service exposing frontend-oriented endpoints for map rendering and KPI cards.
+Java 17 / Spring Boot service that exposes read APIs consumed by the React dashboard.
 
-## Endpoints
+This README focuses on **runtime behavior and internals**.
+For HTTP contract details, see `docs/api/dashboard-api.md`.
 
-### `GET /api/flights`
-Lightweight map feed (frequent refresh).
+## Purpose
 
-Default response fields:
-- `icao24`
-- `callsign`
-- `lat`
-- `lon`
-- `heading`
-- `lastSeen`
-- `speed`
-- `altitude`
+- Serve map payloads from Redis aggregates.
+- Serve per-aircraft detail payloads with optional enrichment.
+- Serve KPI aggregates for frontend cards/charts.
+- Push refresh signals to frontend through SSE when a new OpenSky batch is detected.
 
-Supported query params:
-- `bbox=minLon,minLat,maxLon,maxLat`
-- `since=<epoch|iso8601>`
-- `limit=<int>`
-- `sort=lastSeen|speed|altitude`
-- `order=asc|desc`
-- `militaryHint=true|false|unknown`
-- `airframeType=airplane|helicopter|unknown`
-- `category=<string>`
-- `country=<string>`
-- `typecode=<string>`
+## Endpoints (high-level)
 
-### `GET /api/flights/stream`
-Server-Sent Events stream for frontend refresh triggers.
+Base path: `/api/flights`
 
-Events:
-- `connected`
-- `batch-update` (sent when latest `opensky_fetch_epoch` changes)
-- `heartbeat` (keepalive)
+- `GET /api/flights` -> map list payload
+- `GET /api/flights/{icao24}` -> detail payload
+- `GET /api/flights/metrics` -> KPI payload
+- `GET /api/flights/stream` -> SSE events (`connected`, `batch-update`, `heartbeat`)
 
-### `GET /api/flights/{icao24}`
-Aircraft detail view for click interactions.
+See `docs/api/dashboard-api.md` for full request/response schemas and examples.
 
-Query params:
-- `include=track,enrichment` (optional)
+## Internal Flow
 
-### `GET /api/flights/metrics`
-Aggregated KPIs for dashboard cards under the map.
+### 1. Map list (`GET /api/flights`)
 
-Query params:
-- `bbox=minLon,minLat,maxLon,maxLat` (optional)
-- `window=<duration>` where duration is `30m`, `6h`, `24h`, `2d`.
+Implemented in `FlightQueryService#listFlights`.
 
-Response includes:
-- `activeAircraft`
-- `trafficDensityPer10kKm2`
-- `militarySharePercent`
-- `defenseActivityScore`
-- `fleetBreakdown[]`
-- `aircraftSizes[]`
-- `aircraftTypes[]`
-- `activitySeries[]`
-- `estimates` (planned placeholders for v1.1 signals)
+Pipeline:
 
-## Security and hardening
-- Read-only API (GET).
-- CORS allowlist (`API_CORS_ALLOW_ORIGINS`).
-- In-memory per-client rate limit (`API_RATE_LIMIT_*`).
-- Strict query validation (`400` on invalid values).
-- Prometheus metrics at `/metrics/prometheus`.
+1. Parse and validate query parameters (`bbox`, `limit`, `sort`, filters).
+2. Scan Redis hash `cloudradar:aircraft:last` (key configurable).
+3. Build in-memory candidates with normalized `icao24`.
+4. Batch continuity policy:
+   - select latest `opensky_fetch_epoch` as primary snapshot,
+   - include ICAO from up to two previous batches when missing in latest batch (short continuity fallback).
+5. Enrich metadata on read (if aircraft DB enabled):
+   - category, country, typecode, military hint,
+   - inferred fields used by UI (`airframeType`, `fleetType`, `aircraftSize`).
+6. Filter/sort/limit and return frontend payload.
 
-## v1.1 notes (planned)
-- Add estimated takeoffs/landings counters based on `on_ground` transition logic.
-- Add `noiseProxyIndex` heuristic using speed, altitude, and aircraft class/type.
-- Tracking issue: #425.
+### 2. Detail (`GET /api/flights/{icao24}`)
 
-## De-scoped from issue #129
-- Alerts endpoint is intentionally out of scope here and tracked via a dedicated v1 issue.
-- Tracking issue: #424.
+Implemented in `FlightQueryService#getFlightDetail`.
+
+Pipeline:
+
+1. Read latest position from Redis hash by `icao24`.
+2. Optionally load track points from `cloudradar:aircraft:track:<icao24>`.
+3. Optionally enrich with aircraft metadata from local SQLite repository.
+4. Return a single merged DTO.
+
+### 3. Metrics (`GET /api/flights/metrics`)
+
+Implemented in `FlightQueryService#getFlightsMetrics`.
+
+Pipeline:
+
+1. Reuse snapshot loading logic (bbox/window aware).
+2. Aggregate active aircraft, density, defense share, type/size/fleet breakdowns.
+3. Build activity series buckets for lightweight frontend sparklines.
+
+### 4. Refresh stream (`GET /api/flights/stream`)
+
+Implemented in `FlightUpdateStreamService`.
+
+Pipeline:
+
+1. Register SSE emitter.
+2. Poll Redis latest batch epoch in background.
+3. Emit `batch-update` when epoch changes.
+4. Emit periodic `heartbeat` keepalive.
+5. Frontend subscribes with `EventSource` and refreshes on push.
+
+## Data Sources
+
+- Redis (required):
+  - last positions hash
+  - track lists
+- Aircraft metadata DB (optional):
+  - local SQLite file (`/refdata/aircraft.db` by default)
+  - enabled through `dashboard.aircraft-db.enabled`
+
+## Config Highlights
+
+From `src/dashboard/src/main/resources/application.yml`:
+
+- Redis:
+  - `REDIS_HOST`, `REDIS_PORT`
+  - `DASHBOARD_REDIS_LAST_POSITIONS_KEY`
+  - `DASHBOARD_REDIS_TRACK_KEY_PREFIX`
+- API behavior:
+  - `API_LIMIT_DEFAULT`, `API_LIMIT_MAX`
+  - `API_BBOX_*`
+  - `API_CORS_ALLOW_ORIGINS`
+  - `API_RATE_LIMIT_*`
+- Aircraft DB:
+  - `API_AIRCRAFT_DB_ENABLED`
+  - `API_AIRCRAFT_DB_PATH`
+  - `API_AIRCRAFT_DB_CACHE_SIZE`
+
+## Security and Hardening
+
+- Read-only API surface (`GET` only).
+- API validation and structured 400/404 errors.
+- In-memory per-client API rate limiting on `/api/**`.
+- CORS allowlist support.
+
+## Local Run
+
+```bash
+cd src/dashboard
+mvn spring-boot:run
+```
+
+Run tests:
+
+```bash
+mvn test
+```
+
+## Related Docs
+
+- API reference: `docs/api/dashboard-api.md`
+- Architecture deep dive: `docs/architecture/frontend-dashboard-technical-architecture.md`
+- Project architecture overview: `docs/architecture/application-architecture.md`


### PR DESCRIPTION
## Summary
- Added a dedicated technical architecture document for dashboard internals.
- Reduced overlap between dashboard API reference and dashboard service README.
- Updated docs hub navigation to reference the new architecture entry.
- Aligned continuity wording with current behavior (`latest + 2 previous` batches).

## Changelog (Meta #57)
- Added `docs/architecture/frontend-dashboard-technical-architecture.md`.
- Updated links and scope split across `docs/api/dashboard-api.md` and `src/dashboard/README.md`.
- Updated docs index entry in `docs/README.md`.

## Validation
- Documentation consistency review after rebase on `main`.

Refs #57
