### PR TITLE
fix(infra): make grafana ssm parameter idempotent

### DIFF
--- a/infra/aws/live/dev/monitoring.tf
+++ b/infra/aws/live/dev/monitoring.tf
@@ -18,6 +18,7 @@ resource "aws_ssm_parameter" "grafana_admin_password" {
   description = "Grafana admin password (created by Terraform, stored for audit + recovery)"
   type        = "SecureString"
   value       = local.grafana_admin_password
+  overwrite   = true
 
   tags = merge(var.tags, {
     Name = "cloudradar-grafana-admin-password"


### PR DESCRIPTION
## Summary
- set `overwrite = true` on `aws_ssm_parameter.grafana_admin_password` in `infra/aws/live/dev/monitoring.tf`
- fixed `ParameterAlreadyExists` failures during `terraform apply` when `/cloudradar/grafana/admin-password` already exists
- kept scope minimal to restore Terraform idempotence for the dev monitoring password parameter

## Validation
- `terraform -chdir=infra/aws/live/dev fmt -check -diff monitoring.tf`
- local plan context from reported failure now shows `overwrite = true` on the SSM parameter resource

Fixes #463
