### PR TITLE
fix(ci): reduce alertmanager re-enable false negatives on fresh startup

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -644,8 +644,8 @@ jobs:
           else
             params="$(jq -n \
               --arg c0 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' \
-              --arg c1 'AM_STS=$(sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring get statefulset -l app.kubernetes.io/name=alertmanager -o jsonpath="{.items[0].metadata.name}" 2>/dev/null || true)' \
-              --arg c2 'if [ -z "$AM_STS" ]; then echo "Alertmanager statefulset not found in namespace monitoring"; exit 2; fi' \
+              --arg c1 'AM_STS=""; i=0; while [ $i -lt 18 ]; do AM_STS=$(sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring get statefulset -l app.kubernetes.io/name=alertmanager -o jsonpath="{.items[0].metadata.name}" 2>/dev/null || true); if [ -n "$AM_STS" ]; then break; fi; echo "Waiting for Alertmanager statefulset..."; sleep 10; i=$((i+1)); done' \
+              --arg c2 'if [ -z "$AM_STS" ]; then echo "Alertmanager statefulset not found in namespace monitoring after wait"; exit 2; fi' \
               --arg c3 'sudo --preserve-env=KUBECONFIG /usr/local/bin/kubectl -n monitoring scale "statefulset/$AM_STS" --replicas=1' \
               '{commands:[$c0,$c1,$c2,$c3]}')"
 


### PR DESCRIPTION
## Summary
- Added a short retry/wait loop before reading Alertmanager StatefulSet name in `alertmanager-reenable`.
- Kept the existing selector `app.kubernetes.io/name=alertmanager` (no selector semantics change).
- Kept best-effort workflow behavior unchanged: warning only, no hard block.

## Why
On fresh apply cycles, `alertmanager-reenable` could run before the StatefulSet became visible, causing a false warning even though Alertmanager was healthy moments later.

## Validation
- Targeted diff reviewed for `alertmanager-reenable` step in `.github/workflows/ci-infra.yml`.
- `git diff --check` passed.

Fixes #477
