### PR TITLE
fix(ci-infra): move alertmanager re-enable after ESO readiness

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -560,35 +560,6 @@ jobs:
           aws cloudwatch enable-alarm-actions --alarm-names "${alarms[@]}"
           echo "::notice title=cloudwatch-alerting::Re-enabled alarm actions for ${#alarms[@]} alarm(s)."
 
-      - name: Re-enable in-cluster Alertmanager (dev best effort)
-        if: ${{ inputs.environment == 'dev' && vars.ALERTS_ENABLED != 'false' }}
-        run: |
-          set -euo pipefail
-          K3S_SERVER_INSTANCE_ID="$(terraform -chdir="${{ needs.env-select.outputs.tf_dir }}" output -raw k3s_server_instance_id 2>/dev/null || true)"
-          if [[ -z "${K3S_SERVER_INSTANCE_ID}" ]]; then
-            echo "::notice title=alertmanager::k3s_server_instance_id missing; skipping Alertmanager re-enable."
-            exit 0
-          fi
-
-          params="$(jq -n \
-            --arg c0 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' \
-            --arg c1 'sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring scale statefulset/alertmanager-kube-prometheus-alertmanager --replicas=1 || true' \
-            '{commands:[$c0,$c1]}')"
-
-          unmute_cmd_id="$(aws ssm send-command \
-            --instance-ids "${K3S_SERVER_INSTANCE_ID}" \
-            --document-name "AWS-RunShellScript" \
-            --parameters "${params}" \
-            --timeout-seconds 300 \
-            --query "Command.CommandId" \
-            --output text)"
-
-          echo "::notice title=SSM::Unmute Alertmanager command_id=${unmute_cmd_id}"
-          if ! aws ssm wait command-executed --command-id "${unmute_cmd_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}"; then
-            aws ssm get-command-invocation --command-id "${unmute_cmd_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}" || true
-            echo "::warning title=alertmanager::Failed to scale Alertmanager up; continuing."
-          fi
-
       - name: tf-apply summary
         if: ${{ always() }}
         env:
@@ -609,6 +580,103 @@ jobs:
           else
             echo "::warning title=tf-apply::apply failed or was blocked."
           fi
+
+  alertmanager-reenable:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'dev' && vars.ALERTS_ENABLED != 'false' }}
+    runs-on: ubuntu-latest
+    needs:
+      - eso-secrets-ready
+      - tf-outputs
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.TF_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Re-enable in-cluster Alertmanager (best effort)
+        env:
+          K3S_SERVER_INSTANCE_ID: ${{ needs.tf-outputs.outputs.k3s_server_instance_id }}
+        run: |
+          set -euo pipefail
+
+          result="ok"
+          detail="alertmanager re-enabled"
+
+          wait_for_instance_ready() {
+            local instance_id=$1
+            local max_attempts=12
+            local attempt=1
+            local sleep_seconds=10
+
+            while [ "${attempt}" -le "${max_attempts}" ]; do
+              local state
+              local ping
+              state="$(aws ec2 describe-instance-status \
+                --instance-ids "${instance_id}" \
+                --include-all-instances \
+                --query "InstanceStatuses[0].InstanceState.Name" \
+                --output text 2>/dev/null || true)"
+
+              ping="$(aws ssm describe-instance-information \
+                --filters "Key=InstanceIds,Values=${instance_id}" \
+                --query "InstanceInformationList[0].PingStatus" \
+                --output text 2>/dev/null || true)"
+
+              if [ "${state}" = "running" ] && [ "${ping}" = "Online" ]; then
+                return 0
+              fi
+
+              sleep "${sleep_seconds}"
+              attempt=$((attempt + 1))
+              sleep_seconds=$((sleep_seconds + 5))
+            done
+
+            return 1
+          }
+
+          if [[ -z "${K3S_SERVER_INSTANCE_ID}" ]]; then
+            result="warn"
+            detail="k3s_server_instance_id missing; skipped"
+          elif ! wait_for_instance_ready "${K3S_SERVER_INSTANCE_ID}"; then
+            result="warn"
+            detail="k3s instance not SSM-online; skipped"
+          else
+            params="$(jq -n \
+              --arg c0 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' \
+              --arg c1 'sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring scale statefulset/alertmanager-kube-prometheus-alertmanager --replicas=1' \
+              '{commands:[$c0,$c1]}')"
+
+            unmute_cmd_id="$(aws ssm send-command \
+              --instance-ids "${K3S_SERVER_INSTANCE_ID}" \
+              --document-name "AWS-RunShellScript" \
+              --parameters "${params}" \
+              --timeout-seconds 300 \
+              --query "Command.CommandId" \
+              --output text 2>/dev/null || true)"
+
+            if [[ -z "${unmute_cmd_id}" || "${unmute_cmd_id}" == "None" ]]; then
+              result="warn"
+              detail="send-command failed"
+            elif ! aws ssm wait command-executed --command-id "${unmute_cmd_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}"; then
+              aws ssm get-command-invocation --command-id "${unmute_cmd_id}" --instance-id "${K3S_SERVER_INSTANCE_ID}" || true
+              result="warn"
+              detail="kubectl scale command failed"
+            fi
+          fi
+
+          if [[ "${result}" == "warn" ]]; then
+            echo "::warning title=alertmanager::${detail}"
+          else
+            echo "::notice title=alertmanager::${detail}"
+          fi
+
+          {
+            echo "### alertmanager-reenable"
+            echo "- Result: \`${result}\`"
+            echo "- Detail: \`${detail}\`"
+            echo "- Instance: \`${K3S_SERVER_INSTANCE_ID:-n/a}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   setup-eso-secrets:
     name: Setup ESO Secrets (Prometheus auth)


### PR DESCRIPTION
## Summary
- moved in-cluster Alertmanager re-enable out of `tf-apply`
- added dedicated `alertmanager-reenable` job after `eso-secrets-ready` + `tf-outputs`
- kept this step best-effort with explicit warning signals (no pipeline failure)
- updated CI runbook ordering and Mermaid workflow diagram

## Why
The previous placement in `tf-apply` could fail with `InvalidInstanceId` when k3s/SSM was not ready yet, even though the step was intended as best-effort.

## Validation
- reviewed workflow dependencies and ordering in `.github/workflows/ci-infra.yml`
- reviewed runbook consistency in `docs/runbooks/ci-cd/ci-infra.md`

Fixes #470
