### PR TITLE
ci(infra): detect and clean orphan EBS volumes after destroy

### DIFF
--- a/k8s/apps/storageclass-gp3.yaml
+++ b/k8s/apps/storageclass-gp3.yaml
@@ -12,3 +12,7 @@ parameters:
   type: gp3
   fsType: ext4
   encrypted: "true"
+  tagSpecification_1: "Project=cloudradar"
+  tagSpecification_2: "Environment=dev"
+  tagSpecification_3: "managed-by=terraform"
+  tagSpecification_4: "Component=k8s-ebs-csi"

--- a/scripts/ci/find-orphans.sh
+++ b/scripts/ci/find-orphans.sh
@@ -171,6 +171,36 @@ if (( finding_count > 0 )); then
   status="FAIL"
 fi
 
+deleted_ebs_count=0
+skipped_ebs_count=0
+
+if [[ "${MODE}" == "post-destroy" && "${finding_count}" -gt 0 ]]; then
+  while IFS= read -r arn; do
+    case "${arn}" in
+      arn:aws:ec2:*:volume/*)
+        volume_id="${arn##*/}"
+        state="$(aws ec2 describe-volumes --volume-ids "${volume_id}" --query 'Volumes[0].State' --output text 2>/dev/null || echo "missing")"
+
+        if [[ "${state}" == "available" ]]; then
+          if aws ec2 delete-volume --volume-id "${volume_id}" >/dev/null 2>&1; then
+            echo "action: deleted orphan EBS volume ${volume_id}"
+            ((deleted_ebs_count+=1))
+          else
+            echo "warning: failed to delete orphan EBS volume ${volume_id}"
+            ((skipped_ebs_count+=1))
+          fi
+        else
+          echo "info: skip EBS volume ${volume_id} (state=${state})"
+          ((skipped_ebs_count+=1))
+        fi
+        ;;
+      *)
+        :
+        ;;
+    esac
+  done < "${findings_file}"
+fi
+
 echo "orphan-scan mode=${MODE} env=${ENVIRONMENT} status=${status}"
 echo "info: terraform_state_arn_count=${state_count}"
 echo "info: aws_tagged_arn_count=${tagged_count}"
@@ -190,6 +220,10 @@ if [[ -n "${SUMMARY_PATH}" ]]; then
     echo "- Terraform state ARNs: \`${state_count}\`"
     echo "- AWS tagged ARNs: \`${tagged_count}\`"
     echo "- Findings: \`${finding_count}\`"
+    if [[ "${MODE}" == "post-destroy" ]]; then
+      echo "- Deleted EBS volumes: \`${deleted_ebs_count}\`"
+      echo "- Skipped EBS volumes: \`${skipped_ebs_count}\`"
+    fi
     if (( finding_count == 0 )); then
       echo "- Result: no tagged-orphan resources detected."
     else


### PR DESCRIPTION
## Summary
- add tags on CSI-created EBS volumes so orphan-scan can detect them (`Project`, `Environment`, `managed-by`)
- extend `scripts/ci/find-orphans.sh` to delete orphan EBS volumes in `post-destroy` mode when they are `available`
- include deleted/skipped EBS counters in scan summary output

## Why
`ci-infra-destroy` could finish successfully while unattached EBS volumes remained in AWS because they were not discoverable by the existing tag-based scan.

## Validation
- `bash -n scripts/ci/find-orphans.sh`
- `kubectl kustomize k8s/apps` confirms StorageClass tag specifications
