### PR TITLE
test(qa): raise SonarCloud coverage above 80% with targeted tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ target/
 build/
 node_modules/
 dist/
+src/frontend/coverage/
 venv/
 __pycache__/
 *.class

--- a/src/dashboard/src/test/java/com/cloudradar/dashboard/aircraft/SqliteAircraftMetadataRepositoryTest.java
+++ b/src/dashboard/src/test/java/com/cloudradar/dashboard/aircraft/SqliteAircraftMetadataRepositoryTest.java
@@ -1,0 +1,118 @@
+package com.cloudradar.dashboard.aircraft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SqliteAircraftMetadataRepositoryTest {
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void constructorFailsWhenDatabaseIsMissing() {
+    Path missing = tempDir.resolve("missing.db");
+    assertThatThrownBy(() -> new SqliteAircraftMetadataRepository(missing, 10))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Aircraft DB not found");
+  }
+
+  @Test
+  void findByIcao24ReturnsMetadataAndUsesCache() throws Exception {
+    Path db = tempDir.resolve("aircraft.db");
+    try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + db.toAbsolutePath());
+         Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE aircraft ("
+              + "icao24 TEXT PRIMARY KEY,"
+              + "country TEXT,"
+              + "category_description TEXT,"
+              + "icao_aircraft_class TEXT,"
+              + "manufacturer_icao TEXT,"
+              + "manufacturer_name TEXT,"
+              + "model TEXT,"
+              + "registration TEXT,"
+              + "typecode TEXT,"
+              + "military_hint INTEGER,"
+              + "year_built INTEGER,"
+              + "owner_operator TEXT)");
+      st.execute(
+          "INSERT INTO aircraft VALUES "
+              + "('abc123','FR','A3','L2J','AIB','Airbus','A320','F-TEST','A320',1,2015,'Air France')");
+    }
+
+    try (SqliteAircraftMetadataRepository repository = new SqliteAircraftMetadataRepository(db, 10);
+         Connection conn = DriverManager.getConnection("jdbc:sqlite:" + db.toAbsolutePath());
+         Statement st = conn.createStatement()) {
+      AircraftMetadata first = repository.findByIcao24("ABC123").orElseThrow();
+      assertThat(first.country()).isEqualTo("FR");
+      assertThat(first.militaryHint()).isTrue();
+      assertThat(first.yearBuilt()).isEqualTo(2015);
+
+      // Delete backing row; second read should still resolve from cache.
+      st.execute("DELETE FROM aircraft WHERE icao24='abc123'");
+      AircraftMetadata second = repository.findByIcao24("abc123").orElseThrow();
+      assertThat(second.registration()).isEqualTo("F-TEST");
+    }
+  }
+
+  @Test
+  void findByIcao24HandlesMissingOptionalColumnsWithNullValues() throws Exception {
+    Path db = tempDir.resolve("aircraft-minimal.db");
+    try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + db.toAbsolutePath());
+         Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE aircraft ("
+              + "icao24 TEXT PRIMARY KEY,"
+              + "country TEXT,"
+              + "category_description TEXT,"
+              + "icao_aircraft_class TEXT,"
+              + "manufacturer_icao TEXT,"
+              + "manufacturer_name TEXT,"
+              + "model TEXT,"
+              + "registration TEXT,"
+              + "typecode TEXT)");
+      st.execute(
+          "INSERT INTO aircraft(icao24,country,category_description,icao_aircraft_class,manufacturer_icao,manufacturer_name,model,registration,typecode)"
+              + " VALUES ('def456','DE','A1','L1P','BOE','Boeing','737','D-TEST','B737')");
+    }
+
+    try (SqliteAircraftMetadataRepository repository = new SqliteAircraftMetadataRepository(db, 2)) {
+      AircraftMetadata metadata = repository.findByIcao24("def456").orElseThrow();
+      assertThat(metadata.ownerOperator()).isNull();
+      assertThat(metadata.yearBuilt()).isNull();
+      assertThat(metadata.militaryHint()).isNull();
+    }
+  }
+
+  @Test
+  void findByIcao24ReturnsEmptyForInvalidInputAndUnknownIcao() throws Exception {
+    Path db = tempDir.resolve("aircraft-empty.db");
+    try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + db.toAbsolutePath());
+         Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE aircraft ("
+              + "icao24 TEXT PRIMARY KEY,"
+              + "country TEXT,"
+              + "category_description TEXT,"
+              + "icao_aircraft_class TEXT,"
+              + "manufacturer_icao TEXT,"
+              + "manufacturer_name TEXT,"
+              + "model TEXT,"
+              + "registration TEXT,"
+              + "typecode TEXT)");
+    }
+
+    try (SqliteAircraftMetadataRepository repository = new SqliteAircraftMetadataRepository(db, 1)) {
+      assertThat(repository.findByIcao24(null)).isEmpty();
+      assertThat(repository.findByIcao24("   ")).isEmpty();
+      assertThat(repository.findByIcao24("zzz999")).isEmpty();
+    }
+  }
+}

--- a/src/dashboard/src/test/java/com/cloudradar/dashboard/service/BboxBoostServiceTest.java
+++ b/src/dashboard/src/test/java/com/cloudradar/dashboard/service/BboxBoostServiceTest.java
@@ -1,0 +1,135 @@
+package com.cloudradar.dashboard.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cloudradar.dashboard.api.BadRequestException;
+import com.cloudradar.dashboard.api.TooManyRequestsException;
+import com.cloudradar.dashboard.config.DashboardProperties;
+import com.cloudradar.dashboard.model.BboxBoostStatusResponse;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class BboxBoostServiceTest {
+
+  private StringRedisTemplate redisTemplate;
+  private ValueOperations<String, String> valueOps;
+  private DashboardProperties properties;
+  private BboxBoostService service;
+
+  @BeforeEach
+  void setUp() {
+    redisTemplate = mock(StringRedisTemplate.class);
+    valueOps = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    when(redisTemplate.getExpire(any(String.class), eq(TimeUnit.SECONDS))).thenReturn(0L);
+
+    properties = new DashboardProperties();
+    properties.getApi().getBbox().setDefaultValue("1,2,3,4");
+    properties.getBoost().setEnabled(true);
+    properties.getBoost().setFactor(2.0);
+    properties.getBoost().setDurationSeconds(120);
+    properties.getBoost().setCooldownSeconds(900);
+    properties.getBoost().setSecureCookie(true);
+    properties.getBoost().setIpHashSalt("test-salt");
+
+    service = new BboxBoostService(redisTemplate, properties);
+  }
+
+  @Test
+  void getStatusSetsClientCookieWhenMissing() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("10.0.0.1");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    BboxBoostStatusResponse status = service.getStatus(request, response);
+
+    assertThat(status.active()).isFalse();
+    assertThat(status.factor()).isEqualTo(2.0);
+    assertThat(status.bbox()).containsEntry("minLon", 1.0).containsEntry("maxLat", 4.0);
+    String setCookie = response.getHeader("Set-Cookie");
+    assertThat(setCookie).contains("cloudradar_boost_client=");
+    assertThat(setCookie).contains("HttpOnly");
+    assertThat(setCookie).contains("Secure");
+  }
+
+  @Test
+  void triggerBoostThrowsWhenDisabled() {
+    properties.getBoost().setEnabled(false);
+    service = new BboxBoostService(redisTemplate, properties);
+
+    assertThatThrownBy(() -> service.triggerBoost(new MockHttpServletRequest(), new MockHttpServletResponse()))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessage("bbox boost is disabled");
+  }
+
+  @Test
+  void triggerBoostThrowsWhenCooldownActive() {
+    when(redisTemplate.getExpire(any(String.class), eq(TimeUnit.SECONDS))).thenReturn(120L);
+
+    assertThatThrownBy(() -> service.triggerBoost(new MockHttpServletRequest(), new MockHttpServletResponse()))
+        .isInstanceOf(TooManyRequestsException.class)
+        .extracting("retryAfterSeconds")
+        .isEqualTo(120L);
+  }
+
+  @Test
+  void triggerBoostWritesRedisKeysAndReturnsActiveStatus() {
+    String activeKey = properties.getBoost().getActiveKey();
+    when(redisTemplate.getExpire(any(String.class), eq(TimeUnit.SECONDS)))
+        .thenAnswer(invocation -> {
+          String key = invocation.getArgument(0);
+          return activeKey.equals(key) ? 90L : 0L;
+        });
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Forwarded-For", "203.0.113.10, 10.0.0.1");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    BboxBoostStatusResponse status = service.triggerBoost(request, response);
+
+    assertThat(status.active()).isTrue();
+    assertThat(status.factor()).isEqualTo(2.0);
+    verify(valueOps).set(eq(activeKey), eq("1"), any());
+
+    ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(valueOps, org.mockito.Mockito.atLeast(3)).set(keyCaptor.capture(), eq("1"), any());
+    assertThat(keyCaptor.getAllValues())
+        .anySatisfy(key -> assertThat(key).startsWith(properties.getBoost().getCooldownPrefix() + "cookie:"))
+        .anySatisfy(key -> assertThat(key).startsWith(properties.getBoost().getCooldownPrefix() + "ip:"));
+  }
+
+  @Test
+  void statusClampsFactorBelowOneAndScalesBboxWhenActive() {
+    properties.getBoost().setFactor(0.5);
+    service = new BboxBoostService(redisTemplate, properties);
+
+    when(redisTemplate.getExpire(any(String.class), eq(TimeUnit.SECONDS)))
+        .thenAnswer(invocation -> {
+          String key = invocation.getArgument(0);
+          return properties.getBoost().getActiveKey().equals(key) ? 60L : 0L;
+        });
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("192.0.2.5");
+    request.setCookies(new jakarta.servlet.http.Cookie("cloudradar_boost_client", "cid-1"));
+
+    BboxBoostStatusResponse status = service.getStatus(request, new MockHttpServletResponse());
+
+    assertThat(status.active()).isTrue();
+    assertThat(status.factor()).isEqualTo(1.0);
+    assertThat(status.bbox().get("minLon")).isEqualTo(1.0);
+    assertThat(status.bbox().get("maxLon")).isEqualTo(3.0);
+  }
+}

--- a/src/frontend/src/api.test.ts
+++ b/src/frontend/src/api.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchBboxBoostStatus,
+  fetchFlightDetail,
+  fetchFlights,
+  fetchIngesterScale,
+  fetchIngesterScalePublic,
+  fetchMetrics,
+  scaleIngester,
+  subscribeFlightUpdates,
+  triggerBboxBoost
+} from './api';
+import { ADMIN_SCALE_PATH, API_FLIGHTS_BASE } from './constants';
+
+type Listener = (event: MessageEvent) => void;
+
+class MockEventSource {
+  public onerror: (() => void) | null = null;
+  public closed = false;
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  constructor(public readonly url: string) {}
+
+  addEventListener(type: string, listener: Listener): void {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set());
+    }
+    this.listeners.get(type)?.add(listener);
+  }
+
+  removeEventListener(type: string, listener: Listener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: string, payload: unknown): void {
+    const event = { data: JSON.stringify(payload) } as MessageEvent;
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  emitRaw(type: string, raw: string): void {
+    const event = { data: raw } as MessageEvent;
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+describe('api helpers', () => {
+  const fetchMock = vi.fn();
+  let lastEventSource: MockEventSource | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+
+    vi.stubGlobal(
+      'EventSource',
+      vi.fn((url: string) => {
+        lastEventSource = new MockEventSource(url);
+        return lastEventSource;
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('builds expected query for flights and calls fetch with JSON headers', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [], count: 0 })
+    });
+
+    await fetchFlights({ minLon: 1, minLat: 2, maxLon: 3, maxLat: 4 }, 123);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(`${API_FLIGHTS_BASE}?`);
+    expect(url).toContain('bbox=1%2C2%2C3%2C4');
+    expect(url).toContain('limit=123');
+    expect(url).toContain('sort=lastSeen');
+    expect(url).toContain('order=desc');
+    expect(options.credentials).toBe('same-origin');
+    expect((options.headers as Record<string, string>).Accept).toBe('application/json');
+  });
+
+  it('calls expected endpoints for detail/metrics/boost/admin status', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true })
+    });
+
+    await fetchFlightDetail('abc123');
+    await fetchMetrics({ minLon: 1, minLat: 2, maxLon: 3, maxLat: 4 });
+    await fetchBboxBoostStatus();
+    await triggerBboxBoost();
+    await fetchIngesterScalePublic();
+
+    const urls = fetchMock.mock.calls.map((call) => call[0] as string);
+    expect(urls).toContain(`${API_FLIGHTS_BASE}/abc123?include=track,enrichment`);
+    expect(urls.some((u) => u.startsWith(`${API_FLIGHTS_BASE}/metrics?`))).toBe(true);
+    expect(urls).toContain(`${API_FLIGHTS_BASE}/bbox/boost`);
+    expect(urls).toContain(ADMIN_SCALE_PATH);
+  });
+
+  it('uses basic auth for admin read/write calls', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 'ok' })
+    });
+
+    await fetchIngesterScale('admin', 'secret');
+    await scaleIngester(1, 'admin', 'secret');
+
+    const authRead = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    const authWrite = (fetchMock.mock.calls[1][1] as RequestInit).headers as Record<string, string>;
+    expect(authRead.Authorization).toMatch(/^Basic /);
+    expect(authWrite.Authorization).toMatch(/^Basic /);
+    expect((fetchMock.mock.calls[1][1] as RequestInit).method).toBe('POST');
+    expect((fetchMock.mock.calls[1][1] as RequestInit).body).toBe(JSON.stringify({ replicas: 1 }));
+  });
+
+  it('surfaces payload message on apiGet error and falls back to HTTP status text', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        json: async () => ({ message: 'cooldown active' })
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Server Error',
+        json: async () => {
+          throw new Error('non-json');
+        }
+      });
+
+    await expect(fetchBboxBoostStatus()).rejects.toThrow('cooldown active');
+    await expect(fetchFlights({ minLon: 1, minLat: 1, maxLon: 2, maxLat: 2 })).rejects.toThrow(
+      '500 Server Error'
+    );
+  });
+
+  it('prefers payload.error for authenticated calls and falls back to status text', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: async () => ({ error: 'invalid credentials', message: 'ignored' })
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        json: async () => {
+          throw new Error('non-json');
+        }
+      });
+
+    await expect(fetchIngesterScale('admin', 'bad')).rejects.toThrow('invalid credentials');
+    await expect(scaleIngester(0, 'admin', 'bad')).rejects.toThrow('403 Forbidden');
+  });
+
+  it('subscribes to flight stream, forwards valid events, ignores invalid JSON, and cleans up', () => {
+    const updates: unknown[] = [];
+    const errors = vi.fn();
+
+    const unsubscribe = subscribeFlightUpdates((evt) => updates.push(evt), errors);
+
+    expect(lastEventSource).not.toBeNull();
+    expect(lastEventSource?.url).toBe(`${API_FLIGHTS_BASE}/stream`);
+
+    lastEventSource?.emit('connected', {
+      latestOpenSkyBatchEpoch: 123,
+      timestamp: '2026-03-10T10:00:00Z'
+    });
+    lastEventSource?.emitRaw('batch-update', '{not-valid-json');
+    lastEventSource?.emit('batch-update', {
+      latestOpenSkyBatchEpoch: 'bad-type',
+      timestamp: '2026-03-10T10:01:00Z'
+    });
+    lastEventSource?.onerror?.();
+
+    expect(updates).toHaveLength(2);
+    expect((updates[0] as { latestOpenSkyBatchEpoch: number }).latestOpenSkyBatchEpoch).toBe(123);
+    expect((updates[1] as { latestOpenSkyBatchEpoch: null }).latestOpenSkyBatchEpoch).toBeNull();
+    expect(errors).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    expect(lastEventSource?.closed).toBe(true);
+  });
+});

--- a/src/frontend/src/components/DetailPanel.test.tsx
+++ b/src/frontend/src/components/DetailPanel.test.tsx
@@ -1,0 +1,192 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DetailPanel } from './DetailPanel';
+import type { FlightDetailResponse } from '../types';
+
+const baseDetail: FlightDetailResponse = {
+  icao24: 'abc123',
+  callsign: 'AFR123',
+  registration: 'F-ABCD',
+  manufacturer: 'Airbus',
+  model: 'A320',
+  typecode: 'A320',
+  category: 'A3',
+  lat: 48.8566,
+  lon: 2.3522,
+  heading: 180,
+  altitude: 10200,
+  groundSpeed: 250,
+  verticalRate: null,
+  lastSeen: 1_700_000_000,
+  onGround: false,
+  country: 'FR',
+  militaryHint: false,
+  yearBuilt: 2015,
+  ownerOperator: 'Air France',
+  photo: null,
+  recentTrack: [],
+  timestamp: '2026-03-10T12:00:00Z'
+};
+
+describe('DetailPanel', () => {
+  it('renders loading, error and empty states', () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <DetailPanel detail={null} fleetType={null} open={true} loading={true} error={null} onClose={onClose} />
+    );
+    expect(screen.getByText('loading detail...')).toBeInTheDocument();
+
+    rerender(
+      <DetailPanel
+        detail={null}
+        fleetType={null}
+        open={true}
+        loading={false}
+        error={'api down'}
+        onClose={onClose}
+      />
+    );
+    expect(screen.getByText('api down')).toBeInTheDocument();
+
+    rerender(
+      <DetailPanel detail={null} fleetType={null} open={true} loading={false} error={null} onClose={onClose} />
+    );
+    expect(screen.getByText('select an aircraft')).toBeInTheDocument();
+  });
+
+  it('renders detail values and formatting helpers', () => {
+    render(
+      <DetailPanel
+        detail={{ ...baseDetail, callsign: '', groundSpeed: 200, militaryHint: null }}
+        fleetType={' '}
+        open={true}
+        loading={false}
+        error={null}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByText('n/a').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/370\.4 km\/h/)).toBeInTheDocument();
+    expect(screen.getAllByText('unknown').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('last seen')).toBeInTheDocument();
+    expect(screen.getByText(/UTC/)).toBeInTheDocument();
+  });
+
+  it('renders photo status fallback messages', () => {
+    const { rerender } = render(
+      <DetailPanel
+        detail={{ ...baseDetail, photo: { ...basePhoto(), status: 'not_found' } }}
+        fleetType={'commercial'}
+        open={true}
+        loading={false}
+        error={null}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText('no photo found')).toBeInTheDocument();
+
+    rerender(
+      <DetailPanel
+        detail={{ ...baseDetail, photo: { ...basePhoto(), status: 'rate_limited' } }}
+        fleetType={'commercial'}
+        open={true}
+        loading={false}
+        error={null}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText('photo lookup rate-limited')).toBeInTheDocument();
+
+    rerender(
+      <DetailPanel
+        detail={{ ...baseDetail, photo: { ...basePhoto(), status: 'error' } }}
+        fleetType={'commercial'}
+        open={true}
+        loading={false}
+        error={null}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText('photo temporarily unavailable')).toBeInTheDocument();
+  });
+
+  it('opens and closes photo modal, handles image errors and close action', () => {
+    const onClose = vi.fn();
+    render(
+      <DetailPanel
+        detail={{
+          ...baseDetail,
+          photo: {
+            ...basePhoto(),
+            status: 'available',
+            thumbnailSrc: 'thumb.jpg',
+            thumbnailLargeSrc: 'large.jpg',
+            sourceLink: 'https://example.com/photo'
+          }
+        }}
+        fleetType={'commercial'}
+        open={true}
+        loading={false}
+        error={null}
+        onClose={onClose}
+      />
+    );
+
+    const openBtn = screen.getByLabelText('Open large aircraft photo');
+    fireEvent.click(openBtn);
+    expect(screen.getByRole('dialog', { name: 'Aircraft photo preview' })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('dialog', { name: 'Aircraft photo preview' })).not.toBeInTheDocument();
+
+    // Re-open then force large image failure and close via backdrop.
+    fireEvent.click(openBtn);
+    const largeImg = screen.getByAltText('Aircraft abc123 large');
+    fireEvent.error(largeImg);
+    expect(screen.queryByRole('dialog', { name: 'Aircraft photo preview' })).not.toBeInTheDocument();
+
+    const closeBtn = screen.getByLabelText('Close panel');
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back when thumbnail image fails to load', () => {
+    render(
+      <DetailPanel
+        detail={{
+          ...baseDetail,
+          photo: {
+            ...basePhoto(),
+            status: 'available',
+            thumbnailSrc: 'thumb.jpg',
+            thumbnailLargeSrc: null
+          }
+        }}
+        fleetType={'commercial'}
+        open={true}
+        loading={false}
+        error={null}
+        onClose={vi.fn()}
+      />
+    );
+
+    const thumb = screen.getByAltText('Aircraft abc123');
+    fireEvent.error(thumb);
+    expect(screen.getByText('n/a')).toBeInTheDocument();
+  });
+});
+
+function basePhoto() {
+  return {
+    status: 'available' as const,
+    thumbnailSrc: null,
+    thumbnailWidth: null,
+    thumbnailHeight: null,
+    thumbnailLargeSrc: null,
+    thumbnailLargeWidth: null,
+    thumbnailLargeHeight: null,
+    photographer: null,
+    sourceLink: null
+  };
+}

--- a/src/ingester/src/test/java/com/cloudradar/ingester/FlightIngestJobTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/FlightIngestJobTest.java
@@ -3,6 +3,8 @@ package com.cloudradar.ingester;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import com.cloudradar.ingester.config.IngesterProperties;
@@ -177,6 +179,53 @@ class FlightIngestJobTest {
     assertThat(invokeQuotaOrDefault(job)).isEqualTo(4000.0);
   }
 
+  @Test
+  void ingestAppliesProgressiveBackoffOnConsecutiveFailures() {
+    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
+    RedisPublisher redisPublisher = mock(RedisPublisher.class);
+    when(openSkyClient.fetchStates()).thenThrow(new RuntimeException("opensky down"));
+
+    FlightIngestJob job = new FlightIngestJob(
+        openSkyClient,
+        redisPublisher,
+        new SimpleMeterRegistry(),
+        buildProperties());
+
+    job.ingest();
+    assertThat(readAtomicLongField(job, "currentBackoffSeconds")).isEqualTo(1L);
+    assertThat(readBooleanField(job, "disabled")).isFalse();
+
+    forceNextCycle(job);
+    job.ingest();
+    assertThat(readAtomicLongField(job, "currentBackoffSeconds")).isEqualTo(2L);
+    assertThat(readBooleanField(job, "disabled")).isFalse();
+  }
+
+  @Test
+  void ingestDisablesAfterTooManyFailures() {
+    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
+    RedisPublisher redisPublisher = mock(RedisPublisher.class);
+    when(openSkyClient.fetchStates()).thenThrow(new RuntimeException("still down"));
+
+    FlightIngestJob job = new FlightIngestJob(
+        openSkyClient,
+        redisPublisher,
+        new SimpleMeterRegistry(),
+        buildProperties());
+
+    setAtomicIntField(job, "consecutiveFailures", 10);
+    forceNextCycle(job);
+    job.ingest();
+
+    assertThat(readBooleanField(job, "disabled")).isTrue();
+    assertThat(readAtomicLongField(job, "currentBackoffSeconds")).isZero();
+    assertThat(readLongField(job, "nextAllowedAtMs")).isEqualTo(Long.MAX_VALUE);
+
+    // Once disabled, ingest should return immediately.
+    job.ingest();
+    verify(openSkyClient, times(1)).fetchStates();
+  }
+
   private IngesterProperties buildProperties() {
     return buildPropertiesWithQuota(4000L);
   }
@@ -248,6 +297,26 @@ class FlightIngestJobTest {
       return field.getLong(target);
     } catch (ReflectiveOperationException ex) {
       throw new IllegalStateException("Unable to read test field: " + fieldName, ex);
+    }
+  }
+
+  private boolean readBooleanField(Object target, String fieldName) {
+    try {
+      Field field = FlightIngestJob.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getBoolean(target);
+    } catch (ReflectiveOperationException ex) {
+      throw new IllegalStateException("Unable to read test field: " + fieldName, ex);
+    }
+  }
+
+  private void setAtomicIntField(Object target, String fieldName, int value) {
+    try {
+      Field field = FlightIngestJob.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      ((java.util.concurrent.atomic.AtomicInteger) field.get(target)).set(value);
+    } catch (ReflectiveOperationException ex) {
+      throw new IllegalStateException("Unable to set test field: " + fieldName, ex);
     }
   }
 }

--- a/src/processor/src/test/java/com/cloudradar/processor/aircraft/SqliteAircraftMetadataRepositoryTest.java
+++ b/src/processor/src/test/java/com/cloudradar/processor/aircraft/SqliteAircraftMetadataRepositoryTest.java
@@ -1,0 +1,118 @@
+package com.cloudradar.processor.aircraft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SqliteAircraftMetadataRepositoryTest {
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void constructorFailsWhenDatabaseIsMissing() {
+    Path missing = tempDir.resolve("missing.db");
+    assertThatThrownBy(() -> new SqliteAircraftMetadataRepository(missing, 10))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Aircraft DB not found");
+  }
+
+  @Test
+  void findByIcao24ReturnsMetadataAndUsesCache() throws Exception {
+    Path db = tempDir.resolve("aircraft.db");
+    try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + db.toAbsolutePath());
+         Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE aircraft ("
+              + "icao24 TEXT PRIMARY KEY,"
+              + "country TEXT,"
+              + "category_description TEXT,"
+              + "icao_aircraft_class TEXT,"
+              + "manufacturer_icao TEXT,"
+              + "manufacturer_name TEXT,"
+              + "model TEXT,"
+              + "registration TEXT,"
+              + "typecode TEXT,"
+              + "military_hint INTEGER,"
+              + "year_built INTEGER,"
+              + "owner_operator TEXT)");
+      st.execute(
+          "INSERT INTO aircraft VALUES "
+              + "('abc123','FR','A3','L2J','AIB','Airbus','A320','F-TEST','A320',0,2012,'Air France')");
+    }
+
+    try (SqliteAircraftMetadataRepository repository = new SqliteAircraftMetadataRepository(db, 10);
+         Connection conn = DriverManager.getConnection("jdbc:sqlite:" + db.toAbsolutePath());
+         Statement st = conn.createStatement()) {
+      AircraftMetadata first = repository.findByIcao24("ABC123").orElseThrow();
+      assertThat(first.country()).isEqualTo("FR");
+      assertThat(first.militaryHint()).isFalse();
+      assertThat(first.yearBuilt()).isEqualTo(2012);
+
+      // Delete backing row; second read should still resolve from cache.
+      st.execute("DELETE FROM aircraft WHERE icao24='abc123'");
+      AircraftMetadata second = repository.findByIcao24("abc123").orElseThrow();
+      assertThat(second.registration()).isEqualTo("F-TEST");
+    }
+  }
+
+  @Test
+  void findByIcao24HandlesMissingOptionalColumnsWithNullValues() throws Exception {
+    Path db = tempDir.resolve("aircraft-minimal.db");
+    try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + db.toAbsolutePath());
+         Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE aircraft ("
+              + "icao24 TEXT PRIMARY KEY,"
+              + "country TEXT,"
+              + "category_description TEXT,"
+              + "icao_aircraft_class TEXT,"
+              + "manufacturer_icao TEXT,"
+              + "manufacturer_name TEXT,"
+              + "model TEXT,"
+              + "registration TEXT,"
+              + "typecode TEXT)");
+      st.execute(
+          "INSERT INTO aircraft(icao24,country,category_description,icao_aircraft_class,manufacturer_icao,manufacturer_name,model,registration,typecode)"
+              + " VALUES ('def456','DE','A1','L1P','BOE','Boeing','737','D-TEST','B737')");
+    }
+
+    try (SqliteAircraftMetadataRepository repository = new SqliteAircraftMetadataRepository(db, 2)) {
+      AircraftMetadata metadata = repository.findByIcao24("def456").orElseThrow();
+      assertThat(metadata.ownerOperator()).isNull();
+      assertThat(metadata.yearBuilt()).isNull();
+      assertThat(metadata.militaryHint()).isNull();
+    }
+  }
+
+  @Test
+  void findByIcao24ReturnsEmptyForInvalidInputAndUnknownIcao() throws Exception {
+    Path db = tempDir.resolve("aircraft-empty.db");
+    try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + db.toAbsolutePath());
+         Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE aircraft ("
+              + "icao24 TEXT PRIMARY KEY,"
+              + "country TEXT,"
+              + "category_description TEXT,"
+              + "icao_aircraft_class TEXT,"
+              + "manufacturer_icao TEXT,"
+              + "manufacturer_name TEXT,"
+              + "model TEXT,"
+              + "registration TEXT,"
+              + "typecode TEXT)");
+    }
+
+    try (SqliteAircraftMetadataRepository repository = new SqliteAircraftMetadataRepository(db, 1)) {
+      assertThat(repository.findByIcao24(null)).isEmpty();
+      assertThat(repository.findByIcao24("   ")).isEmpty();
+      assertThat(repository.findByIcao24("zzz999")).isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add focused frontend tests for API utils and DetailPanel rendering branches
- add backend unit tests for bbox boost TTL logic and SQLite metadata repositories
- extend ingester job tests for disabled mode and retry/backoff failure path
- ignore generated Vitest coverage artifacts in git

## Validation
- npm run test:coverage (frontend > 82%)
- mvn verify for dashboard, ingester, processor
- estimated repo aggregate coverage ~82.6%

Closes #546