### PR TITLE
docs(ci): sync CI runbook and test strategy follow-up

### DIFF
--- a/docs/code-reviews/test-strategy-review.md
+++ b/docs/code-reviews/test-strategy-review.md
@@ -8,7 +8,7 @@
 
 ## Status Update (2026-02-24)
 
-Progress implemented in issues #490, #491, and #506:
+Progress implemented in issues #490, #491, #506, and #509:
 - Added blocking CI test execution in `build-and-push.yml` (`mvn -B test`, `npm test -- --run`).
 - Added `contextLoads()` smoke tests for `ingester`, `processor`, and `dashboard`.
 - Added critical mapping/parsing unit tests:
@@ -16,6 +16,10 @@ Progress implemented in issues #490, #491, and #506:
   - `processor`: `PositionEventTest` (JSON contract parsing/serialization)
 - Added `spring-boot-starter-test` in `ingester` and `processor` test scopes.
 - Added quality/safety gates to app CI: Hadolint (all Dockerfiles), Trivy fs dependency scan, and kubeconform manifest validation (in `ci-k8s.yml`).
+- Updated Java service READMEs with local test command and coverage notes.
+- Added visible CI quality gates (`java-tests`, `frontend-tests`, `dockerfile-lint`, `dependency-security-scan`) before image build.
+- Added workflow-level summary reports in both `build-and-push` and `ci-k8s`.
+- Removed CI annotation noise from unsupported Trivy action input and known Hadolint warning-only findings.
 
 Progress in issue #492 (open, in progress on this branch):
 - Added Redis Testcontainers integration tests for `ingester`, `processor`, and `dashboard`.
@@ -40,7 +44,7 @@ Note: section 2 keeps a historical proposal-review snapshot for traceability; se
 
 ## 1. Current Baseline (2026-02-24)
 
-Current repository status after #490/#491/#506, with #492 currently in progress:
+Current repository status after #490/#491/#506/#509, with #492 currently in progress:
 
 | Service | Language | Source files | Tests | Type | Test framework |
 |---|---|---|---|---|---|
@@ -1014,6 +1018,8 @@ This is achievable in **~20h incremental work**, spread over 3-4 short iteration
 - [x] `mvn test` (or `mvn verify -DskipITs`) executed in `build-and-push.yml`
 - [x] Hadolint added to `build-and-push.yml`
 - [x] kubeconform added to `ci-k8s.yml`
+- [x] Workflow-level CI summary reports added (`build-and-push`, `ci-k8s`)
+- [x] Trivy fs action input normalized (`vuln-type`) to avoid unsupported-input warnings
 - [ ] `.github/dependabot.yml` configured (maven + npm + github-actions)
 
 **Phase 1 — Context smoke + static analysis:**

--- a/docs/runbooks/ci-cd/ci-app.md
+++ b/docs/runbooks/ci-cd/ci-app.md
@@ -27,6 +27,10 @@ flowchart TD
   B2 --> TAG{"Push target"}
   TAG -->|"main"| TMAIN["tags: main/latest/sha"]
   TAG -->|"tag v*"| TTAG["tags: semver/sha"]
+
+  B1 --> S["CI summary report"]
+  TTAG --> S
+  TMAIN --> S
 ```
 
 ## When it runs
@@ -45,12 +49,14 @@ The workflow now exposes test and quality checks as **dedicated jobs** (visible 
 | `java-tests` | `ingester`, `processor`, `dashboard` (matrix) | `mvn -B test` (unit + Redis Testcontainers integration contracts) |
 | `frontend-tests` | `frontend` | `npm ci && npm test -- --run` |
 | `dockerfile-lint` | all service Dockerfiles (matrix) | `hadolint` |
-| `dependency-security-scan` | dependencies under `src/` | `trivy fs` (`HIGH,CRITICAL`, `pkg-types=library`, `scanners=vuln`) |
+| `dependency-security-scan` | dependencies under `src/` | `trivy fs` (`HIGH,CRITICAL`, `vuln-type=library`, `scanners=vuln`) |
+| `ci-summary-report` | workflow-level | publish gate/build results to `GITHUB_STEP_SUMMARY` |
 
 Behavior:
 - Any failing gate blocks the `build-and-push` matrix (`needs` dependency).
 - Docker build/push is skipped until all gates are green.
 - On pull requests, image push remains disabled for all services (`push=false`).
+- A final summary job always runs and publishes gate/build status in `GITHUB_STEP_SUMMARY`.
 
 Redis contract reference:
 - See [`docs/events-schemas/redis-keys.md`](/home/xclem/projetsperso/CloudRadar/docs/events-schemas/redis-keys.md) for key/payload conventions validated by integration tests.
@@ -91,6 +97,11 @@ kubeconform -strict -summary \
 
 Expected success signal:
 - `Summary: ... Invalid: 0, Errors: 0`
+
+`ci-k8s` also publishes a final `ci-k8s-summary-report` job in `GITHUB_STEP_SUMMARY` to recap:
+- app version/tag sync check
+- GHCR lowercase check
+- kubeconform manifest validation
 
 ### Related quality gate (`sonarcloud`)
 
@@ -182,6 +193,7 @@ Execution order:
 
 1. Run visible quality/test jobs in parallel: `java-tests`, `frontend-tests`, `dockerfile-lint`, `dependency-security-scan`.
 2. If all are green, start `build-and-push` matrix for the 6 services.
+3. Always publish `ci-summary-report` with consolidated gate + build results.
 
 ### Services built
 


### PR DESCRIPTION
## Summary
- preserved the documentation follow-up originally carried by #511 in a clean branch rebased on `main`
- updated `docs/runbooks/ci-cd/ci-app.md` to keep CI summary jobs (`ci-summary-report`, `ci-k8s-summary-report`) and Trivy `vuln-type` wording aligned with current workflows
- updated `docs/code-reviews/test-strategy-review.md` status section to retain CI follow-up points (#509 context) without reintroducing stale branch-only content

## Why
PR #511 is now conflicting/stale. This PR keeps the useful docs commit on top of current `main` so the change is not lost.

## Validation
- manual conflict resolution against latest `main`
- checked final files for conflict markers and coherence with current workflow behavior

Refs #57
Supersedes #511
