### PR TITLE
fix(ci): add workflow summaries and clean annotations

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -112,7 +112,7 @@ jobs:
           scanners: vuln
           scan-type: fs
           scan-ref: src
-          pkg-types: library
+          vuln-type: library
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: "1"
@@ -196,3 +196,42 @@ jobs:
           echo "Repository: ${{ env.REPO_LOWER }}"
           echo "Tags:"
           echo "${{ steps.meta.outputs.tags }}" | tr ',' '\n' | sed 's/^/  - /'
+
+  ci-summary-report:
+    name: CI summary report
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - java-tests
+      - frontend-tests
+      - dockerfile-lint
+      - dependency-security-scan
+      - build-and-push
+    steps:
+      - name: Publish run summary
+        run: |
+          {
+            echo "## CI Quality Summary"
+            echo ""
+            echo "- Workflow: \`${GITHUB_WORKFLOW}\`"
+            echo "- Event: \`${GITHUB_EVENT_NAME}\`"
+            echo "- Ref: \`${GITHUB_REF}\`"
+            echo ""
+            echo "| Gate | Result |"
+            echo "| --- | --- |"
+            echo "| Java tests | ${{ needs['java-tests'].result }} |"
+            echo "| Frontend tests | ${{ needs['frontend-tests'].result }} |"
+            echo "| Hadolint (Dockerfiles) | ${{ needs['dockerfile-lint'].result }} |"
+            echo "| Trivy fs dependency scan | ${{ needs['dependency-security-scan'].result }} |"
+            echo "| Build-and-push matrix | ${{ needs['build-and-push'].result }} |"
+            echo ""
+
+            if [ "${{ needs['java-tests'].result }}" != "success" ] || \
+               [ "${{ needs['frontend-tests'].result }}" != "success" ] || \
+               [ "${{ needs['dockerfile-lint'].result }}" != "success" ] || \
+               [ "${{ needs['dependency-security-scan'].result }}" != "success" ]; then
+              echo "❌ One or more quality gates failed. Check the job logs and annotations."
+            else
+              echo "✅ All quality gates passed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-k8s.yml
+++ b/.github/workflows/ci-k8s.yml
@@ -71,3 +71,37 @@ jobs:
             -schema-location default \
             -schema-location "${CRD_SCHEMA_URL}" \
             "${manifests[@]}"
+
+  ci-k8s-summary-report:
+    name: ci-k8s summary report
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - check-app-version-sync
+      - lint-ghcr-lowercase
+      - validate-k8s-manifests
+    steps:
+      - name: Publish run summary
+        run: |
+          {
+            echo "## ci-k8s Summary"
+            echo ""
+            echo "- Workflow: \`${GITHUB_WORKFLOW}\`"
+            echo "- Event: \`${GITHUB_EVENT_NAME}\`"
+            echo "- Ref: \`${GITHUB_REF}\`"
+            echo ""
+            echo "| Check | Result |"
+            echo "| --- | --- |"
+            echo "| App version/image tag sync | ${{ needs['check-app-version-sync'].result }} |"
+            echo "| GHCR lowercase references | ${{ needs['lint-ghcr-lowercase'].result }} |"
+            echo "| K8s manifest validation (kubeconform) | ${{ needs['validate-k8s-manifests'].result }} |"
+            echo ""
+
+            if [ "${{ needs['check-app-version-sync'].result }}" != "success" ] || \
+               [ "${{ needs['lint-ghcr-lowercase'].result }}" != "success" ] || \
+               [ "${{ needs['validate-k8s-manifests'].result }}" != "success" ]; then
+              echo "❌ One or more ci-k8s checks failed. Inspect job logs and annotations."
+            else
+              echo "✅ All ci-k8s checks passed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/src/admin-scale/Dockerfile
+++ b/src/admin-scale/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.11-slim
 
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
+# hadolint ignore=DL3013
 RUN pip install --no-cache-dir boto3
 
 WORKDIR /app

--- a/src/health/Dockerfile
+++ b/src/health/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.11-slim
 
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- added a final `CI summary report` job to `build-and-push.yml` with gate-level results in `GITHUB_STEP_SUMMARY`
- added a final `ci-k8s summary report` job to `ci-k8s.yml` with check-level results in `GITHUB_STEP_SUMMARY`
- fixed Trivy action input noise by replacing unsupported `pkg-types` with `vuln-type: library`
- removed remaining Hadolint annotation noise for Python Dockerfiles (`health`, `admin-scale`) using explicit rule ignores

## Validation
- `actionlint .github/workflows/build-and-push.yml .github/workflows/ci-k8s.yml`
- `docker run --rm -i ghcr.io/hadolint/hadolint < src/health/Dockerfile`
- `docker run --rm -i ghcr.io/hadolint/hadolint < src/admin-scale/Dockerfile`

Fixes #509
