### PR TITLE
fix(frontend): restore dashboard scroll and add testing docs

### DIFF
--- a/docs/code-reviews/leaflet-aircraft-movement-review.md
+++ b/docs/code-reviews/leaflet-aircraft-movement-review.md
@@ -1,0 +1,425 @@
+# Code Review: Leaflet Aircraft Movement — Static Markers Problem
+
+**Date**: 2026-02-26  
+**Scope**: `src/frontend/src/App.tsx` — map refresh, marker animation, and data lifecycle  
+**Severity**: High — core UX feature (aircraft movement) is visually broken  
+
+---
+
+## 1. Executive Summary
+
+Aircraft markers on the Leaflet map frequently appear static instead of smoothly moving between positions. The root cause is a combination of **animation cancellation by competing refresh triggers**, **extreme DOM churn from icon recreation on every frame**, and **lack of separation between data updates and visual animation**. The code has a well-designed interpolation system (`animateMarkers`, `lerpNumber`, `lerpHeading`) that is effectively short-circuited before it can complete.
+
+---
+
+## 2. Architecture Overview
+
+### Data Pipeline (Backend → Frontend)
+
+```
+OpenSky API  →(~10s)→  Ingester  →(RPUSH)→  Redis Queue
+                                                 ↓
+                                            Processor
+                                                 ↓ (HSET)
+                                     Redis Hash (cloudradar:aircraft:last)
+                                                 ↓
+                              Dashboard API (poll + SSE stream)
+                                                 ↓
+                                       Frontend (React/Leaflet)
+```
+
+### Frontend Refresh Triggers
+
+The frontend has **two concurrent refresh triggers** in the same `useEffect` (App.tsx L786-806):
+
+| Trigger | Mechanism | Frequency |
+|---------|-----------|-----------|
+| **SSE stream** | `subscribeFlightUpdates()` → fires on `batch-update` event | ~every 10s (aligned with ingester cycle) |
+| **Timer** | `setInterval(refreshDataRef.current, REFRESH_INTERVAL_MS)` | every 10s (fixed) |
+
+Both call `refreshDataRef.current()` → `refreshData()` → `performRefreshCycle()`.
+
+### Animation System
+
+The interpolation pipeline in `animateMarkers()` (App.tsx L443-472):
+
+1. Captures current `mapFlightsRef.current` as start positions
+2. Builds a `startByIcao` map for O(1) lookup
+3. Uses `requestAnimationFrame` loop to interpolate positions
+4. Calls `setMapFlights()` on each frame → triggers React re-render → Leaflet updates markers
+
+---
+
+## 3. Identified Problems
+
+### P1 — CRITICAL: Timer Cancels SSE-triggered Animation
+
+**Location**: `performRefreshCycle()` (App.tsx L550-565)
+
+```tsx
+if (!mapFlightsRef.current.length) {
+  cancelMarkerAnimation();
+  setMapFlights(normalizedFlights);
+} else if (batchChanged) {
+  // ✅ Animation starts here
+  animateMarkers(normalizedFlights, resolveAnimationDurationMs(batchEpoch, previousBatchEpoch));
+} else {
+  // ❌ Animation is KILLED here
+  cancelMarkerAnimation();
+  setMapFlights(normalizedFlights);
+}
+```
+
+**Scenario**:
+1. `t=0s` — SSE fires `batch-update`, `batchChanged=true` → animation starts with duration ~10s
+2. `t=2s` — Timer fires, fetches same batch from API → `batchChanged=false`
+3. → `cancelMarkerAnimation()` is called → **animation cancelled after only 2s** (20% progress)
+4. → `setMapFlights(normalizedFlights)` snaps all markers to final positions instantly
+
+**Result**: Aircraft appear to teleport or not move at all (if the delta is small at the current zoom level).
+
+**Why it's frequent**: The timer and SSE are unsynchronized. With both running at ~10s intervals, they frequently overlap. The SSE notification arrives when new data is ready, and the timer fires independently. Any time they overlap, the animation is interrupted.
+
+### P2 — CRITICAL: Icon DOM Replacement on Every Animation Frame
+
+**Location**: Render loop (App.tsx L948-970)
+
+```tsx
+{mapFlights.map((flight) => {
+  // ...
+  return (
+    <Marker
+      key={flight.icao24}
+      position={[flight.lat as number, flight.lon as number]}
+      icon={markerIcon(flight, selected, mapZoom, isStatic)}
+      // ...
+    />
+  );
+})}
+```
+
+**Problem**: `markerIcon()` creates a **new `L.divIcon()` instance** on every render. During animation, `setMapFlights()` fires via `requestAnimationFrame` (60fps target), triggering a React re-render for each frame. For each of the N markers, a new DivIcon is created with new HTML (because `heading` changes per frame via interpolation):
+
+```tsx
+// Inside markerIcon() - heading is baked into the HTML string
+html: `<div class="aircraft-rotator" style="transform: rotate(${heading}deg)">`
+```
+
+React-Leaflet detects icon prop change (new object reference) → calls Leaflet `marker.setIcon()` → Leaflet **removes and recreates the entire icon DOM element**.
+
+**Performance impact**: With 200 aircraft × 60fps = **12,000 DOM element replacements per second**. This causes:
+- Massive frame drops, making animation appear jerky or frozen
+- High GC pressure from thousands of short-lived DivIcon + DOM objects
+- Potential browser tab unresponsiveness
+
+### P3 — HIGH: Coalesce Drain Loop Cancels Animation
+
+**Location**: `drainQueuedRefreshes()` (App.tsx L614-620)
+
+```tsx
+const drainQueuedRefreshes = useCallback(async () => {
+  do {
+    refreshQueuedRef.current = false;
+    await performRefreshCycle();
+  } while (refreshQueuedRef.current && isMountedRef.current);
+}, [performRefreshCycle]);
+```
+
+When a refresh is coalesced (timer fires while SSE refresh is in-flight), the drain loop runs **an additional cycle** after the first one completes. This second cycle:
+1. Fetches the same batch (no new data yet)
+2. Finds `batchChanged=false`
+3. Cancels any animation that the first cycle started
+
+This makes animation cancellation even more likely than P1 alone.
+
+### P4 — MEDIUM: No Icon Memoization
+
+**Problem**: Even outside animation frames, every React re-render (state change from clock, detail panel, etc.) recreates all icons. The `markerIcon()` function:
+- Has no caching
+- Returns a new `L.divIcon()` object every time
+- Is called for every marker on every render
+
+Any state change (UTC clock updates every 1s, detail panel open/close, ingester status refresh, etc.) triggers a full icon rebuild for all markers.
+
+### P5 — MEDIUM: Zoom Interaction Drops Animation
+
+When the user zooms, `setMapZoom()` triggers a re-render. The `markerIcon` parameters change (zoom affects scale), so all icons are rebuilt. Any in-progress animation continues but with a potentially jarring icon swap mid-animation. Additionally, zooming generates multiple `zoomend` events that trigger re-renders while animation is running.
+
+### P6 — LOW: Detail Panel Open/Close Recreates Refresh Chain
+
+`selectedIcao24` is in the dependency array of `performRefreshCycle`. Every select/deselect recreates `performRefreshCycle` → `drainQueuedRefreshes` → `refreshData`. While `refreshDataRef` ensures the latest version is always used, the cascade recreation is unnecessary cognitive complexity.
+
+### P7 — LOW: First Paint After Page Load Has No Animation
+
+On page load, `previousSnapshotPositionsRef` is empty and `mapFlightsRef.current` is empty. The first batch hits the `!mapFlightsRef.current.length` branch and snaps. This is correct behavior, but subsequent batches may also snap if P1/P3 kill the animation.
+
+---
+
+## 4. Root Cause Hierarchy
+
+```
+Aircraft appear static
+├── Animation is cancelled prematurely (P1, P3)
+│   ├── Timer and SSE are unsynchronized
+│   ├── Non-batch refreshes cancel in-progress animation
+│   └── Drain loop runs extra cycle with same batch
+├── Animation frames are too expensive to render (P2, P4)
+│   ├── New DivIcon per marker per frame
+│   ├── Heading baked into icon HTML → DOM replacement
+│   └── No icon memoization at all
+└── Edge cases compound the problem (P5, P6)
+    ├── Zoom triggers icon rebuild during animation
+    └── Detail panel interactions cascade refresh chain
+```
+
+---
+
+## 5. Proposed Solution
+
+### Architecture Change: Separate Animation from Data Fetching
+
+The core principle: **data refresh and visual animation must be decoupled**. Animation should run independently between two known states, immune to subsequent data fetches that return the same batch.
+
+#### S1 — Guard Animation Against Non-Batch Refreshes
+
+**Fix P1 + P3**: When `batchChanged=false` and an animation is already running, **do not cancel it**.
+
+```tsx
+// BEFORE (current code)
+} else {
+  cancelMarkerAnimation();
+  setMapFlights(normalizedFlights);
+}
+
+// AFTER (proposed)
+} else if (animationFrameRef.current === null) {
+  // No animation running, safe to snap (e.g., first load, error recovery)
+  setMapFlights(normalizedFlights);
+}
+// else: animation in progress for same batch — let it finish
+```
+
+This is the single highest-impact fix. No animation will be cancelled by a redundant refresh.
+
+#### S2 — Move Heading Rotation Out of Icon HTML
+
+**Fix P2 core**: The heading rotation should NOT be part of the DivIcon HTML. Instead, rotate via direct DOM manipulation after render:
+
+```tsx
+// Option A: Use a ref-based approach to rotate the marker's DOM element
+// The icon HTML stays static (no rotation in template):
+html: `<div class="aircraft-marker ...">
+         <div class="aircraft-rotator">${glyph}</div>
+       </div>`
+
+// After marker is rendered, rotate via CSS on the DOM element:
+markerElement.style.transform = `rotate(${heading}deg)`;
+```
+
+**Implementation approach**: Create a custom React component wrapping `<Marker>` that:
+1. Creates the DivIcon only when shape/color/size/selected/zoom changes (NOT on heading change)
+2. After Leaflet renders the icon, grabs the `.aircraft-rotator` DOM element
+3. Updates `transform: rotate(...)` directly via `element.style.transform`
+4. Updates position via `marker.setLatLng()` directly (bypassing React re-render)
+
+```tsx
+// Proposed: AnimatedMarker component
+function AnimatedMarker({ flight, selected, zoom, isStatic, onSelect }: Props) {
+  const markerRef = useRef<L.Marker>(null);
+  
+  // Memoize icon — only recreate when visual identity changes
+  const icon = useMemo(
+    () => markerIconStatic(flight, selected, zoom, isStatic),
+    [flight.fleetType, flight.militaryHint, flight.aircraftSize, 
+     flight.airframeType, selected, zoom, isStatic]
+  );
+
+  // Update position and rotation via direct DOM manipulation
+  useEffect(() => {
+    const marker = markerRef.current;
+    if (!marker || flight.lat == null || flight.lon == null) return;
+    
+    marker.setLatLng([flight.lat, flight.lon]);
+    
+    const el = marker.getElement()?.querySelector('.aircraft-rotator') as HTMLElement;
+    if (el) {
+      el.style.transform = `rotate(${flight.heading ?? 0}deg)`;
+    }
+  }, [flight.lat, flight.lon, flight.heading]);
+
+  return (
+    <Marker ref={markerRef} position={[flight.lat!, flight.lon!]} icon={icon} ... />
+  );
+}
+```
+
+This reduces DOM operations from **N markers × 60fps** to **N markers × icon-change-frequency** (near zero during animation).
+
+#### S3 — Use requestAnimationFrame Without React State
+
+**Fix P2 amplifier**: The animation loop should NOT call `setMapFlights()` on every frame. Instead:
+
+1. Store target and start positions in refs
+2. On each `requestAnimationFrame`, calculate interpolated positions
+3. Update Leaflet markers **directly** via `marker.setLatLng()` and DOM rotation
+4. Only call `setMapFlights()` once at animation end (to sync React state)
+
+```tsx
+const animateMarkers = useCallback(
+  (targetFlights: FlightMapItem[], durationMs: number) => {
+    cancelMarkerAnimation();
+    
+    const startFlights = mapFlightsRef.current;
+    const startByIcao = new Map(startFlights.map(f => [f.icao24, f]));
+    const markersByIcao = markerRefsMap.current; // Map<string, L.Marker>
+    const animStart = performance.now();
+
+    const tick = (now: number) => {
+      const progress = Math.min(1, (now - animStart) / durationMs);
+      
+      for (const target of targetFlights) {
+        const start = startByIcao.get(target.icao24);
+        const marker = markersByIcao.get(target.icao24);
+        if (!marker || !start || !canInterpolateFlight(start, target)) continue;
+        
+        const interpolated = interpolateFlight(start, target, progress);
+        // Direct Leaflet API — NO React re-render
+        marker.setLatLng([interpolated.lat!, interpolated.lon!]);
+        const rotator = marker.getElement()?.querySelector('.aircraft-rotator');
+        if (rotator) {
+          (rotator as HTMLElement).style.transform = 
+            `rotate(${interpolated.heading ?? 0}deg)`;
+        }
+      }
+      
+      if (progress < 1) {
+        animationFrameRef.current = requestAnimationFrame(tick);
+      } else {
+        animationFrameRef.current = null;
+        // Sync React state only at the end
+        setMapFlights(targetFlights);
+      }
+    };
+    
+    animationFrameRef.current = requestAnimationFrame(tick);
+  },
+  [cancelMarkerAnimation]
+);
+```
+
+#### S4 — Memoize Static Icon Creation
+
+**Fix P4**: Cache DivIcon instances to avoid recreating identical icons.
+
+```tsx
+const iconCache = new Map<string, DivIcon>();
+
+function getCachedIcon(
+  flight: FlightMapItem, selected: boolean, zoom: number, isStatic: boolean
+): DivIcon {
+  // Key based on visual-identity fields only (NOT lat/lon/heading)
+  const key = `${flight.fleetType}-${flight.militaryHint}-${flight.aircraftSize}`
+    + `-${flight.airframeType}-${selected}-${zoom}-${isStatic}`;
+  
+  let icon = iconCache.get(key);
+  if (!icon) {
+    icon = markerIconStatic(flight, selected, zoom, isStatic);
+    iconCache.set(key, icon);
+  }
+  return icon;
+}
+```
+
+#### S5 — Deduplicate Refresh Triggers
+
+**Fix P1 root cause**: Instead of running two independent triggers, make the timer a **fallback** that only fires when SSE is silent:
+
+```tsx
+useEffect(() => {
+  void refreshDataRef.current();
+  
+  let refreshTimer: number | null = null;
+  
+  const scheduleNextPoll = () => {
+    if (refreshTimer !== null) clearTimeout(refreshTimer);
+    refreshTimer = window.setTimeout(() => {
+      void refreshDataRef.current();
+      scheduleNextPoll();
+    }, REFRESH_INTERVAL_MS);
+  };
+  
+  scheduleNextPoll();
+  
+  const unsubscribeStream = subscribeFlightUpdates(
+    (event) => {
+      if (
+        event.latestOpenSkyBatchEpoch === null
+        || event.latestOpenSkyBatchEpoch !== lastBatchEpochRef.current
+      ) {
+        void refreshDataRef.current();
+        // Reset timer — SSE already triggered the refresh
+        scheduleNextPoll();
+      }
+    },
+    () => {
+      setApiStatus(prev => prev === 'online' ? 'degraded' : prev);
+    }
+  );
+
+  return () => {
+    unsubscribeStream();
+    if (refreshTimer !== null) clearTimeout(refreshTimer);
+  };
+}, []);
+```
+
+This ensures only **one** refresh per batch, eliminating the race condition entirely.
+
+---
+
+## 6. Edge Cases Addressed
+
+| Scenario | Current Behavior | Proposed Behavior |
+|----------|-----------------|-------------------|
+| **Page reload** | First paint snaps (correct), subsequent animation often killed | First paint snaps, subsequent animations complete fully |
+| **Zoom** | Icons rebuilt during animation, potential jank | Icons memoized, rotation via DOM, zoom doesn't break animation |
+| **Click on aircraft** | `selectedIcao24` change cascades refresh chain rebuild | Decouple detail loading from refresh cycle, use refs for selection |
+| **Close detail modal** | Same cascade as click | Same fix as click |
+| **SSE + Timer race** | Animation cancelled ~50% of the time | Single deduplicated trigger, animation never cancelled by stale poll |
+| **SSE disconnection** | Timer keeps running (correct), but animation still fragile | Timer serves as reliable fallback, animation protected |
+| **Rapid batch updates** | Drain loop may cancel animation | Guard ensures running animation isn't cancelled for same batch |
+
+---
+
+## 7. Implementation Priority
+
+| Priority | Fix | Impact | Effort |
+|----------|-----|--------|--------|
+| **1** | S1 — Guard animation against non-batch cancellation | Fixes visible static markers immediately | ~15 min |
+| **2** | S5 — Deduplicate refresh triggers | Eliminates root cause of timer/SSE race | ~30 min |
+| **3** | S2 + S3 — Direct DOM manipulation for animation | Fixes performance, enables smooth 60fps | ~2-3h |
+| **4** | S4 — Icon memoization | Reduces render cost for all re-renders | ~30 min |
+
+**Recommendation**: Start with S1 + S5 (quick wins, high impact). Then S2 + S3 as a follow-up for production-quality animation. S4 is a good general performance improvement.
+
+---
+
+## 8. Affected Files
+
+| File | Changes |
+|------|---------|
+| `src/frontend/src/App.tsx` | Animation logic, refresh cycle, marker rendering |
+| `src/frontend/src/components/AnimatedMarker.tsx` | New component (proposed for S2+S3) |
+| `src/frontend/src/aircraftVisuals.ts` | Separate icon creation from heading rotation |
+
+---
+
+## 9. Test Scenarios for Validation
+
+1. **Baseline**: Open map, observe aircraft movement over 60s — markers should visibly move between positions
+2. **Zoom**: Zoom in/out during active animation — markers should continue moving smoothly
+3. **Select flight**: Click a marker during animation — animation should continue for other markers
+4. **Close detail**: Close detail panel — markers should continue moving
+5. **Page reload**: Reload, wait 20s — second batch should show smooth movement
+6. **Network jitter**: Throttle network in DevTools — timer fallback should maintain updates
+7. **Performance**: Open DevTools Performance tab — no excessive DOM operations during animation

--- a/docs/testing-overview-en.md
+++ b/docs/testing-overview-en.md
@@ -1,0 +1,325 @@
+# CloudRadar — Testing & Quality Assurance Overview
+
+> Consolidated view of the testing strategy, quality pipelines and DevSecOps practices of the CloudRadar project.
+> Goal: demonstrate a structured, multi-layered approach aligned with Cloud Architecture and DevSecOps best practices.
+
+---
+
+## Table of Contents
+
+- [CloudRadar — Testing \& Quality Assurance Overview](#cloudradar--testing--quality-assurance-overview)
+  - [1. Big Picture](#1-big-picture)
+    - [Key Metrics](#key-metrics)
+  - [2. Shift-Left Testing](#2-shift-left-testing)
+  - [3. The 9 Test Categories](#3-the-9-test-categories)
+    - [Category × Coverage Matrix](#category--coverage-matrix)
+  - [4. CI/CD Pipelines](#4-cicd-pipelines)
+  - [5. Coverage by Service](#5-coverage-by-service)
+  - [6. Workflow × Category: Who Checks What?](#6-workflow--category-who-checks-what)
+  - [7. Possible Improvements](#7-possible-improvements)
+
+---
+
+## 1. Big Picture
+
+CloudRadar is made of **6 microservices** written in 4 languages (Java, TypeScript, Python, Shell), communicating through **Redis** as a data bus. This technical diversity requires a multi-layered testing strategy: no single framework can cover everything. The pyramid below shows how tests are stacked, from fastest (unit) to slowest (performance).
+
+```mermaid
+block-beta
+  columns 2
+
+  P["🏔️ Performance<br>load testing"]:1 Pd["k6 nightly · 10 VUs · p95 < 1500ms"]:1
+  E["🌐 E2E Smoke<br>post-deploy health"]:1 Ed["/healthz · /api/flights · /grafana"]:1
+  D["🔗 Integration<br>services + real Redis"]:1 Dd["Redis Testcontainers · 3 services"]:1
+  C["📝 Contract<br>inter-service data format"]:1 Cd["JSON parsing · Redis keys"]:1
+  S["🚀 Context Smoke<br>each service starts"]:1 Sd["@SpringBootTest · contextLoads"]:1
+  U["🧪 Unit / Slice<br>isolated business logic"]:1 Ud["JUnit · Mockito · @WebMvcTest · Vitest"]:1
+  SA["🔍 Code Quality — Hadolint, SonarCloud, terraform fmt"]:2
+  SC["🛡️ Dependency Security — Trivy CVE, GitGuardian secrets"]:2
+
+  style P fill:#e1bee7,color:#000
+  style Pd fill:#f3e5f5,color:#000
+  style E fill:#ce93d8,color:#000
+  style Ed fill:#e1bee7,color:#000
+  style D fill:#ba68c8,color:#fff
+  style Dd fill:#ce93d8,color:#000
+  style C fill:#ab47bc,color:#fff
+  style Cd fill:#ba68c8,color:#fff
+  style S fill:#9c27b0,color:#fff
+  style Sd fill:#ab47bc,color:#fff
+  style U fill:#7b1fa2,color:#fff
+  style Ud fill:#9c27b0,color:#fff
+  style SA fill:#37474f,color:#fff
+  style SC fill:#263238,color:#fff
+```
+
+> Read bottom to top. Lower layers are fast (< 1 min) and numerous. Higher layers are slower and more targeted. The two dark bars are **cross-cutting**: they run in parallel with everything else.
+
+| Layer | What it protects | Concrete example |
+|---|---|---|
+| Unit / Slice | Isolated business logic | "OpenSky flight parsing returns the correct fields" |
+| Context Smoke | Each service startup | "Spring Boot starts without configuration errors" |
+| Contract | Inter-service data format | "JSON written by the ingester is readable by the processor" |
+| Integration | Behavior with a real Redis instance | "the ingester writes to Redis, the dashboard reads it correctly" |
+| E2E Smoke | The deployed application in real conditions | "after deploy, /api/flights returns valid JSON" |
+| Performance | Load handling | "10 concurrent users, response time < 1.5s" |
+| Code Quality | Standards and best practices compliance | "Dockerfiles follow best-practices, IaC is secured" |
+| Dependency Security | No known vulnerabilities in libraries | "no critical CVE in Maven/npm dependencies" |
+
+### Key Metrics
+
+| Metric | Value |
+|---|---|
+| Automated tests | **52 tests** (15 files, 4 languages) |
+| Test categories covered | **9** (unit, slice, integration, contract, smoke, security, quality, infra, perf) |
+| GitHub Actions workflows | **9** (5 related to tests/quality) |
+| Services with tests | **4/6** (ingester, processor, dashboard, frontend) |
+| Pyramid ratio (unit / integ / E2E) | ~70% / 20% / 10% |
+
+---
+
+## 2. Shift-Left Testing
+
+### The Concept
+
+In a traditional approach, security, quality and infrastructure tests are executed **late** in the cycle: in staging or even in production. Problems are discovered after deployment, when fixing them is expensive in time and effort.
+
+**Shift-Left** reverses this logic: checks are **shifted to the left** of the timeline (= towards the beginning), catching errors as early as possible — ideally as soon as the developer pushes code.
+
+```mermaid
+flowchart LR
+  subgraph TRAD["❌ Traditional approach"]
+    direction LR
+    T1["Dev"] --> T2["Build"] --> T3["Deploy staging"] --> T4["Security + quality tests"] --> T5["😱 Bug found late"]
+  end
+
+  subgraph SHIFT["✅ Shift-Left (CloudRadar)"]
+    direction LR
+    S1["Dev"] --> S2["PR: tests + security + quality"] --> S3["Build"] --> S4["Deploy"] --> S5["✅ Confidence"]
+  end
+
+  style TRAD fill:#ffebee,stroke:#e53935,color:#000
+  style SHIFT fill:#e8f5e9,stroke:#43a047,color:#000
+  style T5 fill:#e53935,color:#fff
+  style S2 fill:#43a047,color:#fff
+  style S5 fill:#43a047,color:#fff
+```
+
+### What CloudRadar Implements
+
+In this project, **8 out of 10 automated checks run before merge**. The developer gets feedback in minutes, not after a failed deployment.
+
+Concretely, when a developer opens a Pull Request on CloudRadar, **4 GitHub Actions workflows launch in parallel**: application tests (Java + React), Kubernetes validation, Terraform verification, and SonarCloud analysis. The whole process takes about 5 minutes. If any single one fails, the merge is blocked — impossible to break `main` by accident.
+
+```mermaid
+flowchart LR
+  DEV["🧑‍💻 Dev local<br>tests · lint · format"] -->|"< 5 min"| PR["🔀 Pull Request<br>8 blocking gates"]
+  PR -->|"all green"| MERGE["✅ Build & Push<br>6 Docker images"]
+  MERGE --> DEPLOY["🚀 Deploy<br>infra + app + smoke"]
+  DEPLOY -.-> NIGHT["🌙 Nightly<br>load testing"]
+
+  style DEV fill:#c8e6c9,color:#000
+  style PR fill:#bbdefb,color:#000
+  style MERGE fill:#fff3e0,color:#000
+  style DEPLOY fill:#fce4ec,color:#000
+  style NIGHT fill:#f3e5f5,color:#000
+```
+
+> **80% of checks** happen in the first two stages (Dev + PR). The remaining 20% (image builds, deploy, performance) only run after merge or nightly.
+
+**Why is this Shift-Left?** Traditionally, security, quality and infrastructure tests happen late (in staging or prod). Here, they all run **on every Pull Request**, before merge:
+
+| PR Gate (blocking) | What it checks | Time |
+|---|---|---|
+| Java tests (3 services) | Business code works correctly | 1–4 min |
+| Frontend tests (Vitest) | UI renders correctly | 20–60s |
+| Hadolint (6 Dockerfiles) | Docker images follow best practices | 20–60s |
+| Trivy (dependencies) | No known security vulnerabilities (CVE) | 30–120s |
+| kubeconform (k8s manifests) | Kubernetes files are valid | 3–5s |
+| tfsec (Terraform) | Infrastructure as code is secure | 10–30s |
+| Terraform plan | Infrastructure can be applied without errors | 1–3 min |
+| SonarCloud | Overall code quality is maintained | 2–4 min |
+
+---
+
+## 3. The 9 Test Categories
+
+To cover application code, cloud infrastructure (Terraform, Kubernetes) and dependency security, CloudRadar uses **9 test categories** organized in 3 families. This ensures that every type of change — whether it touches Java code, a k8s manifest or a Terraform module — is validated by appropriate checks.
+
+```mermaid
+block-beta
+  columns 3
+
+  APP["🟢 Application code"]:3
+  U["🧪 Unit / Slice<br>isolated business logic"]:1
+  I["🔗 Integration<br>services + real Redis"]:1
+  C["📝 Contract<br>JSON format between services"]:1
+
+  INFRA["🔵 Infrastructure & deployment"]:3
+  IV["⚙️ Infra Validation<br>Terraform + k8s manifests"]:1
+  E["🌐 E2E / Smoke<br>post-deployment health"]:1
+  P["🏔️ Performance<br>load testing (k6)"]:1
+
+  CROSS["🟠 Cross-cutting (every PR)"]:3
+  S["🔒 Security<br>CVE · secrets · IaC"]:1
+  Q["📏 Quality<br>lint · coverage · smells"]:1
+  UI["🖥️ UI<br>React component rendering"]:1
+
+  style APP fill:#43a047,color:#fff
+  style U fill:#e8f5e9,color:#000
+  style I fill:#c8e6c9,color:#000
+  style C fill:#a5d6a7,color:#000
+
+  style INFRA fill:#1976d2,color:#fff
+  style IV fill:#e3f2fd,color:#000
+  style E fill:#bbdefb,color:#000
+  style P fill:#90caf9,color:#000
+
+  style CROSS fill:#ef6c00,color:#fff
+  style S fill:#fff3e0,color:#000
+  style Q fill:#ffe0b2,color:#000
+  style UI fill:#ffcc80,color:#000
+```
+
+> **3 families**: **green** tests validate application code (Java/React), **blue** tests validate infrastructure and deployment, **orange** tests are cross-cutting and run on every PR regardless of the nature of the change.
+
+### Category × Coverage Matrix
+
+| Category | What | When | Where | Status |
+|---|---|---|---|---|
+| 🧪 **Unit / Slice** | Business logic, controllers, parsing | PR | `build-and-push` | ✅ Implemented |
+| 🔗 **Integration** | Spring Boot context + Redis data-path | PR | `build-and-push` | ✅ Implemented |
+| 📝 **Contract** | JSON serialization, Redis key format | PR | `build-and-push` | ✅ Implemented |
+| 🌐 **E2E / Smoke** | Health + data pipeline post-deploy | Dispatch | `ci-infra` | ✅ Implemented |
+| 🔒 **Security** | CVE dependencies, secrets, IaC | PR | `build-and-push` + `ci-infra` | ✅ Implemented |
+| 📏 **Code Quality** | Smells, duplication, coverage trends | PR | `sonarcloud` + `build-and-push` | ✅ Implemented |
+| ⚙️ **Infra Validation** | Terraform + k8s manifest schemas | PR | `ci-infra` + `ci-k8s` | ✅ Implemented |
+| 🏔️ **Performance** | p95 latency, error rate | Nightly / dispatch | `k6-nightly-baseline` | ✅ Implemented |
+| 🖥️ **UI** | React component render smoke | PR | `build-and-push` | ✅ Implemented |
+
+---
+
+## 4. CI/CD Pipelines
+
+CloudRadar's 9 GitHub Actions workflows are designed to **run in parallel** and provide fast feedback. Each workflow has a clear scope and precise trigger. AWS authentication uses **OIDC** (no stored keys), and Docker builds use a **matrix** to build all 6 images in parallel.
+
+Here's **who checks what, and when**:
+
+```mermaid
+block-beta
+  columns 2
+
+  PR["🔀 On every Pull Request"]:2
+  BAP["🏗️ build-and-push<br>Compiles, tests and scans all 6 services"]:1
+  SQG["📊 sonarcloud<br>Technical debt, coverage, duplication"]:1
+  CIK["☸️ ci-k8s<br>Kubernetes manifests valid?"]:1
+  CII["🔒 ci-infra<br>Terraform safe and deployable?"]:1
+
+  POST["After merge"]:2
+  CIID["🌍 ci-infra dispatch<br>Full deploy + smoke tests"]:1
+  K6["⚡ k6 nightly<br>10 users — does the app handle the load?"]:1
+
+  style PR fill:#1976d2,color:#fff
+  style BAP fill:#bbdefb,color:#000
+  style SQG fill:#bbdefb,color:#000
+  style CIK fill:#bbdefb,color:#000
+  style CII fill:#bbdefb,color:#000
+  style POST fill:#757575,color:#fff
+  style CIID fill:#ffe0b2,color:#000
+  style K6 fill:#e1bee7,color:#000
+```
+
+| Workflow | Role in one sentence | Checks | Time |
+|---|---|---|---|
+| **build-and-push** | Compile and test all 6 services | Java tests ×3, React, lint Dockerfiles ×6, CVE scan | 2–5 min |
+| **sonarcloud** | Monitor technical debt | Quality gate, coverage, code smells, duplication | 2–4 min |
+| **ci-k8s** | Validate Kubernetes files | kubeconform schemas, version sync, image names | < 1 min |
+| **ci-infra** (PR) | Verify infra before deployment | terraform fmt/validate/plan, tfsec security | 1–3 min |
+| **ci-infra** (dispatch) | Deploy and verify in real conditions | Terraform apply → ArgoCD sync → smoke tests | 5–15 min |
+| **k6-nightly** | Measure performance every night | p95 < 1.5s, error rate < 5%, checks > 95% | ~1 min |
+
+> Workflow details: see `docs/runbooks/ci-cd/`.
+
+---
+
+## 5. Coverage by Service
+
+CloudRadar has 6 microservices. The 3 Java services (ingester, processor, dashboard) hold the majority of tests because they carry the business logic — OpenSky ingestion, Redis aggregation, REST API. The React frontend has render tests (Vitest). The 2 Python services (health, admin-scale) are lightweight utilities with no tests for now.
+
+```mermaid
+block-beta
+  columns 6
+  header["Test coverage by service"]:6
+  space:6
+  A["dashboard"] B["ingester"] C["processor"] D["frontend"] E["health"] F["admin-scale"]
+  A1["37 tests"] B1["3 tests"] C1["7 tests"] D1["5 tests"] E1["0 test"] F1["0 test"]
+
+  style A1 fill:#4caf50,color:#fff
+  style B1 fill:#4caf50,color:#fff
+  style C1 fill:#4caf50,color:#fff
+  style D1 fill:#4caf50,color:#fff
+  style E1 fill:#f44336,color:#fff
+  style F1 fill:#f44336,color:#fff
+```
+
+4 out of 6 services have automated tests (52 tests, 15 files). The 3 Java services cover all 3 levels of the pyramid: unit (Mockito, @WebMvcTest), integration (Redis Testcontainers), and context smoke (@SpringBootTest). The frontend covers component rendering (Vitest + Testing Library).
+
+Inter-service contracts (Redis keys, JSON format) are validated by dedicated Testcontainers tests in each service — documented in `docs/events-schemas/redis-keys.md`.
+
+SonarCloud ingests Java coverage (JaCoCo) and frontend coverage (lcov) for unified trend tracking.
+
+---
+
+## 6. Workflow × Category: Who Checks What?
+
+This matrix cross-references the 6 workflows with the 9 test categories. It lets you verify at a glance that **no category is orphaned** — every type of check is carried by at least one workflow.
+
+| Category | build-and-push | sonarcloud | ci-k8s | ci-infra PR | ci-infra deploy | k6 nightly |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| 🧪 Unit | 🟢 | | | | | |
+| 🔗 Integ | 🟢 | | | | | |
+| 📝 Contract | 🟢 | | | | | |
+| 🖥️ UI | 🟢 | | | | | |
+| 🔒 Security | 🟢 | | | 🟢 | | |
+| 📏 Quality | | 🟢 | | | | |
+| ⚙️ Infra | | | 🟢 | 🟢 | | |
+| 🌐 E2E | | | | | 🟢 | |
+| 🏔️ Perf | | | | | | 🟢 |
+
+> `build-and-push` carries **5/9 categories**. All categories are covered by at least one workflow.
+
+---
+
+## 7. Possible Improvements
+
+```mermaid
+quadrantChart
+  title Effort / Impact ratio of improvements
+  x-axis "Low effort" --> "High effort"
+  y-axis "Low impact" --> "High impact"
+
+  "Dependabot": [0.08, 0.80]
+  "SpotBugs": [0.15, 0.70]
+  "ESLint + Prettier": [0.15, 0.60]
+  "Trivy image": [0.08, 0.65]
+  "Python tests": [0.35, 0.55]
+  "HTTP contracts": [0.50, 0.55]
+  "Coverage gate": [0.05, 0.50]
+  "Rollback validation": [0.25, 0.45]
+  "Frontend E2E": [0.65, 0.40]
+  "Mutation testing": [0.40, 0.30]
+  "Chaos testing": [0.85, 0.25]
+```
+
+| Priority | Improvement | Why | Effort |
+|---|---|---|---|
+| 🔴 High | **Dependabot** | Automatic dependency update PRs (Maven, npm, Actions) | ~15 min |
+| 🔴 High | **SpotBugs** | Static detection of NPE, concurrency, Java anti-patterns | ~30 min |
+| 🔴 High | **ESLint + Prettier** | No TypeScript/React linting in CI | ~30 min |
+| 🔴 High | **Trivy image** | Scan OS/runtime layers of Docker images (only Trivy fs exists) | ~15 min |
+| 🟡 Medium | **Python tests** | 2/6 services without tests (health, admin-scale) | ~2h |
+| 🟡 Medium | **HTTP contract tests** | OpenSky parsing and `/api/flights` payload tested without HTTP mock server | ~3h |
+| 🟡 Medium | **Coverage enforcement** | Enable SonarCloud blocking threshold on new code | ~10 min |
+| 🔵 Low | **Rollback validation** | No verification of ArgoCD rollback capability | ~1h |
+| 🔵 Low | **Frontend E2E** | No real browser testing (Playwright/Cypress) | ~4h |
+| 🔵 Low | **Mutation testing** | Verify that tests actually detect regressions (PIT) | ~2h |

--- a/docs/testing-overview.md
+++ b/docs/testing-overview.md
@@ -1,0 +1,325 @@
+# CloudRadar — Testing & Quality Assurance Overview
+
+> Vue consolidée de la stratégie de tests, des pipelines de qualité et des pratiques DevSecOps du projet CloudRadar.
+> Objectif : montrer une approche structurée, multi-couche, conforme aux bonnes pratiques Cloud Architecture et DevSecOps.
+
+---
+
+## Table des matières
+
+- [CloudRadar — Testing \& Quality Assurance Overview](#cloudradar--testing--quality-assurance-overview)
+  - [Table des matières](#table-des-matières)
+  - [1. Big Picture](#1-big-picture)
+    - [Chiffres clés](#chiffres-clés)
+  - [2. Shift-Left Testing](#2-shift-left-testing)
+  - [3. Les 9 catégories de tests](#3-les-9-catégories-de-tests)
+    - [Matrice catégorie × couverture](#matrice-catégorie--couverture)
+  - [4. Pipelines CI/CD](#4-pipelines-cicd)
+  - [5. Couverture par service](#5-couverture-par-service)
+  - [6. Améliorations possibles](#6-améliorations-possibles)
+
+---
+
+## 1. Big Picture
+
+CloudRadar est composé de **6 microservices** écrits en 4 langages (Java, TypeScript, Python, Shell), communiquant via **Redis** comme bus de données. Cette diversité technique impose une stratégie de tests multi-couche : on ne peut pas tout couvrir avec un seul framework. La pyramide ci-dessous montre comment les tests sont empilés, du plus rapide (unitaire) au plus lent (performance).
+
+```mermaid
+block-beta
+  columns 2
+
+  P["🏔️ Performance<br>tenue en charge"]:1 Pd["k6 nightly · 10 VUs · p95 < 1500ms"]:1
+  E["🌐 E2E Smoke<br>santé après déploiement"]:1 Ed["/healthz · /api/flights · /grafana"]:1
+  D["🔗 Integration<br>services + vraie base Redis"]:1 Dd["Redis Testcontainers · 3 services"]:1
+  C["📝 Contract<br>format d'échange entre services"]:1 Cd["JSON parsing · Redis keys"]:1
+  S["🚀 Context Smoke<br>chaque service démarre"]:1 Sd["@SpringBootTest · contextLoads"]:1
+  U["🧪 Unit / Slice<br>logique métier isolée"]:1 Ud["JUnit · Mockito · @WebMvcTest · Vitest"]:1
+  SA["🔍 Qualité du code — Hadolint, SonarCloud, terraform fmt"]:2
+  SC["🛡️ Sécurité des dépendances — Trivy CVE, GitGuardian secrets"]:2
+
+  style P fill:#e1bee7,color:#000
+  style Pd fill:#f3e5f5,color:#000
+  style E fill:#ce93d8,color:#000
+  style Ed fill:#e1bee7,color:#000
+  style D fill:#ba68c8,color:#fff
+  style Dd fill:#ce93d8,color:#000
+  style C fill:#ab47bc,color:#fff
+  style Cd fill:#ba68c8,color:#fff
+  style S fill:#9c27b0,color:#fff
+  style Sd fill:#ab47bc,color:#fff
+  style U fill:#7b1fa2,color:#fff
+  style Ud fill:#9c27b0,color:#fff
+  style SA fill:#37474f,color:#fff
+  style SC fill:#263238,color:#fff
+```
+
+> Lecture de bas en haut. Les couches basses sont rapides (< 1 min) et nombreuses. Plus on monte, plus les tests sont lents et ciblés. Les deux barres sombres sont **transversales** : elles tournent en parallèle de tout le reste.
+
+| Couche | Ce qu'elle protège | Exemple concret |
+|---|---|---|
+| Unit / Slice | La logique métier isolée | "le parsing d'un vol OpenSky retourne les bons champs" |
+| Context Smoke | Le démarrage de chaque service | "Spring Boot démarre sans erreur de configuration" |
+| Contract | Le format d'échange entre services | "le JSON écrit par l'ingester est lisible par le processor" |
+| Integration | Le fonctionnement avec une vraie base Redis | "l'ingester écrit dans Redis, le dashboard relit correctement" |
+| E2E Smoke | L'application déployée en conditions réelles | "après deploy, /api/flights retourne du JSON valide" |
+| Performance | La tenue en charge | "10 utilisateurs simultanés, temps de réponse < 1.5s" |
+| Qualité du code | Le respect des standards et bonnes pratiques | "les Dockerfiles suivent les best-practices, l'IaC est sécurisée" |
+| Sécurité dépendances | L'absence de failles connues dans les librairies | "aucune CVE critique dans les dépendances Maven/npm" |
+
+### Chiffres clés
+
+| Indicateur | Valeur |
+|---|---|
+| Tests automatisés | **52 tests** (15 fichiers, 4 langages) |
+| Catégories de tests couvertes | **9** (unit, slice, integration, contract, smoke, security, quality, infra, perf) |
+| Workflows GitHub Actions | **9** (dont 5 liés aux tests/qualité) |
+| Services avec tests | **4/6** (ingester, processor, dashboard, frontend) |
+| Ratio pyramide (unit / integ / E2E) | ~70% / 20% / 10% |
+
+---
+
+## 2. Shift-Left Testing
+
+### Le concept
+
+Dans une approche classique, les tests de sécurité, de qualité et d'infrastructure sont exécutés **tard** dans le cycle : en staging, voire en production. On découvre les problèmes après avoir déployé, quand corriger coûte cher en temps et en énergie.
+
+Le **Shift-Left** inverse cette logique : on **décale les vérifications vers la gauche** de la timeline (= vers le début), pour attraper les erreurs le plus tôt possible — idéalement dès que le développeur pousse son code.
+
+```mermaid
+flowchart LR
+  subgraph TRAD["❌ Approche traditionnelle"]
+    direction LR
+    T1["Dev"] --> T2["Build"] --> T3["Deploy staging"] --> T4["Tests sécu + qualité"] --> T5["😱 Bug trouvé tard"]
+  end
+
+  subgraph SHIFT["✅ Shift-Left (CloudRadar)"]
+    direction LR
+    S1["Dev"] --> S2["PR : tests + sécu + qualité"] --> S3["Build"] --> S4["Deploy"] --> S5["✅ Confiance"]
+  end
+
+  style TRAD fill:#ffebee,stroke:#e53935,color:#000
+  style SHIFT fill:#e8f5e9,stroke:#43a047,color:#000
+  style T5 fill:#e53935,color:#fff
+  style S2 fill:#43a047,color:#fff
+  style S5 fill:#43a047,color:#fff
+```
+
+### Ce que CloudRadar applique
+
+Dans ce projet, **8 vérifications automatiques sur 10 tournent avant le merge**. Le développeur obtient un retour en quelques minutes, pas après un déploiement raté.
+
+Concrètement, quand un développeur ouvre une Pull Request sur CloudRadar, **4 workflows GitHub Actions se lancent en parallèle** : les tests applicatifs (Java + React), la validation Kubernetes, la vérification Terraform, et l'analyse SonarCloud. Le tout prend environ 5 minutes. Si un seul échoue, le merge est bloqué — impossible de casser `main` par accident.
+
+```mermaid
+flowchart LR
+  DEV["🧑‍💻 Dev local<br>tests · lint · format"] -->|"< 5 min"| PR["🔀 Pull Request<br>8 gates bloquantes"]
+  PR -->|"tout vert"| MERGE["✅ Build & Push<br>6 images Docker"]
+  MERGE --> DEPLOY["🚀 Deploy<br>infra + app + smoke"]
+  DEPLOY -.-> NIGHT["🌙 Nightly<br>test de charge"]
+
+  style DEV fill:#c8e6c9,color:#000
+  style PR fill:#bbdefb,color:#000
+  style MERGE fill:#fff3e0,color:#000
+  style DEPLOY fill:#fce4ec,color:#000
+  style NIGHT fill:#f3e5f5,color:#000
+```
+
+> **80% des checks** se jouent sur les deux premières étapes (Dev + PR). Les 20% restants (build d'images, deploy, perf) ne tournent qu'après le merge ou en nightly.
+
+**Pourquoi c'est du Shift-Left ?** Traditionnellement, les tests de sécurité, de qualité et d'infrastructure se font tard (en staging ou en prod). Ici, ils sont tous exécutés **sur chaque Pull Request**, avant le merge :
+
+| Gate PR (bloquant) | Ce qu'on vérifie | Temps |
+|---|---|---|
+| Tests Java (3 services) | Le code métier fonctionne | 1–4 min |
+| Tests Frontend (Vitest) | L'interface s'affiche correctement | 20–60s |
+| Hadolint (6 Dockerfiles) | Les images Docker suivent les bonnes pratiques | 20–60s |
+| Trivy (dépendances) | Aucune faille de sécurité connue (CVE) | 30–120s |
+| kubeconform (manifests k8s) | Les fichiers Kubernetes sont valides | 3–5s |
+| tfsec (Terraform) | L'infrastructure as code est sécurisée | 10–30s |
+| Terraform plan | L'infra peut être appliquée sans erreur | 1–3 min |
+| SonarCloud | La qualité globale du code est maintenue | 2–4 min |
+
+---
+
+## 3. Les 9 catégories de tests
+
+Pour couvrir à la fois le code applicatif, l'infrastructure cloud (Terraform, Kubernetes) et la sécurité des dépendances, CloudRadar utilise **9 catégories de tests** réparties en 3 familles. Cette organisation garantit que chaque type de changement — qu'il touche du Java, un manifest k8s ou un module Terraform — est validé par des checks adaptés.
+
+```mermaid
+block-beta
+  columns 3
+
+  APP["🟢 Code applicatif"]:3
+  U["🧪 Unit / Slice<br>logique métier isolée"]:1
+  I["🔗 Integration<br>services + Redis réel"]:1
+  C["📝 Contract<br>format JSON entre services"]:1
+
+  INFRA["🔵 Infrastructure & déploiement"]:3
+  IV["⚙️ Infra Validation<br>Terraform + manifests k8s"]:1
+  E["🌐 E2E / Smoke<br>santé post-déploiement"]:1
+  P["🏔️ Performance<br>tenue en charge (k6)"]:1
+
+  CROSS["🟠 Transversal (toutes les PR)"]:3
+  S["🔒 Sécurité<br>CVE · secrets · IaC"]:1
+  Q["📏 Qualité<br>lint · coverage · smells"]:1
+  UI["🖥️ UI<br>rendu composants React"]:1
+
+  style APP fill:#43a047,color:#fff
+  style U fill:#e8f5e9,color:#000
+  style I fill:#c8e6c9,color:#000
+  style C fill:#a5d6a7,color:#000
+
+  style INFRA fill:#1976d2,color:#fff
+  style IV fill:#e3f2fd,color:#000
+  style E fill:#bbdefb,color:#000
+  style P fill:#90caf9,color:#000
+
+  style CROSS fill:#ef6c00,color:#fff
+  style S fill:#fff3e0,color:#000
+  style Q fill:#ffe0b2,color:#000
+  style UI fill:#ffcc80,color:#000
+```
+
+> **3 familles** : les tests **verts** valident le code applicatif (Java/React), les tests **bleus** valident l'infrastructure et le déploiement, les tests **oranges** sont transversaux et s'exécutent sur chaque PR quelle que soit la nature du changement.
+
+### Matrice catégorie × couverture
+
+| Catégorie | Quoi | Quand | Où | Statut |
+|---|---|---|---|---|
+| 🧪 **Unit / Slice** | Business logic, contrôleurs, parsing | PR | `build-and-push` | ✅ Implémenté |
+| 🔗 **Integration** | Context Spring Boot + data-path Redis | PR | `build-and-push` | ✅ Implémenté |
+| 📝 **Contract** | JSON serialization, Redis key format | PR | `build-and-push` | ✅ Implémenté |
+| 🌐 **E2E / Smoke** | Health + data pipeline post-deploy | Dispatch | `ci-infra` | ✅ Implémenté |
+| 🔒 **Security** | Dépendances CVE, secrets, IaC | PR | `build-and-push` + `ci-infra` | ✅ Implémenté |
+| 📏 **Code Quality** | Smells, duplication, coverage trends | PR | `sonarcloud` + `build-and-push` | ✅ Implémenté |
+| ⚙️ **Infra Validation** | Terraform + k8s manifest schemas | PR | `ci-infra` + `ci-k8s` | ✅ Implémenté |
+| 🏔️ **Performance** | Latence p95, taux d'erreur | Nightly / dispatch | `k6-nightly-baseline` | ✅ Implémenté |
+| 🖥️ **UI** | Render smoke composants React | PR | `build-and-push` | ✅ Implémenté |
+
+---
+
+## 4. Pipelines CI/CD
+
+Les 9 workflows GitHub Actions de CloudRadar sont organisés pour **tourner en parallèle** et donner un feedback rapide. Chaque workflow a un périmètre clair et un déclencheur précis. L'authentification AWS se fait par **OIDC** (pas de clés stockées), et les builds Docker utilisent une **matrice** pour construire les 6 images en parallèle.
+
+Voici **qui vérifie quoi, et quand** :
+
+```mermaid
+block-beta
+  columns 2
+
+  PR["🔀 Sur chaque Pull Request"]:2
+  BAP["🏗️ build-and-push<br>Compile, teste et scanne les 6 services"]:1
+  SQG["📊 sonarcloud<br>Dette technique, couverture, duplication"]:1
+  CIK["☸️ ci-k8s<br>Manifests Kubernetes valides ?"]:1
+  CII["🔒 ci-infra<br>Terraform sûr et déployable ?"]:1
+
+  POST["Après merge"]:2
+  CIID["🌍 ci-infra dispatch<br>Deploy complet + smoke tests"]:1
+  K6["⚡ k6 nightly<br>10 utilisateurs — l'app tient la charge ?"]:1
+
+  style PR fill:#1976d2,color:#fff
+  style BAP fill:#bbdefb,color:#000
+  style SQG fill:#bbdefb,color:#000
+  style CIK fill:#bbdefb,color:#000
+  style CII fill:#bbdefb,color:#000
+  style POST fill:#757575,color:#fff
+  style CIID fill:#ffe0b2,color:#000
+  style K6 fill:#e1bee7,color:#000
+```
+
+| Workflow | Rôle en une phrase | Vérifie | Temps |
+|---|---|---|---|
+| **build-and-push** | Compiler et tester les 6 services | Tests Java ×3, React, lint Dockerfiles ×6, scan CVE | 2–5 min |
+| **sonarcloud** | Surveiller la dette technique | Quality gate, coverage, code smells, duplication | 2–4 min |
+| **ci-k8s** | Valider les fichiers Kubernetes | Schemas kubeconform, sync versions, noms d'images | < 1 min |
+| **ci-infra** (PR) | Vérifier l'infra avant déploiement | terraform fmt/validate/plan, tfsec sécurité | 1–3 min |
+| **ci-infra** (dispatch) | Déployer et vérifier en conditions réelles | Terraform apply → ArgoCD sync → smoke tests | 5–15 min |
+| **k6-nightly** | Mesurer la performance chaque nuit | p95 < 1.5s, taux d'erreur < 5%, checks > 95% | ~1 min |
+
+> Détails de chaque workflow : voir `docs/runbooks/ci-cd/`.
+
+---
+
+## 5. Couverture par service
+
+CloudRadar a 6 microservices. Les 3 services Java (ingester, processor, dashboard) concentrent la majorité des tests car ils portent la logique métier — ingestion OpenSky, agrégation Redis, API REST. Le frontend React a des tests de rendu (Vitest). Les 2 services Python (health, admin-scale) sont des utilitaires légers sans tests pour l'instant.
+
+```mermaid
+block-beta
+  columns 6
+  header["Couverture tests par service"]:6
+  space:6
+  A["dashboard"] B["ingester"] C["processor"] D["frontend"] E["health"] F["admin-scale"]
+  A1["37 tests"] B1["3 tests"] C1["7 tests"] D1["5 tests"] E1["0 test"] F1["0 test"]
+
+  style A1 fill:#4caf50,color:#fff
+  style B1 fill:#4caf50,color:#fff
+  style C1 fill:#4caf50,color:#fff
+  style D1 fill:#4caf50,color:#fff
+  style E1 fill:#f44336,color:#fff
+  style F1 fill:#f44336,color:#fff
+```
+
+4 services sur 6 ont des tests automatisés (52 tests, 15 fichiers). Les 3 services Java couvrent les 3 niveaux de la pyramide : unitaire (Mockito, @WebMvcTest), intégration (Redis Testcontainers), et context smoke (@SpringBootTest). Le frontend couvre le rendu composant (Vitest + Testing Library).
+
+Les contrats inter-services (clés Redis, format JSON) sont validés par des tests Testcontainers dédiés dans chaque service — documentés dans `docs/events-schemas/redis-keys.md`.
+
+SonarCloud ingère la couverture Java (JaCoCo) et frontend (lcov) pour un suivi de tendance unifié.
+
+---
+
+## 6. Workflow × catégorie : qui vérifie quoi ?
+
+Cette matrice croise les 6 workflows avec les 9 catégories de tests. Elle permet de vérifier d'un coup d'œil qu'**aucune catégorie n'est orpheline** — chaque type de vérification est porté par au moins un workflow.
+
+| Catégorie | build-and-push | sonarcloud | ci-k8s | ci-infra PR | ci-infra deploy | k6 nightly |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| 🧪 Unit | 🟢 | | | | | |
+| 🔗 Integ | 🟢 | | | | | |
+| 📝 Contract | 🟢 | | | | | |
+| 🖥️ UI | 🟢 | | | | | |
+| 🔒 Sécu | 🟢 | | | 🟢 | | |
+| 📏 Qualité | | 🟢 | | | | |
+| ⚙️ Infra | | | 🟢 | 🟢 | | |
+| 🌐 E2E | | | | | 🟢 | |
+| 🏔️ Perf | | | | | | 🟢 |
+
+> `build-and-push` porte **5/9 catégories**. Toutes les catégories sont couvertes par au moins un workflow.
+
+---
+
+## 7. Améliorations possibles
+
+```mermaid
+quadrantChart
+  title Rapport effort / impact des améliorations
+  x-axis "Effort faible" --> "Effort élevé"
+  y-axis "Impact faible" --> "Impact élevé"
+
+  "Dependabot": [0.08, 0.80]
+  "SpotBugs": [0.15, 0.70]
+  "ESLint + Prettier": [0.15, 0.60]
+  "Trivy image": [0.08, 0.65]
+  "Tests Python": [0.35, 0.55]
+  "HTTP contracts": [0.50, 0.55]
+  "Coverage gate": [0.05, 0.50]
+  "Rollback validation": [0.25, 0.45]
+  "Frontend E2E": [0.65, 0.40]
+  "Mutation testing": [0.40, 0.30]
+  "Chaos testing": [0.85, 0.25]
+```
+
+| Priorité | Amélioration | Pourquoi | Effort |
+|---|---|---|---|
+| 🔴 Haute | **Dependabot** | PR automatiques de mise à jour dépendances (Maven, npm, Actions) | ~15 min |
+| 🔴 Haute | **SpotBugs** | Détection statique NPE, concurrence, anti-patterns Java | ~30 min |
+| 🔴 Haute | **ESLint + Prettier** | Aucun linting TypeScript/React en CI | ~30 min |
+| 🔴 Haute | **Trivy image** | Scan couches OS/runtime des images Docker (seul Trivy fs existe) | ~15 min |
+| 🟡 Moyenne | **Tests Python** | 2/6 services sans tests (health, admin-scale) | ~2h |
+| 🟡 Moyenne | **HTTP contract tests** | Parsing OpenSky et payload `/api/flights` testés sans serveur HTTP mock | ~3h |
+| 🟡 Moyenne | **Coverage enforcement** | Activer le seuil bloquant SonarCloud sur le nouveau code | ~10 min |
+| 🔵 Basse | **Rollback validation** | Aucune vérification de la capacité de rollback ArgoCD | ~1h |
+| 🔵 Basse | **Frontend E2E** | Pas de test navigateur réel (Playwright/Cypress) | ~4h |
+| 🔵 Basse | **Mutation testing** | Vérifier que les tests détectent réellement les régressions (PIT) | ~2h |

--- a/src/dashboard/pom.xml
+++ b/src/dashboard/pom.xml
@@ -19,6 +19,7 @@
 
   <properties>
     <java.version>17</java.version>
+    <jackson-bom.version>2.21.1</jackson-bom.version>
   </properties>
 
   <dependencies>

--- a/src/frontend/src/styles.css
+++ b/src/frontend/src/styles.css
@@ -32,7 +32,8 @@ body,
   position: relative;
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: 16px;
   display: grid;
   grid-template-rows: auto 1fr auto;

--- a/src/ingester/pom.xml
+++ b/src/ingester/pom.xml
@@ -19,6 +19,7 @@
 
   <properties>
     <java.version>17</java.version>
+    <jackson-bom.version>2.21.1</jackson-bom.version>
   </properties>
 
   <dependencyManagement>

--- a/src/processor/pom.xml
+++ b/src/processor/pom.xml
@@ -19,6 +19,7 @@
 
   <properties>
     <java.version>17</java.version>
+    <jackson-bom.version>2.21.1</jackson-bom.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary
- restored vertical scrolling in `dashboard-shell` by switching from `overflow: hidden` to `overflow-y: auto` (`overflow-x: hidden` kept)
- added French and English testing overview documents for portfolio/QA visibility
- added the Leaflet aircraft movement review document under code reviews
- added a CI-unblock security fix by overriding Jackson BOM to `2.21.1` in Java services to remediate `GHSA-72hv-8253-57qq` detected by Trivy

## Validation
- `mvn -B -f src/dashboard/pom.xml test`
- `mvn -B -f src/ingester/pom.xml test`
- `mvn -B -f src/processor/pom.xml test`
- manual CSS diff check on `src/frontend/src/styles.css`

Refs #57
