### PR TITLE
fix(ci): resolve alertmanager statefulset naming drift

### DIFF
--- a/.github/workflows/ci-infra-destroy.yml
+++ b/.github/workflows/ci-infra-destroy.yml
@@ -111,8 +111,10 @@ jobs:
           params="$(jq -n \
             --arg c0 'i=0; while [ $i -lt 30 ]; do if [ -x /usr/local/bin/kubectl ]; then break; fi; echo \"Waiting for kubectl...\"; sleep 10; i=$((i+1)); done; if [ ! -x /usr/local/bin/kubectl ]; then echo \"kubectl not found after 300s\"; exit 1; fi' \
             --arg c1 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' \
-            --arg c2 'sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring scale statefulset/alertmanager-kube-prometheus-alertmanager --replicas=0 || true' \
-            '{commands:[$c0,$c1,$c2]}')"
+            --arg c2 'AM_STS=$(sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring get statefulset -l app.kubernetes.io/name=alertmanager -o jsonpath="{.items[0].metadata.name}" 2>/dev/null || true)' \
+            --arg c3 'if [ -z "$AM_STS" ]; then echo "Alertmanager statefulset not found in namespace monitoring"; exit 0; fi' \
+            --arg c4 'sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring scale "statefulset/$AM_STS" --replicas=0 || true' \
+            '{commands:[$c0,$c1,$c2,$c3,$c4]}')"
 
           mute_cmd_id="$(aws ssm send-command \
             --instance-ids "${K3S_SERVER_INSTANCE_ID}" \

--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -644,8 +644,10 @@ jobs:
           else
             params="$(jq -n \
               --arg c0 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' \
-              --arg c1 'sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring scale statefulset/alertmanager-kube-prometheus-alertmanager --replicas=1' \
-              '{commands:[$c0,$c1]}')"
+              --arg c1 'AM_STS=$(sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring get statefulset -l app.kubernetes.io/name=alertmanager -o jsonpath="{.items[0].metadata.name}" 2>/dev/null || true)' \
+              --arg c2 'if [ -z "$AM_STS" ]; then echo "Alertmanager statefulset not found in namespace monitoring"; exit 2; fi' \
+              --arg c3 'sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring scale "statefulset/$AM_STS" --replicas=1' \
+              '{commands:[$c0,$c1,$c2,$c3]}')"
 
             unmute_cmd_id="$(aws ssm send-command \
               --instance-ids "${K3S_SERVER_INSTANCE_ID}" \

--- a/docs/runbooks/ci-cd/ci-infra.md
+++ b/docs/runbooks/ci-cd/ci-infra.md
@@ -150,6 +150,7 @@ flowchart TB
   - If restore is requested, the job still protects data by skipping restore when Redis data is not fresh.
 - `alertmanager-reenable` runs after `eso-secrets-ready` (not in `tf-apply`) to avoid early SSM/instance readiness races.
   - It is best-effort and emits `warning` signals instead of failing the pipeline.
+  - It resolves the Alertmanager StatefulSet dynamically by label (`app.kubernetes.io/name=alertmanager`) instead of a hardcoded name.
 - `orphan-scan-pre-deploy` runs a strict `state vs tagged` scan before planning/apply and fails fast on tagged resources found in AWS but missing from Terraform state.
 - Both `orphan-scan-pre-deploy` and `ci-infra-destroy` post-destroy scan append findings to `GITHUB_STEP_SUMMARY`.
 - Script details (modes, usage, flow): `scripts/ci/find-orphans.md`.
@@ -198,7 +199,7 @@ Use the dedicated destroy workflow when you need to tear down an environment.
 - The workflow validates the selected root before destroying.
 - Before destroy, the workflow mutes alert noise:
   - disables CloudWatch alarm actions for CloudRadar status-check alarms
-  - scales Alertmanager statefulset to 0 on dev (best effort, via SSM)
+  - scales Alertmanager statefulset to 0 on dev (best effort, via SSM), resolved dynamically by label (`app.kubernetes.io/name=alertmanager`)
 
 ## Required repo variables
 


### PR DESCRIPTION
## Summary
- replaced hardcoded Alertmanager StatefulSet name with dynamic lookup by label (`app.kubernetes.io/name=alertmanager`) in `ci-infra` re-enable step
- applied the same dynamic lookup in `ci-infra-destroy` mute step
- updated CI runbook to document label-based resolution behavior

## Why
The previous hardcoded name did not match the actual Helm-generated StatefulSet name in dev, causing best-effort alertmanager re-enable to warn on every run.

Fixes #470