### PR TITLE
fix(dashboard): harden Planespotters timeout and transient error recovery

### DIFF
--- a/k8s/apps/dashboard/deployment.yaml
+++ b/k8s/apps/dashboard/deployment.yaml
@@ -113,6 +113,10 @@ spec:
               value: "200"
             - name: API_LIMIT_MAX
               value: "1000"
+            - name: PLANESPOTTERS_TIMEOUT_MS
+              value: "3500"
+            - name: PLANESPOTTERS_ERROR_CACHE_TTL_SECONDS
+              value: "20"
             - name: API_CORS_ALLOW_ORIGINS
               value: "https://cloudradar.local"
             - name: API_AIRCRAFT_DB_ENABLED


### PR DESCRIPTION
## Summary
- Increased dashboard Planespotters upstream request timeout from default to `3500ms` to better absorb transient network latency.
- Reduced Planespotters `error` cache TTL to `20s` so temporary upstream failures recover faster in the UI.
- Kept all existing lookup logic unchanged (cache + upstream + fallback).

## Validation
- Manifest diff reviewed.
- Local `kubectl apply --dry-run=client -f k8s/apps/dashboard/deployment.yaml` could not run in this environment because kube-api endpoint `127.0.0.1:16443` is unreachable.

Fixes #502
