### PR TITLE
ci(infra): add state-vs-tagged orphan scan

### DIFF
--- a/.github/workflows/ci-infra-destroy.yml
+++ b/.github/workflows/ci-infra-destroy.yml
@@ -259,3 +259,14 @@ jobs:
 
       - name: Terraform destroy
         run: terraform -chdir="${TF_DIR}" destroy -input=false -auto-approve -var-file=terraform.tfvars
+
+      - name: Orphan scan post-destroy (best effort)
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          scripts/ci/find-orphans.sh \
+            --environment "${{ inputs.environment }}" \
+            --tf-dir "${TF_DIR}" \
+            --mode post-destroy \
+            --strict false \
+            --summary-path "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -276,12 +276,48 @@ jobs:
             echo "::warning title=tf-validate::terraform validate failed."
           fi
 
+  orphan-scan-pre-deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    needs: env-select
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.TF_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform init (remote backend)
+        run: |
+          terraform -chdir="${{ needs.env-select.outputs.tf_dir }}" init \
+            -backend-config="bucket=${TF_STATE_BUCKET}" \
+            -backend-config="region=${AWS_REGION}" \
+            -backend-config="dynamodb_table=${TF_LOCK_TABLE_NAME}" \
+            -backend-config="key=${{ needs.env-select.outputs.tf_key }}"
+
+      - name: Orphan scan pre-deploy (strict)
+        run: |
+          scripts/ci/find-orphans.sh \
+            --environment "${{ inputs.environment }}" \
+            --tf-dir "${{ needs.env-select.outputs.tf_dir }}" \
+            --mode pre-deploy \
+            --strict true \
+            --summary-path "$GITHUB_STEP_SUMMARY"
+
   tf-plan:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     needs:
       - env-select
       - tf-validate
+      - orphan-scan-pre-deploy
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout

--- a/docs/runbooks/ci-cd/ci-infra.md
+++ b/docs/runbooks/ci-cd/ci-infra.md
@@ -65,21 +65,22 @@ The manual dispatch runs a chained set of jobs (visible in the Actions graph):
 
 1. `env-select`: select `dev` or `prod`, expose `TF_DIR`/`TF_KEY`.
 2. `tf-validate`: init + validate (remote backend).
-3. `tf-plan`: init + plan with `terraform.tfvars`.
-4. `tf-apply`: guarded apply (requires `auto_approve` checked).
-5. `tf-outputs` (dev only): load Terraform outputs for SSM/edge checks.
-6. `k3s-ready-check` (dev): wait for k3s nodes via SSM.
-7. `prometheus-crds` (dev): apply Prometheus CRDs before ArgoCD bootstrap.
-8. `argocd-install` (dev): install ArgoCD via SSM.
-9. `argocd-platform` (dev): bootstrap platform apps (ESO/operator prerequisites).
-10. `eso-ready-check` (dev): wait for ESO readiness.
-11. `argocd-apps` (dev): bootstrap root apps from `k8s/apps`.
-12. `eso-secrets-ready` (dev): enforce External Secrets synchronization (`ExternalSecret Ready=True` and target Secrets materialized) before restore/smoke.
-13. `REDIS-RESTORE` (dev): restore Redis from the latest backup.
+3. `orphan-scan-pre-deploy`: strict orphan check based on `state vs tagged` before planning/apply.
+4. `tf-plan`: init + plan with `terraform.tfvars`.
+5. `tf-apply`: guarded apply (requires `auto_approve` checked).
+6. `tf-outputs` (dev only): load Terraform outputs for SSM/edge checks.
+7. `k3s-ready-check` (dev): wait for k3s nodes via SSM.
+8. `prometheus-crds` (dev): apply Prometheus CRDs before ArgoCD bootstrap.
+9. `argocd-install` (dev): install ArgoCD via SSM.
+10. `argocd-platform` (dev): bootstrap platform apps (ESO/operator prerequisites).
+11. `eso-ready-check` (dev): wait for ESO readiness.
+12. `argocd-apps` (dev): bootstrap root apps from `k8s/apps`.
+13. `eso-secrets-ready` (dev): enforce External Secrets synchronization (`ExternalSecret Ready=True` and target Secrets materialized) before restore/smoke.
+14. `REDIS-RESTORE` (dev): restore Redis from the latest backup.
    - Visible as a dedicated job in the Actions graph.
    - Logs explicit decision and reason (`RUN` / `SKIPPED`) in both logs and Step Summary.
    - Skips restore safely when disabled by input, when no backup is found, or when Redis `/data` is not empty.
-14. `smoke-tests` (dev + smoke): wait for ArgoCD sync, healthz rollout, and curl `/healthz`.
+15. `smoke-tests` (dev + smoke): wait for ArgoCD sync, healthz rollout, and curl `/healthz`.
    - Logs explicit decision and reason (`RUN` / `SKIPPED`) in both logs and Step Summary.
    - Uses signal-focused annotations (decision/outcome) instead of internal `command_id` noise.
 
@@ -102,6 +103,7 @@ flowchart TB
   subgraph Dispatch["workflow_dispatch"]
     env-select[env-select]
     tf-validate[tf-validate]
+    orphan-scan-pre-deploy[orphan-scan-pre-deploy]
     tf-plan[tf-plan]
     tf-apply[tf-apply]
     tf-outputs[tf-outputs]
@@ -115,7 +117,7 @@ flowchart TB
     redis-restore[REDIS-RESTORE]
     smoke-tests[smoke-tests]
 
-    env-select --> tf-validate --> tf-plan --> tf-apply --> tf-outputs
+    env-select --> tf-validate --> orphan-scan-pre-deploy --> tf-plan --> tf-apply --> tf-outputs
     tf-outputs --> k3s-ready-check --> prometheus-crds --> argocd-install --> argocd-platform --> eso-ready-check --> argocd-apps --> eso-secrets-ready --> redis-restore --> smoke-tests
   end
 
@@ -142,6 +144,9 @@ flowchart TB
 - The Redis restore phase is represented by a dedicated job named `REDIS-RESTORE` in the graph.
   - If `redis_backup_restore=false`, the job emits an explicit skip reason in logs and summary.
   - If restore is requested, the job still protects data by skipping restore when Redis data is not fresh.
+- `orphan-scan-pre-deploy` runs a strict `state vs tagged` scan before planning/apply and fails fast on tagged resources found in AWS but missing from Terraform state.
+- Both `orphan-scan-pre-deploy` and `ci-infra-destroy` post-destroy scan append findings to `GITHUB_STEP_SUMMARY`.
+- Script details (modes, usage, flow): `scripts/ci/find-orphans.md`.
 - When `run_smoke_tests=true` (dev only), it also waits for the ArgoCD app to be Synced/Healthy, waits for the `healthz` deployment rollout, then curls `/healthz` from the Internet.
   - If `run_smoke_tests=false`, the smoke-tests job emits an explicit skip reason in logs and summary.
 - The smoke test verifies edge Nginx via SSM (3 retries with 10s delay) before running the external `/healthz` curl.
@@ -209,4 +214,5 @@ Use the dedicated destroy workflow when you need to tear down an environment.
 
 - Workflow: `.github/workflows/ci-infra.yml`
 - Workflow: `.github/workflows/ci-infra-destroy.yml`
+- Script docs: `scripts/ci/find-orphans.md`
 - Backend bootstrap runbook: `docs/runbooks/terraform-backend-bootstrap.md`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,6 +31,13 @@ scripts/bootstrap-prometheus-crds.sh <instance-id> us-east-1
 Notes:
 - Overrides: `PROMETHEUS_CRD_REPO`, `PROMETHEUS_CRD_REVISION`, `PROMETHEUS_CRD_DIR`, `PROMETHEUS_CRD_TIMEOUT`.
 
+## ci/find-orphans.sh
+
+Runs state-vs-tagged orphan checks used by infra CI before deploy and after destroy.
+
+See detailed documentation:
+- `scripts/ci/find-orphans.md`
+
 ## build-aircraft-sqlite.py
 
 Builds a lightweight aircraft reference database (`aircraft.db`) from a large CSV dataset.

--- a/scripts/ci/find-orphans.md
+++ b/scripts/ci/find-orphans.md
@@ -1,0 +1,77 @@
+# find-orphans.sh
+
+Detects orphan resources by comparing Terraform state against AWS tagged resources.
+
+## Purpose
+
+- Fail fast before deploy when AWS has Terraform-tagged resources that are absent from Terraform state.
+- Report tagged residual resources after destroy.
+- Publish a short summary to `GITHUB_STEP_SUMMARY` in CI.
+
+## Detection model
+
+- **A (expected):** AWS resources managed by Terraform state (ARNs from `terraform show -json`).
+- **B (observed):** AWS resources returned by Resource Groups Tagging API with tags:
+  - `managed-by=<value>` (default `terraform`)
+  - `Project=<project>`
+  - `Environment=<env>`
+- **Findings:** `B - A`
+  - tagged resources present in AWS but not present in Terraform state.
+
+## Modes
+
+- `pre-deploy`:
+  - default mode
+  - strict by default (`--strict true`)
+  - exits non-zero on findings
+- `post-destroy`:
+  - report mode by default (`--strict false`)
+  - still computes findings, but usually does not fail the workflow
+
+Backward compatibility:
+- `--mode preflight` is accepted as an alias of `pre-deploy`.
+
+## Usage
+
+```bash
+scripts/ci/find-orphans.sh \
+  --environment dev \
+  --project cloudradar \
+  --tf-dir infra/aws/live/dev \
+  --mode pre-deploy \
+  --strict true \
+  --summary-path "$GITHUB_STEP_SUMMARY"
+```
+
+```bash
+scripts/ci/find-orphans.sh \
+  --environment dev \
+  --project cloudradar \
+  --tf-dir infra/aws/live/dev \
+  --mode post-destroy \
+  --strict false \
+  --summary-path "$GITHUB_STEP_SUMMARY"
+```
+
+## Flow
+
+```mermaid
+flowchart LR
+  A[Read Terraform state JSON] --> B[Extract managed AWS ARNs from state]
+  C[Query AWS Tagging API by managed-by/Project/Environment] --> D[Extract tagged ARNs]
+  B --> E[Compute diff: tagged - state]
+  D --> E
+  E --> F{findings > 0}
+  F -->|yes| G[Write findings to logs and summary]
+  F -->|no| H[Write clean summary]
+  G --> I{strict=true}
+  I -->|yes| J[Exit 1]
+  I -->|no| K[Exit 0]
+  H --> K
+```
+
+## Scope and limitations
+
+- Designed for live infra pipelines (`ci-infra`, `ci-infra-destroy`).
+- Bootstrap stack is out of scope.
+- Comparison currently relies on ARN matching from Terraform state; resources without ARN in state are not part of this diff.

--- a/scripts/ci/find-orphans.sh
+++ b/scripts/ci/find-orphans.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ci/find-orphans.sh --environment <dev|prod> --tf-dir <path> [options]
+
+Options:
+  --environment <env>      Target environment (dev|prod).
+  --project <name>         Project tag value (default: cloudradar).
+  --tf-dir <path>          Terraform root (required, used to read state).
+  --mode <pre-deploy|post-destroy>
+                           Scan mode (default: pre-deploy).
+  --strict <true|false>    Exit non-zero on findings (default: true in pre-deploy, false in post-destroy).
+  --managed-by <value>     managed-by tag value (default: terraform).
+  --summary-path <path>    Markdown summary output path (e.g. $GITHUB_STEP_SUMMARY).
+USAGE
+}
+
+ENVIRONMENT=""
+PROJECT="cloudradar"
+TF_DIR=""
+MODE="pre-deploy"
+STRICT=""
+MANAGED_BY="terraform"
+SUMMARY_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --environment)
+      ENVIRONMENT="${2:-}"
+      shift 2
+      ;;
+    --project)
+      PROJECT="${2:-}"
+      shift 2
+      ;;
+    --tf-dir)
+      TF_DIR="${2:-}"
+      shift 2
+      ;;
+    --mode)
+      MODE="${2:-}"
+      shift 2
+      ;;
+    --strict)
+      STRICT="${2:-}"
+      shift 2
+      ;;
+    --managed-by)
+      MANAGED_BY="${2:-}"
+      shift 2
+      ;;
+    --summary-path)
+      SUMMARY_PATH="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${ENVIRONMENT}" ]]; then
+  echo "--environment is required" >&2
+  exit 2
+fi
+
+if [[ -z "${TF_DIR}" ]]; then
+  echo "--tf-dir is required" >&2
+  exit 2
+fi
+
+if [[ "${MODE}" == "preflight" ]]; then
+  # Backward-compatible alias.
+  MODE="pre-deploy"
+fi
+
+if [[ "${MODE}" != "pre-deploy" && "${MODE}" != "post-destroy" ]]; then
+  echo "--mode must be pre-deploy or post-destroy" >&2
+  exit 2
+fi
+
+if [[ -z "${STRICT}" ]]; then
+  if [[ "${MODE}" == "pre-deploy" ]]; then
+    STRICT="true"
+  else
+    STRICT="false"
+  fi
+fi
+
+if [[ "${STRICT}" != "true" && "${STRICT}" != "false" ]]; then
+  echo "--strict must be true or false" >&2
+  exit 2
+fi
+
+for bin in aws terraform jq sort comm; do
+  if ! command -v "${bin}" >/dev/null 2>&1; then
+    echo "${bin} is required" >&2
+    exit 2
+  fi
+done
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+state_json="${tmp_dir}/state.json"
+state_arns="${tmp_dir}/state_arns.txt"
+tagged_arns="${tmp_dir}/tagged_arns.txt"
+tagged_tmp="${tmp_dir}/tagged_raw.txt"
+findings_file="${tmp_dir}/findings.txt"
+
+terraform -chdir="${TF_DIR}" show -json > "${state_json}"
+
+jq -r '
+  def all_resources(m):
+    (m.resources // [])[],
+    ((m.child_modules // [])[] | all_resources(.));
+
+  .values.root_module as $root
+  | all_resources($root)
+  | select(.mode == "managed")
+  | select(.type | startswith("aws_"))
+  | .values.arn? // empty
+' "${state_json}" \
+  | sed '/^$/d' \
+  | sort -u > "${state_arns}"
+
+: > "${tagged_tmp}"
+pagination_token=""
+
+while :; do
+  if [[ -n "${pagination_token}" ]]; then
+    response="$(aws resourcegroupstaggingapi get-resources \
+      --tag-filters "Key=managed-by,Values=${MANAGED_BY}" "Key=Project,Values=${PROJECT}" "Key=Environment,Values=${ENVIRONMENT}" \
+      --resources-per-page 100 \
+      --pagination-token "${pagination_token}" \
+      --output json)"
+  else
+    response="$(aws resourcegroupstaggingapi get-resources \
+      --tag-filters "Key=managed-by,Values=${MANAGED_BY}" "Key=Project,Values=${PROJECT}" "Key=Environment,Values=${ENVIRONMENT}" \
+      --resources-per-page 100 \
+      --output json)"
+  fi
+
+  jq -r '.ResourceTagMappingList[].ResourceARN // empty' <<< "${response}" >> "${tagged_tmp}"
+  pagination_token="$(jq -r '.PaginationToken // empty' <<< "${response}")"
+
+  if [[ -z "${pagination_token}" ]]; then
+    break
+  fi
+done
+
+sort -u "${tagged_tmp}" > "${tagged_arns}"
+
+comm -23 "${tagged_arns}" "${state_arns}" > "${findings_file}" || true
+
+state_count="$(wc -l < "${state_arns}" | tr -d ' ')"
+tagged_count="$(wc -l < "${tagged_arns}" | tr -d ' ')"
+finding_count="$(wc -l < "${findings_file}" | tr -d ' ')"
+
+status="PASS"
+if (( finding_count > 0 )); then
+  status="FAIL"
+fi
+
+echo "orphan-scan mode=${MODE} env=${ENVIRONMENT} status=${status}"
+echo "info: terraform_state_arn_count=${state_count}"
+echo "info: aws_tagged_arn_count=${tagged_count}"
+if (( finding_count > 0 )); then
+  while IFS= read -r arn; do
+    echo "finding: tagged resource not found in Terraform state: ${arn}"
+  done < "${findings_file}"
+fi
+
+if [[ -n "${SUMMARY_PATH}" ]]; then
+  {
+    echo "### orphan-scan (${MODE})"
+    echo "- Status: \`${status}\`"
+    echo "- Environment: \`${ENVIRONMENT}\`"
+    echo "- Strict mode: \`${STRICT}\`"
+    echo "- Comparison: \`AWS(tagged managed-by=${MANAGED_BY}, Project=${PROJECT}, Environment=${ENVIRONMENT}) - Terraform state ARNs\`"
+    echo "- Terraform state ARNs: \`${state_count}\`"
+    echo "- AWS tagged ARNs: \`${tagged_count}\`"
+    echo "- Findings: \`${finding_count}\`"
+    if (( finding_count == 0 )); then
+      echo "- Result: no tagged-orphan resources detected."
+    else
+      echo "- Result:"
+      while IFS= read -r arn; do
+        echo "  - tagged resource not found in Terraform state: ${arn}"
+      done < "${findings_file}"
+    fi
+  } >> "${SUMMARY_PATH}"
+fi
+
+if [[ "${STRICT}" == "true" && "${status}" == "FAIL" ]]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- added `scripts/ci/find-orphans.sh` to detect orphans with a strict `AWS(tagged) - Terraform state` model
- integrated orphan scan in `ci-infra` pre-deploy and `ci-infra-destroy` post-destroy summary
- documented script usage and flow in `scripts/ci/find-orphans.md` with a Mermaid diagram
- linked script docs from `docs/runbooks/ci-cd/ci-infra.md` and `scripts/README.md`

## Validation
- `bash -n scripts/ci/find-orphans.sh`
- `scripts/ci/find-orphans.sh --help`

Closes #465
