### PR TITLE
ci(bootstrap): simplify workflow inputs to toggle-only

### DIFF
--- a/.github/workflows/bootstrap-terraform-backend.yml
+++ b/.github/workflows/bootstrap-terraform-backend.yml
@@ -3,37 +3,11 @@ name: bootstrap-terraform-backend
 on:
   workflow_dispatch:
     inputs:
-      region:
-        description: "AWS region for backend resources"
-        required: true
-        default: "us-east-1"
-      state_bucket_name:
-        description: "S3 bucket name for Terraform state (must be globally unique)"
-        required: true
-      lock_table_name:
-        description: "DynamoDB table name for Terraform locks"
-        required: true
-        default: "cloudradar-tf-lock"
-      backup_bucket_name:
-        description: "Optional S3 bucket name for SQLite backups"
-        required: false
-      aircraft_reference_bucket_name:
-        description: "Optional S3 bucket name for aircraft reference data artifacts"
-        required: false
-      dns_zone_name:
-        description: "Optional Route53 hosted zone name for delegated subdomain (e.g., cloudradar.example.com)"
-        required: false
       issue_tls:
         description: "Issue a public TLS certificate with Let's Encrypt DNS-01 and store it in SSM"
         required: false
         type: boolean
         default: false
-      tls_domain:
-        description: "TLS domain to issue (required when issue_tls=true, e.g., cloudradar.example.com)"
-        required: false
-      role_arn:
-        description: "Optional role ARN to assume (defaults to AWS_TERRAFORM_ROLE_ARN variable)"
-        required: false
 
 permissions:
   id-token: write
@@ -52,10 +26,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          # Prefer explicit input, fallback to repo variable.
-          role-to-assume: ${{ inputs.role_arn || vars.AWS_TERRAFORM_ROLE_ARN }}
-          # Inputs are required, but keep fallback in case defaults change.
-          aws-region: ${{ inputs.region || vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_TERRAFORM_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Terraform init (local backend)
         run: terraform -chdir=infra/aws/bootstrap init -backend=false
@@ -63,22 +35,34 @@ jobs:
       - name: Resolve backend inputs
         run: |
           set -euo pipefail
-          STATE_BUCKET="${{ inputs.state_bucket_name || vars.TF_STATE_BUCKET }}"
-          LOCK_TABLE="${{ inputs.lock_table_name || vars.TF_LOCK_TABLE_NAME }}"
-          BACKUP_BUCKET="${{ inputs.backup_bucket_name || vars.TF_BACKUP_BUCKET_NAME }}"
-          AIRCRAFT_REFERENCE_BUCKET="${{ inputs.aircraft_reference_bucket_name || vars.TF_AIRCRAFT_REFERENCE_BUCKET_NAME }}"
-          DNS_ZONE_NAME="${{ inputs.dns_zone_name || vars.DNS_ZONE_NAME }}"
+          REGION="${{ vars.AWS_REGION }}"
+          STATE_BUCKET="${{ vars.TF_STATE_BUCKET }}"
+          LOCK_TABLE="${{ vars.TF_LOCK_TABLE_NAME }}"
+          BACKUP_BUCKET="${{ vars.TF_BACKUP_BUCKET_NAME }}"
+          AIRCRAFT_REFERENCE_BUCKET="${{ vars.TF_AIRCRAFT_REFERENCE_BUCKET_NAME }}"
+          DNS_ZONE_NAME="${{ vars.DNS_ZONE_NAME }}"
           ISSUE_TLS="${{ inputs.issue_tls }}"
-          TLS_DOMAIN="${{ inputs.tls_domain }}"
+          TLS_DOMAIN="${{ vars.TLS_DOMAIN }}"
+
+          missing_vars=()
+          [[ -z "${REGION}" ]] && missing_vars+=("AWS_REGION")
+          [[ -z "${STATE_BUCKET}" ]] && missing_vars+=("TF_STATE_BUCKET")
+          [[ -z "${LOCK_TABLE}" ]] && missing_vars+=("TF_LOCK_TABLE_NAME")
+
+          if (( ${#missing_vars[@]} > 0 )); then
+            echo "Missing required GitHub Action variables: ${missing_vars[*]}" >&2
+            exit 1
+          fi
 
           {
+            echo "REGION=${REGION}"
             echo "STATE_BUCKET=${STATE_BUCKET}"
             echo "LOCK_TABLE=${LOCK_TABLE}"
             echo "ISSUE_TLS=${ISSUE_TLS}"
             echo "TLS_DOMAIN=${TLS_DOMAIN}"
             echo "TF_VAR_state_bucket_name=${STATE_BUCKET}"
             echo "TF_VAR_lock_table_name=${LOCK_TABLE}"
-            echo "TF_VAR_region=${{ inputs.region || vars.AWS_REGION }}"
+            echo "TF_VAR_region=${REGION}"
           } >> "${GITHUB_ENV}"
 
           if [[ -n "${BACKUP_BUCKET}" ]]; then
@@ -156,7 +140,7 @@ jobs:
           DNS_ZONE_NAME="${DNS_ZONE_NAME:-}"
 
           APPLY_ARGS=(
-            "-var=region=${{ inputs.region || vars.AWS_REGION }}"
+            "-var=region=${REGION}"
             "-var=state_bucket_name=${STATE_BUCKET}"
             "-var=lock_table_name=${LOCK_TABLE}"
           )
@@ -184,7 +168,7 @@ jobs:
             exit 1
           fi
           if [[ -z "${DNS_ZONE_NAME:-}" ]]; then
-            echo "dns_zone_name (input or DNS_ZONE_NAME variable) is required when issue_tls=true" >&2
+            echo "DNS_ZONE_NAME variable is required when issue_tls=true" >&2
             exit 1
           fi
 

--- a/docs/runbooks/bootstrap/terraform-backend-bootstrap.md
+++ b/docs/runbooks/bootstrap/terraform-backend-bootstrap.md
@@ -49,27 +49,23 @@ flowchart TB
 - AWS account bootstrap completed (OIDC provider + CI role).
 - Repo variables set (GitHub → Settings → Secrets and variables → Actions → Variables):
   - `AWS_TERRAFORM_ROLE_ARN`
-  - `AWS_REGION` (default for workflow)
-  - `TF_LOCK_TABLE_NAME` (default for workflow)
-  - `TF_BACKUP_BUCKET_NAME` (optional default for SQLite backups)
-  - `TF_AIRCRAFT_REFERENCE_BUCKET_NAME` (optional default for aircraft reference data artifacts)
-  - `DNS_ZONE_NAME` (optional, delegated subdomain hosted zone name; keep real values out of the repo)
+  - `AWS_REGION`
+  - `TF_STATE_BUCKET`
+  - `TF_LOCK_TABLE_NAME`
+  - `TF_BACKUP_BUCKET_NAME` (optional, SQLite backups bucket)
+  - `TF_AIRCRAFT_REFERENCE_BUCKET_NAME` (optional, aircraft reference bucket)
+  - `DNS_ZONE_NAME` (optional unless `issue_tls=true`)
+  - `TLS_DOMAIN` (required when `issue_tls=true`)
 
 ## Run
 1) In GitHub Actions, run **bootstrap-terraform-backend** workflow.
-2) Provide:
-   - `state_bucket_name` (globally unique)
-   - `lock_table_name` (prefilled from `TF_LOCK_TABLE_NAME`)
-   - `backup_bucket_name` (optional, SQLite backups bucket)
-   - `aircraft_reference_bucket_name` (optional, aircraft reference data bucket)
-   - `dns_zone_name` (optional, delegated subdomain hosted zone name)
-   - `issue_tls` (optional checkbox; default false)
-   - `tls_domain` (required if `issue_tls=true`, e.g. `cloudradar.example.com`)
-   - `region` (prefilled from `AWS_REGION`)
+2) Provide only:
+   - `issue_tls` (checkbox; default false)
 
 Important behavior:
 - If `issue_tls=false`, the workflow validates that a valid existing certificate is already present in SSM (`/cloudradar/edge/tls/fullchain_pem` + `/cloudradar/edge/tls/privkey_pem`).
 - If no valid existing certificate is found, the workflow fails fast.
+- If `issue_tls=true`, `TLS_DOMAIN` and `DNS_ZONE_NAME` variables must be set and consistent.
 
 Example bucket name:
 - `cloudradar-tfstate-<account-id>`
@@ -78,14 +74,7 @@ Example bucket name:
 ```bash
 gh workflow run bootstrap-terraform-backend \
   --ref main \
-  -f region=us-east-1 \
-  -f state_bucket_name=cloudradar-tfstate-<account-id> \
-  -f lock_table_name=cloudradar-tf-lock \
-  -f backup_bucket_name=cloudradar-dev-<account-id>-sqlite-backups \
-  -f aircraft_reference_bucket_name=cloudradar-dev-<account-id>-aircraft-db \
-  -f dns_zone_name=cloudradar.example.com \
-  -f issue_tls=true \
-  -f tls_domain=cloudradar.example.com
+  -f issue_tls=true
 ```
 
 ## Outputs
@@ -139,7 +128,7 @@ terraform -chdir=infra/aws/live/dev init -backend-config=backend.hcl
 - TLS issuance details:
   - Uses Let's Encrypt DNS-01 challenge through Route53.
   - Forces RSA key generation (`--key-type rsa --rsa-key-size 2048`) for edge compatibility.
-  - `tls_domain` must be inside `dns_zone_name`.
+  - `TLS_DOMAIN` must be inside `DNS_ZONE_NAME`.
   - SSM writes use `SecureString` Standard tier first, then Advanced tier fallback only if value size exceeds Standard limits.
 
 ## State Persistence (Recommended)


### PR DESCRIPTION
## Summary
- simplify `bootstrap-terraform-backend` manual inputs to toggle-only (`issue_tls`)
- move infrastructure values (region, buckets, DNS zone, TLS domain, role ARN) to GitHub Actions Variables
- add fail-fast validation for required variables (`AWS_REGION`, `TF_STATE_BUCKET`, `TF_LOCK_TABLE_NAME`)
- update bootstrap runbook to match the new execution model

## Why
- reduce manual input errors during bootstrap runs
- keep configuration values centralized and consistent across runs
- align with MVP expectation: manual input used to trigger behavior, not carry infrastructure values

## Changes
- workflow updated: [bootstrap-terraform-backend.yml](/home/xclem/projetsperso/CloudRadar/.github/workflows/bootstrap-terraform-backend.yml)
- runbook updated: [terraform-backend-bootstrap.md](/home/xclem/projetsperso/CloudRadar/docs/runbooks/bootstrap/terraform-backend-bootstrap.md)

## Validation
- `git diff --check`
- workflow logic reviewed for references to removed inputs

Refs #57
