### PR TITLE
fix(ci): harden edge TLS smoke diagnostics

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -1903,10 +1903,13 @@ jobs:
         env:
           EDGE_INSTANCE_ID: ${{ needs.tf-outputs.outputs.edge_instance_id }}
           EDGE_PUBLIC_IP: ${{ needs.tf-outputs.outputs.edge_public_ip }}
+          EDGE_TLS_SERVER_NAME: ${{ needs.tf-outputs.outputs.dns_zone_name }}
           EDGE_BASIC_AUTH_USER: ${{ needs.tf-outputs.outputs.edge_basic_auth_user }}
           EDGE_BASIC_AUTH_SSM_PARAMETER_NAME: ${{ needs.tf-outputs.outputs.edge_basic_auth_ssm_parameter_name }}
           K3S_SERVER_INSTANCE_ID: ${{ needs.tf-outputs.outputs.k3s_server_instance_id }}
         run: |
+          set -euo pipefail
+
           wait_for_instance_ready() {
             local instance_id=$1
             local max_attempts=12
@@ -1980,6 +1983,167 @@ jobs:
 
           is_uuid() {
             echo "$1" | grep -Eq '^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'
+          }
+
+          run_edge_diagnostics() {
+            local reason=${1:-unknown}
+            local edge_id="${EDGE_INSTANCE_ID:-}"
+
+            if [ -z "${edge_id}" ]; then
+              echo "EDGE_INSTANCE_ID not set; skipping edge diagnostics for ${reason}."
+              return 0
+            fi
+
+            if ! wait_for_instance_ready "${edge_id}"; then
+              echo "Edge instance not ready; skipping edge diagnostics for ${reason}."
+              return 0
+            fi
+
+            local diag_params
+            diag_params="$(jq -cn \
+              --arg c0 'set -euo pipefail' \
+              --arg c1 'echo "edge diagnostics reason='"${reason}"'"' \
+              --arg c2 'echo "cloud-init status:"; cloud-init status --long || true' \
+              --arg c3 'echo "TLS files:"; ls -l /etc/nginx/ssl/edge.crt /etc/nginx/ssl/edge.key || true' \
+              --arg c4 'echo "cloud-init-output tail:"; tail -n 200 /var/log/cloud-init-output.log || true' \
+              --arg c5 'echo "TLS loader stderr files:"; for f in /tmp/ssm-tls-*.err; do [ -f "$f" ] && { echo "--- ${f}"; tail -n 200 "$f"; }; done' \
+              --arg c6 'echo "nginx status:"; systemctl status nginx --no-pager -l || true' \
+              --arg c7 'echo "nginx journal tail:"; journalctl -u nginx --no-pager -n 200 || true' \
+              '{commands: [$c0, $c1, $c2, $c3, $c4, $c5, $c6, $c7]}')"
+
+            local diag_command_id
+            diag_command_id="$(send_ssm_command "${edge_id}" "${diag_params}" 300)"
+            if ! is_uuid "${diag_command_id}"; then
+              echo "Invalid SSM command id for edge diagnostics: ${diag_command_id:-empty}" >&2
+              return 0
+            fi
+
+            echo "::notice title=SMOKE-TESTS::collecting edge diagnostics (${reason})."
+            poll_ssm_command "${diag_command_id}" "${edge_id}" 300 || true
+          }
+
+          run_edge_tls_preflight_via_ssm() {
+            local edge_id=$1
+            local params
+            local command_id
+
+            params="$(jq -cn \
+              --arg c0 'set -euo pipefail' \
+              --arg c1 'cloud-init status --wait || true' \
+              --arg c2 'test -s /etc/nginx/ssl/edge.crt && test -s /etc/nginx/ssl/edge.key' \
+              --arg c3 'openssl x509 -in /etc/nginx/ssl/edge.crt -noout -enddate -subject -issuer' \
+              --arg c4 'cert_modulus_md5="$(openssl x509 -in /etc/nginx/ssl/edge.crt -noout -modulus | openssl md5)"; key_modulus_md5="$(openssl rsa -in /etc/nginx/ssl/edge.key -noout -modulus | openssl md5)"; [ "${cert_modulus_md5}" = "${key_modulus_md5}" ]' \
+              '{commands: [$c0, $c1, $c2, $c3, $c4]}')"
+
+            command_id="$(send_ssm_command "${edge_id}" "${params}" 180)"
+            if ! is_uuid "${command_id}"; then
+              echo "::error title=SMOKE-TESTS::invalid SSM command id while running edge TLS preflight."
+              return 1
+            fi
+
+            if ! poll_ssm_command "${command_id}" "${edge_id}" 180; then
+              echo "::error title=SMOKE-TESTS::edge TLS preflight failed (cloud-init/TLS files/cert-key match)."
+              run_edge_diagnostics "tls-preflight-failed"
+              return 1
+            fi
+
+            echo "::notice title=SMOKE-TESTS::edge TLS preflight via SSM passed."
+          }
+
+          check_public_tls_certificate() {
+            local ip=$1
+            local server_name=$2
+            local min_remaining_seconds=$((14 * 24 * 60 * 60))
+            local cert_file
+            cert_file="$(mktemp)"
+
+            if [ -z "${server_name}" ]; then
+              echo "::warning title=SMOKE-TESTS::EDGE_TLS_SERVER_NAME is empty; skipping strict TLS hostname validation and using -k for HTTP checks."
+              rm -f "${cert_file}"
+              return 0
+            fi
+
+            if ! openssl s_client \
+              -connect "${ip}:443" \
+              -servername "${server_name}" \
+              -verify_hostname "${server_name}" \
+              -showcerts </dev/null 2>/dev/null \
+              | awk '/BEGIN CERTIFICATE/{flag=1} flag{print} /END CERTIFICATE/{exit}' > "${cert_file}"; then
+              echo "::error title=SMOKE-TESTS::failed to fetch/verify public TLS certificate from ${server_name} (${ip}:443)."
+              rm -f "${cert_file}"
+              return 1
+            fi
+
+            if [ ! -s "${cert_file}" ]; then
+              echo "::error title=SMOKE-TESTS::no leaf certificate extracted from ${server_name} (${ip}:443)."
+              rm -f "${cert_file}"
+              return 1
+            fi
+
+            if ! openssl x509 -in "${cert_file}" -noout -checkend "${min_remaining_seconds}" >/dev/null 2>&1; then
+              echo "::error title=SMOKE-TESTS::public TLS certificate for ${server_name} expires in less than 14 days."
+              openssl x509 -in "${cert_file}" -noout -enddate -subject -issuer || true
+              rm -f "${cert_file}"
+              return 1
+            fi
+
+            local not_after
+            not_after="$(openssl x509 -in "${cert_file}" -noout -enddate | cut -d= -f2-)"
+            echo "::notice title=SMOKE-TESTS::public TLS certificate validated for ${server_name} (not_after=${not_after})."
+            rm -f "${cert_file}"
+          }
+
+          TLS_FULLCHAIN_PARAM="/cloudradar/edge/tls/fullchain_pem"
+          TLS_PRIVKEY_PARAM="/cloudradar/edge/tls/privkey_pem"
+
+          verify_tls_artifacts_in_ssm() {
+            local cert_file
+            local key_file
+            local cert_modulus_md5
+            local key_modulus_md5
+            local not_after
+
+            cert_file="$(mktemp)"
+            key_file="$(mktemp)"
+
+            if ! aws ssm get-parameter \
+              --name "${TLS_FULLCHAIN_PARAM}" \
+              --with-decryption \
+              --query "Parameter.Value" \
+              --output text > "${cert_file}"; then
+              echo "::error title=SMOKE-TESTS::TLS certificate parameter missing or unreadable (${TLS_FULLCHAIN_PARAM})."
+              rm -f "${cert_file}" "${key_file}"
+              return 1
+            fi
+
+            if ! aws ssm get-parameter \
+              --name "${TLS_PRIVKEY_PARAM}" \
+              --with-decryption \
+              --query "Parameter.Value" \
+              --output text > "${key_file}"; then
+              echo "::error title=SMOKE-TESTS::TLS private key parameter missing or unreadable (${TLS_PRIVKEY_PARAM})."
+              rm -f "${cert_file}" "${key_file}"
+              return 1
+            fi
+
+            if ! openssl x509 -in "${cert_file}" -noout -checkend 0 >/dev/null 2>&1; then
+              echo "::error title=SMOKE-TESTS::TLS certificate from ${TLS_FULLCHAIN_PARAM} is invalid or expired."
+              rm -f "${cert_file}" "${key_file}"
+              return 1
+            fi
+
+            cert_modulus_md5="$(openssl x509 -in "${cert_file}" -noout -modulus | openssl md5)"
+            key_modulus_md5="$(openssl rsa -in "${key_file}" -noout -modulus | openssl md5)"
+
+            if [ "${cert_modulus_md5}" != "${key_modulus_md5}" ]; then
+              echo "::error title=SMOKE-TESTS::TLS certificate and key mismatch (${TLS_FULLCHAIN_PARAM} vs ${TLS_PRIVKEY_PARAM})."
+              rm -f "${cert_file}" "${key_file}"
+              return 1
+            fi
+
+            not_after="$(openssl x509 -in "${cert_file}" -noout -enddate | cut -d= -f2-)"
+            echo "::notice title=SMOKE-TESTS::TLS artifacts validated in SSM (not_after=${not_after})."
+            rm -f "${cert_file}" "${key_file}"
           }
 
           params="$(jq -cn \
@@ -2083,7 +2247,19 @@ jobs:
             poll_ssm_command "${diag_command_id}" "${K3S_SERVER_INSTANCE_ID}" 300 || true
           }
 
+          verify_tls_artifacts_in_ssm
           wait_for_instance_ready "${EDGE_INSTANCE_ID}"
+          EDGE_TLS_SERVER_NAME="${EDGE_TLS_SERVER_NAME%.}"
+          run_edge_tls_preflight_via_ssm "${EDGE_INSTANCE_ID}"
+          check_public_tls_certificate "${EDGE_PUBLIC_IP}" "${EDGE_TLS_SERVER_NAME:-}"
+
+          EDGE_BASE_URL="https://${EDGE_PUBLIC_IP}"
+          CURL_TLS_ARGS=(-k)
+          if [ -n "${EDGE_TLS_SERVER_NAME:-}" ]; then
+            EDGE_BASE_URL="https://${EDGE_TLS_SERVER_NAME}"
+            CURL_TLS_ARGS=(--resolve "${EDGE_TLS_SERVER_NAME}:443:${EDGE_PUBLIC_IP}")
+          fi
+
           i=0
           while [ $i -lt 3 ]; do
             command_id="$(send_ssm_command "${EDGE_INSTANCE_ID}" "${params}" 120)"
@@ -2111,7 +2287,8 @@ jobs:
               echo "Edge nginx not ready, retrying in 10s..."
               sleep 10
             else
-              echo "Edge nginx not ready after 3 attempts."
+              echo "Edge nginx not ready after 3 attempts. Check nginx logs and edge cloud-init TLS loading."
+              run_edge_diagnostics "nginx-not-ready"
               exit 1
             fi
           done
@@ -2134,14 +2311,15 @@ jobs:
 
             while [ "${attempt}" -le "${max_attempts}" ]; do
               set +e
-              status_code="$(curl -k -sS -o /dev/null -w '%{http_code}' \
+              status_code="$(curl -sS -o /dev/null -w '%{http_code}' \
                 --connect-timeout 5 \
                 --max-time 10 \
                 --retry 2 \
                 --retry-delay 2 \
                 --retry-all-errors \
+                "${CURL_TLS_ARGS[@]}" \
                 -u "${EDGE_BASIC_AUTH_USER}:${edge_basic_auth_password}" \
-                "https://${EDGE_PUBLIC_IP}${path}")"
+                "${EDGE_BASE_URL}${path}")"
               curl_exit=$?
               set -e
 
@@ -2163,6 +2341,7 @@ jobs:
             done
 
             echo "Expected 200/301/302 from ${path}, got ${status_code}."
+            run_edge_diagnostics "http-path-failed-${path}"
             run_cluster_diagnostics "${path}"
             return 1
           }
@@ -2180,14 +2359,15 @@ jobs:
 
             while [ "${attempt}" -le "${max_attempts}" ]; do
               set +e
-              status_code="$(curl -k -sS -o "${body_file}" -w '%{http_code}' \
+              status_code="$(curl -sS -o "${body_file}" -w '%{http_code}' \
                 --connect-timeout 5 \
                 --max-time 15 \
                 --retry 2 \
                 --retry-delay 2 \
                 --retry-all-errors \
+                "${CURL_TLS_ARGS[@]}" \
                 -u "${EDGE_BASIC_AUTH_USER}:${edge_basic_auth_password}" \
-                "https://${EDGE_PUBLIC_IP}${path}")"
+                "${EDGE_BASE_URL}${path}")"
               curl_exit=$?
               set -e
 
@@ -2208,6 +2388,7 @@ jobs:
             done
 
             echo "Expected HTTP 200 + JSON assertion to pass for ${path}."
+            run_edge_diagnostics "http-json-failed-${path}"
             run_cluster_diagnostics "${path}"
             rm -f "${body_file}"
             return 1

--- a/docs/runbooks/bootstrap/terraform-backend-bootstrap.md
+++ b/docs/runbooks/bootstrap/terraform-backend-bootstrap.md
@@ -41,8 +41,8 @@ flowchart TB
   TF --> BK
   TF --> AR
   TF --> R53
-  WF -->|issue cert (optional)| R53
-  WF -->|store fullchain+key (optional)| SSM
+  WF -->|issue cert optional| R53
+  WF -->|store fullchain and key optional| SSM
 ```
 
 ## Prerequisites
@@ -76,6 +76,68 @@ Example bucket name:
 gh workflow run bootstrap-terraform-backend \
   --ref main \
   -f issue_tls=true
+```
+
+## TLS issuance internals (`issue_tls=true`)
+
+This section explains the two workflow steps:
+- `Install certbot DNS Route53 plugin`
+- `Issue TLS certificate and store in SSM Parameter Store`
+
+### Step 1: Install certbot DNS Route53 plugin
+
+Purpose: prepare the runner to solve ACME DNS-01 challenges via Route53.
+
+Commands executed by the workflow:
+```bash
+sudo apt-get update
+sudo apt-get install -y certbot python3-certbot-dns-route53
+```
+
+Why this is needed:
+- `certbot` performs the Let's Encrypt certificate request.
+- `python3-certbot-dns-route53` lets certbot create `_acme-challenge` TXT records in Route53 automatically using the assumed AWS role.
+
+### Step 2: Issue TLS certificate and store in SSM Parameter Store
+
+Purpose: issue a public certificate for `TLS_DOMAIN` and persist artifacts outside Terraform state.
+
+Main actions:
+1. Create a temporary certbot working directory (`mktemp -d`).
+2. Run certificate issuance with DNS-01:
+   - `certbot certonly --dns-route53 -d "${TLS_DOMAIN}" --key-type rsa --rsa-key-size 2048`
+3. Verify generated files exist:
+   - `fullchain.pem`
+   - `privkey.pem`
+4. Store both files in SSM Parameter Store as `SecureString`:
+   - `/cloudradar/edge/tls/fullchain_pem`
+   - `/cloudradar/edge/tls/privkey_pem`
+5. If SSM Standard tier size is exceeded, retry as `Advanced` tier.
+6. Write non-sensitive metadata (`domain`, `not_after`, `fingerprint_sha256`, `issued_at`) to:
+   - `/cloudradar/edge/tls/metadata`
+
+Security and operational notes:
+- Private key material is never committed to Git and not stored in Terraform state.
+- The workflow uses ephemeral files on the runner and removes them at exit.
+- Edge strict TLS mode later reads these SSM parameters at boot.
+
+### TLS sequence (detailed)
+
+```mermaid
+sequenceDiagram
+  participant GH as GitHub runner
+  participant LE as Let's Encrypt
+  participant R53 as Route53 zone
+  participant SSM as SSM Parameter Store
+
+  GH->>GH: Install certbot and dns-route53 plugin
+  GH->>LE: Start ACME order for TLS_DOMAIN
+  LE-->>GH: DNS-01 challenge required
+  GH->>R53: Create TXT _acme-challenge
+  R53-->>LE: TXT record resolvable
+  LE-->>GH: Authorization valid, issue cert
+  GH->>SSM: Put fullchain and private key as SecureString
+  GH->>SSM: Put metadata as String
 ```
 
 ## Outputs

--- a/docs/runbooks/ci-cd/ci-infra.md
+++ b/docs/runbooks/ci-cd/ci-infra.md
@@ -156,7 +156,19 @@ flowchart TB
   - `/api/flights?limit=50&sort=lastSeen&order=desc` (status `200` + JSON body assertion `.items | type == "array"`)
   - If `run_smoke_tests=false`, the smoke-tests job emits an explicit skip reason in logs and summary.
 - The smoke test verifies edge Nginx via SSM (3 retries with 10s delay) before running the external `/healthz` curl.
-  - On failure, it prints `systemctl status nginx`, recent `journalctl` logs, and the 443 listen check to speed up diagnostics.
+  - Before the Nginx readiness check, it validates TLS artifacts in SSM:
+    - `/cloudradar/edge/tls/fullchain_pem` exists and is not expired
+    - `/cloudradar/edge/tls/privkey_pem` exists
+    - certificate/key modulus match
+  - It then runs an edge TLS preflight via SSM:
+    - `cloud-init status --wait` (best effort)
+    - `/etc/nginx/ssl/edge.crt` + `/etc/nginx/ssl/edge.key` presence
+    - certificate metadata (`enddate`, `subject`, `issuer`)
+    - cert/key modulus match on the edge host
+  - On TLS or preflight failure, the job emits explicit `::error` messages and collects dedicated edge diagnostics:
+    - `systemctl status nginx`, `journalctl -u nginx`
+    - `tail /var/log/cloud-init-output.log`
+    - `tail /tmp/ssm-tls-*.err` (when present)
 - The workflow now waits for **SSM PingStatus=Online** before sending commands, and retries `send-command` on transient `InvalidInstanceId` errors.
 - SSM retry logs are sent to stderr so only the command ID is parsed.
 
@@ -168,6 +180,9 @@ When `run_smoke_tests=true` (dev only), the workflow:
 - Waits for the `healthz` deployment rollout in the `cloudradar` namespace.
 - Fetches the edge public IP and Basic Auth settings from Terraform outputs.
 - Reads the Basic Auth password from SSM Parameter Store to validate edge endpoints externally, including a JSON contract check on `/api/flights`.
+  - Validates edge TLS SSM artifacts explicitly before Nginx and external endpoint checks.
+  - Validates public TLS with `openssl s_client` against edge IP:443 and enforces at least 14 days of remaining validity.
+  - When `dns_zone_name` is available, HTTP checks use the DNS name with `--resolve <dns_name>:443:<edge_ip>` (no `-k`); otherwise they fall back to `-k` with an explicit warning.
   - Uses bounded polling for SSM command status to avoid long Pending/InProgress waits.
 
 Success signals for `/api/flights` smoke:

--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -2,6 +2,21 @@
 
 This log tracks incidents and fixes in reverse chronological order. Use it for debugging patterns and onboarding.
 
+## 2026-03-09
+
+### [ci/infra] Edge TLS failure surfaced as generic `nginx inactive` in smoke tests
+- **Severity:** Medium
+- **Impact:** `ci-infra` smoke tests failed late with a generic Nginx readiness error, making TLS root-cause identification slow.
+- **Signal:** `SMOKE-TESTS` reported `Edge nginx not ready after 3 attempts` with `nginx_status=inactive`.
+- **Analysis:** The pipeline checked Nginx readiness and public HTTP endpoints, but lacked explicit TLS preflight and public certificate diagnostics in the same step.
+- **Resolution:**
+  1. Add explicit TLS artifact validation in SSM (`fullchain_pem`, `privkey_pem`, cert not expired, cert/key match).
+  2. Add edge TLS preflight via SSM before Nginx checks (`cloud-init status --wait`, `/etc/nginx/ssl/edge.crt`/`edge.key`, cert metadata, cert/key modulus match).
+  3. Add public TLS verification with `openssl s_client` and expiry guard (`>= 14 days`).
+  4. Use strict HTTPS checks with `--resolve` when `dns_zone_name` is available (fallback to `-k` only when DNS name is missing, with warning).
+  5. Add dedicated edge diagnostics on failure (`cloud-init-output`, `/tmp/ssm-tls-*.err`, `systemctl/journalctl nginx`).
+- **Guardrail:** Keep a TLS-specific preflight before edge health HTTP checks so cert boot issues fail with explicit, actionable errors.
+
 ## 2026-02-26
 
 ### [app/opensky] Cloud egress `522` mitigated with config-driven tunnel-primary/worker-fallback routing


### PR DESCRIPTION
## Summary
- added explicit TLS preflight checks in `SMOKE-TESTS` before edge HTTP probes (SSM artifacts, edge file presence, cert/key match)
- added public TLS verification with `openssl s_client` and expiry guard, plus strict HTTPS checks via DNS `--resolve` when available
- added dedicated edge diagnostics on failure (`cloud-init-output`, `/tmp/ssm-tls-*.err`, `systemctl`/`journalctl nginx`)
- updated CI runbook and troubleshooting journal with the new behavior and guardrails

## Validation
- `git diff --check`
- inspected failed run `22847703696` logs and aligned smoke checks to explicit TLS failure modes

Fixes #539
