### PR TITLE
feat(obs): add OpenSky credits-per-request KPIs

### DIFF
--- a/k8s/apps/monitoring/dashboards/json/cloudradar-app-telemetry.json
+++ b/k8s/apps/monitoring/dashboards/json/cloudradar-app-telemetry.json
@@ -1341,6 +1341,140 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Average OpenSky credits consumed per request over the current credit cycle (since last reset).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 118,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(ingester_opensky_credits_avg_per_request)",
+          "legendFormat": "credits/req",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "OpenSky Credits / Request (Global)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Average OpenSky credits consumed per request over the last 24 hours.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 119,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "clamp_min(increase(ingester_opensky_credits_used_since_reset[24h]), 0) / clamp_min(increase(ingester_opensky_requests_since_reset[24h]), 1)",
+          "legendFormat": "credits/req (24h)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "OpenSky Credits / Request (Last 24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Seconds since processor handled the last event (freshness signal). Lower is better.",
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
## Summary
- added `OpenSky Credits / Request (Global)` stat panel in app telemetry dashboard
- added `OpenSky Credits / Request (Last 24h)` stat panel in app telemetry dashboard
- used existing ingester OpenSky credit metrics (no app code changes)
- kept dashboard JSON valid and unchanged outside the targeted panel insertion

## KPI formulas
- Global: `max(ingester_opensky_credits_avg_per_request)`
- Last 24h: `clamp_min(increase(ingester_opensky_credits_used_since_reset[24h]), 0) / clamp_min(increase(ingester_opensky_requests_since_reset[24h]), 1)`

## Validation
- `jq empty k8s/apps/monitoring/dashboards/json/cloudradar-app-telemetry.json`

Closes #452
