### PR TITLE
feat(demo): add statusz badge endpoint and map interaction tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://cloudradar.iotx.fr">
-    <img src="https://img.shields.io/website?url=https%3A%2F%2Fcloudradar.iotx.fr%2Fhealthz&up_message=live&down_message=offline%20(cost-save)&style=for-the-badge&label=CloudRadar%20Live%20Demo&logo=googlechrome&logoColor=white" alt="CloudRadar Live Demo status" />
+    <img src="https://img.shields.io/website?url=https%3A%2F%2Fcloudradar.iotx.fr%2Fstatusz&up_message=live&down_message=offline%20(cost-save)&style=for-the-badge&label=CloudRadar%20Live%20Demo&logo=googlechrome&logoColor=white" alt="CloudRadar Live Demo status" />
   </a>
   <a href="https://github.com/ClementV78">
     <img src="https://img.shields.io/badge/GitHub-@ClementV78-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub Profile" />
@@ -85,6 +85,16 @@ Evidence: [Decision records](docs/architecture/decisions/) · [Workflow gates](.
     </tr>
   </tbody>
 </table>
+
+<p align="center">
+  <strong>Try the map interaction:</strong> click any aircraft marker to open its detail panel (callsign, altitude, speed, heading, origin country, and last update).
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/1-Open%20Live%20Demo-0A66C2?style=for-the-badge" alt="Step 1 Open Live Demo" />
+  <img src="https://img.shields.io/badge/2-Click%20an%20Aircraft-1F883D?style=for-the-badge" alt="Step 2 Click an Aircraft" />
+  <img src="https://img.shields.io/badge/3-View%20Flight%20Details-8957E5?style=for-the-badge" alt="Step 3 View Flight Details" />
+</p>
 
 ---
 

--- a/infra/aws/modules/edge/templates/nginx.conf.tpl
+++ b/infra/aws/modules/edge/templates/nginx.conf.tpl
@@ -40,6 +40,13 @@ server {
   auth_basic "CloudRadar";
   auth_basic_user_file /etc/nginx/.htpasswd;
 
+  location = /statusz {
+    # Public synthetic status endpoint for README badge.
+    auth_basic off;
+    add_header Content-Type text/plain;
+    return 200 'ok';
+  }
+
   location = /healthz {
     # Route health checks to the private backend.
     proxy_pass http://health_upstream;

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -381,6 +381,7 @@ export default function App(): JSX.Element {
   const [ingesterLoading, setIngesterLoading] = useState(false);
   const [ingesterPendingTarget, setIngesterPendingTarget] = useState<0 | 1 | null>(null);
   const [activeKpiTab, setActiveKpiTab] = useState<KpiTab>('traffic');
+  const [showMapHint, setShowMapHint] = useState(true);
   const lastBatchEpochRef = useRef<number | null>(null);
   const hasMetricsRef = useRef<boolean>(false);
   const missingSelectionCyclesRef = useRef<number>(0);
@@ -1008,6 +1009,26 @@ export default function App(): JSX.Element {
 
       <section className="map-shell glass-panel">
         {refreshError && <div className="refresh-error">{refreshError}</div>}
+        {showMapHint && (
+          <div className={`map-hint${refreshError ? ' has-error' : ''}`} role="note" aria-live="polite">
+            <span className="map-hint-text">
+              <span className="map-hint-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false">
+                  <path d="M21 13v-2l-8-3V3.5a1.5 1.5 0 0 0-3 0V8l-7 3v2l7-1.5V16l-2 1.5V19l3.5-1 3.5 1v-1.5L13 16v-4.5z" />
+                </svg>
+              </span>
+              <span>Tip: click an aircraft to open flight details.</span>
+            </span>
+            <button
+              type="button"
+              className="map-hint-close"
+              aria-label="Dismiss map tip"
+              onClick={() => setShowMapHint(false)}
+            >
+              ×
+            </button>
+          </div>
+        )}
         {mapTheme === 'satellite' && <div className="map-dark-overlay" />}
 
         <MapContainer center={MAP_CENTER} zoom={8} maxBounds={MAX_BOUNDS} maxBoundsViscosity={1.0} zoomControl={false}>

--- a/src/frontend/src/styles.css
+++ b/src/frontend/src/styles.css
@@ -338,6 +338,72 @@ body,
   padding: 8px 10px;
 }
 
+.map-hint {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 500;
+  max-width: min(520px, calc(100% - 24px));
+  padding: 7px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 245, 255, 0.38);
+  background: rgba(6, 15, 26, 0.8);
+  color: #b9f6ff;
+  font-size: 0.86rem;
+  line-height: 1.35;
+  letter-spacing: 0.01em;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.map-hint span {
+  font-weight: 500;
+}
+
+.map-hint-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.map-hint-icon {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 245, 255, 0.45);
+  background: rgba(0, 245, 255, 0.1);
+  flex: 0 0 auto;
+}
+
+.map-hint-icon svg {
+  width: 12px;
+  height: 12px;
+  fill: #9ef6ff;
+}
+
+.map-hint-close {
+  border: 0;
+  background: transparent;
+  color: #d5f9ff;
+  font-size: 1.05rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+
+.map-hint-close:hover {
+  color: #ffffff;
+}
+
+.map-hint.has-error {
+  top: 52px;
+}
+
 .map-legend-shell {
   position: absolute;
   left: 12px;
@@ -1184,6 +1250,18 @@ body,
 }
 
 @media (max-width: 768px) {
+  .map-hint {
+    top: 8px;
+    left: 8px;
+    max-width: calc(100% - 16px);
+    font-size: 0.78rem;
+    padding: 6px 9px;
+  }
+
+  .map-hint.has-error {
+    top: 46px;
+  }
+
   .map-legend-shell {
     left: 8px;
     right: 8px;


### PR DESCRIPTION
## Summary
- add a public edge endpoint `GET /statusz` returning static `200 ok` for synthetic live-demo checks
- switch the README live-demo badge target from `/healthz` to `/statusz`
- add an in-app map tip explaining the aircraft click interaction
- improve tip UX with better readability, plane icon, and dismiss button

## Validation
- npm test -- --run src/App.test.tsx
- local nginx template review for `/statusz` routing behavior
