### PR TITLE
fix(ingester): improve OpenSky credit-limit diagnostics

### DIFF
--- a/docs/runbooks/operations/ingester.md
+++ b/docs/runbooks/operations/ingester.md
@@ -133,6 +133,8 @@ OpenSky credit tracking:
 ### Throttling behavior
 
 Credits are tracked from `X-Rate-Limit-Remaining` on each OpenSky response.
+When available, `X-Rate-Limit-Limit` is used as the effective quota for consumed-percent
+calculation and refresh throttling. If missing, fallback is `OPENSKY_CREDITS_QUOTA`.
 When consumption crosses thresholds (percent consumed):
 
 - >= 50% -> log warn threshold reached
@@ -140,6 +142,11 @@ When consumption crosses thresholds (percent consumed):
 - >= 95% -> refresh interval switches to `INGESTER_REFRESH_CRITICAL_MS`
 
 When credits reset (remaining increases), per-period counters reset automatically.
+
+Operational logs emitted for rate-limit diagnostics:
+- `OpenSky rate-limit header detected: limit=... (configured quota=...)`
+- `OpenSky header limit (...) differs from configured OPENSKY_CREDITS_QUOTA (...)`
+- `OpenSky rate-limit reset header updated: reset_at_epoch_seconds=...`
 
 ### Token refresh resilience
 

--- a/src/ingester/src/test/java/com/cloudradar/ingester/FlightIngestJobTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/FlightIngestJobTest.java
@@ -1,0 +1,73 @@
+package com.cloudradar.ingester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.cloudradar.ingester.config.IngesterProperties;
+import com.cloudradar.ingester.opensky.FetchResult;
+import com.cloudradar.ingester.opensky.OpenSkyClient;
+import com.cloudradar.ingester.redis.RedisPublisher;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FlightIngestJobTest {
+
+  @Test
+  void ingestUsesOpenSkyLimitHeaderForThrottlingWhenAvailable() {
+    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
+    RedisPublisher redisPublisher = mock(RedisPublisher.class);
+    when(openSkyClient.fetchStates()).thenReturn(new FetchResult(List.of(), 399, 400, null));
+    when(redisPublisher.pushEvents(anyList())).thenReturn(0);
+
+    FlightIngestJob job = new FlightIngestJob(
+        openSkyClient,
+        redisPublisher,
+        new SimpleMeterRegistry(),
+        buildProperties());
+
+    job.ingest();
+
+    assertThat(readLongField(job, "currentDelayMs")).isEqualTo(10_000L);
+  }
+
+  @Test
+  void ingestFallsBackToConfiguredQuotaWhenLimitHeaderMissing() {
+    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
+    RedisPublisher redisPublisher = mock(RedisPublisher.class);
+    when(openSkyClient.fetchStates()).thenReturn(new FetchResult(List.of(), 399, null, null));
+    when(redisPublisher.pushEvents(anyList())).thenReturn(0);
+
+    FlightIngestJob job = new FlightIngestJob(
+        openSkyClient,
+        redisPublisher,
+        new SimpleMeterRegistry(),
+        buildProperties());
+
+    job.ingest();
+
+    assertThat(readLongField(job, "currentDelayMs")).isEqualTo(30_000L);
+  }
+
+  private IngesterProperties buildProperties() {
+    return new IngesterProperties(
+        10_000L,
+        new IngesterProperties.Redis("cloudradar:ingest:queue"),
+        new IngesterProperties.Bbox(46.0, 50.0, 2.0, 4.0),
+        new IngesterProperties.RateLimit(4000, 50, 80, 95, 30_000L, 300_000L),
+        new IngesterProperties.BboxBoost("cloudradar:opensky:bbox:boost:active", 1.0));
+  }
+
+  private long readLongField(Object target, String fieldName) {
+    try {
+      Field field = FlightIngestJob.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getLong(target);
+    } catch (ReflectiveOperationException ex) {
+      throw new IllegalStateException("Unable to read test field: " + fieldName, ex);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #517

## Summary
- switched OpenSky consumed-percent/throttling to use the effective limit (`X-Rate-Limit-Limit`) when present, with `OPENSKY_CREDITS_QUOTA` as fallback.
- added explicit diagnostics logs for rate-limit headers (`limit`, configured quota mismatch, reset epoch updates).
- improved warning message to include `remaining/quota` for immediate triage context.
- added unit tests covering both paths:
  - header limit present (`remaining=399`, `limit=400`) -> keep base refresh interval.
  - header limit missing (`remaining=399`) -> fallback to configured quota and warn throttling.
- updated ingester runbook + troubleshooting issue log with the new diagnostics behavior.

## Validation
- `mvn -B -f src/ingester/pom.xml test` ✅ (5 tests, 0 failures, 0 errors)

## Scope
- `src/ingester/src/main/java/com/cloudradar/ingester/FlightIngestJob.java`
- `src/ingester/src/test/java/com/cloudradar/ingester/FlightIngestJobTest.java`
- `docs/runbooks/operations/ingester.md`
- `docs/runbooks/troubleshooting/issue-log.md`
