### PR TITLE
fix(ci): use bootstrap role for backend workflow

### DIFF
--- a/.github/workflows/bootstrap-terraform-backend.yml
+++ b/.github/workflows/bootstrap-terraform-backend.yml
@@ -23,10 +23,29 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
+      - name: Validate required GitHub variables
+        run: |
+          set -euo pipefail
+          BOOTSTRAP_ROLE_ARN="${{ vars.AWS_BOOTSTRAP_ROLE_ARN }}"
+          REGION="${{ vars.AWS_REGION }}"
+          STATE_BUCKET="${{ vars.TF_STATE_BUCKET }}"
+          LOCK_TABLE="${{ vars.TF_LOCK_TABLE_NAME }}"
+
+          missing_vars=()
+          [[ -z "${BOOTSTRAP_ROLE_ARN}" ]] && missing_vars+=("AWS_BOOTSTRAP_ROLE_ARN")
+          [[ -z "${REGION}" ]] && missing_vars+=("AWS_REGION")
+          [[ -z "${STATE_BUCKET}" ]] && missing_vars+=("TF_STATE_BUCKET")
+          [[ -z "${LOCK_TABLE}" ]] && missing_vars+=("TF_LOCK_TABLE_NAME")
+
+          if (( ${#missing_vars[@]} > 0 )); then
+            echo "Missing required GitHub Action variables: ${missing_vars[*]}" >&2
+            exit 1
+          fi
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_TERRAFORM_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_BOOTSTRAP_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Terraform init (local backend)

--- a/docs/runbooks/bootstrap/aws-account-bootstrap.md
+++ b/docs/runbooks/bootstrap/aws-account-bootstrap.md
@@ -498,7 +498,9 @@ Store these values in a secure place and in GitHub Actions variables if needed.
 - OIDC provider tag/name: `github-actions-oidc`
 
 ## Auth paths (GitHub Actions vs AWS CLI)
-- **GitHub Actions** uses OIDC to assume `CloudRadarTerraformRole` (no IAM user or static keys).
+- **GitHub Actions** uses OIDC role separation:
+  - `bootstrap-terraform-backend` -> `CloudRadarBootstrapRole` (`AWS_BOOTSTRAP_ROLE_ARN`)
+  - `ci-infra` / `ci-infra-destroy` -> `CloudRadarTerraformRole` (`AWS_TERRAFORM_ROLE_ARN`)
 - **AWS CLI (local)** uses a profile for `CloudRadarTerraformUser`, then assumes `CloudRadarTerraformRole`.
   The user needs only `sts:AssumeRole` + MFA.
 

--- a/docs/runbooks/bootstrap/terraform-backend-bootstrap.md
+++ b/docs/runbooks/bootstrap/terraform-backend-bootstrap.md
@@ -24,7 +24,7 @@ flowchart TB
   end
 
   subgraph AWS["AWS"]
-    ROLE["OIDC IAM role\n(AWS_TERRAFORM_ROLE_ARN)"]
+    ROLE["OIDC IAM role\n(AWS_BOOTSTRAP_ROLE_ARN)"]
 
     S3["S3 bucket (Terraform state)"]
     DDB["DynamoDB lock table\n(lock_table_name / TF_LOCK_TABLE_NAME)"]
@@ -48,7 +48,8 @@ flowchart TB
 ## Prerequisites
 - AWS account bootstrap completed (OIDC provider + CI role).
 - Repo variables set (GitHub → Settings → Secrets and variables → Actions → Variables):
-  - `AWS_TERRAFORM_ROLE_ARN`
+  - `AWS_BOOTSTRAP_ROLE_ARN` (used by `bootstrap-terraform-backend`)
+  - `AWS_TERRAFORM_ROLE_ARN` (used by `ci-infra`)
   - `AWS_REGION`
   - `TF_STATE_BUCKET`
   - `TF_LOCK_TABLE_NAME`


### PR DESCRIPTION
## Summary
- switched `bootstrap-terraform-backend` to assume `AWS_BOOTSTRAP_ROLE_ARN` instead of `AWS_TERRAFORM_ROLE_ARN`
- added a fail-fast validation step for required GitHub variables before AWS auth
- updated bootstrap runbooks to document OIDC role separation between backend bootstrap and infra CI
- kept scope limited to workflow + docs alignment

## Validation
- `git diff --check`
- `yamllint .github/workflows/bootstrap-terraform-backend.yml` (line-length warnings only, no syntax issue introduced by this change)

Fixes #537
