### PR TITLE
docs(k8s): clarify ArgoCD applications vs workloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # CloudRadar - Real-Time Flight Telemetry Platform on AWS & Kubernetes
 
-> End-to-end DevOps & Cloud Architecture portfolio: Terraform, k3s, GitOps, CI/CD, Observability. Designed, built, and operated solo.
-
+> End-to-end DevOps & Cloud Architecture portfolio: Terraform, k3s, GitOps, CI/CD, Observability.
 <p align="center">
   <a href="https://cloudradar.iotx.fr">
     <img src="https://img.shields.io/website?url=https%3A%2F%2Fcloudradar.iotx.fr%2Fstatusz&up_message=live&down_message=offline%20(cost-save)&style=for-the-badge&label=CloudRadar%20Live%20Demo&logo=googlechrome&logoColor=white" alt="CloudRadar Live Demo status" />
@@ -9,6 +8,7 @@
   <a href="https://github.com/ClementV78">
     <img src="https://img.shields.io/badge/GitHub-@ClementV78-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub Profile" />
   </a>
+  <br/><sub>Click the <strong>CloudRadar Live Demo</strong> badge to open the app.</sub>
 </p>
 
 ![AWS](https://img.shields.io/badge/Cloud-AWS-232F3E?style=flat&logo=amazon-aws&logoColor=white)
@@ -90,12 +90,6 @@ Evidence: [Decision records](docs/architecture/decisions/) · [Workflow gates](.
   <strong>Try the map interaction:</strong> click any aircraft marker to open its detail panel (callsign, altitude, speed, heading, origin country, and last update).
 </p>
 
-<p align="center">
-  <img src="https://img.shields.io/badge/1-Open%20Live%20Demo-0A66C2?style=for-the-badge" alt="Step 1 Open Live Demo" />
-  <img src="https://img.shields.io/badge/2-Click%20an%20Aircraft-1F883D?style=for-the-badge" alt="Step 2 Click an Aircraft" />
-  <img src="https://img.shields.io/badge/3-View%20Flight%20Details-8957E5?style=for-the-badge" alt="Step 3 View Flight Details" />
-</p>
-
 ---
 
 ### Pipeline flow
@@ -103,26 +97,17 @@ Evidence: [Decision records](docs/architecture/decisions/) · [Workflow gates](.
 ```mermaid
 flowchart LR
   subgraph ING["Ingestion"]
-    A["OpenSky API"] --> B["Ingester<br/>Java 17"]
+    OS["OpenSky API"] --> IN["Ingester<br/>Java 17"]
   end
-
   subgraph PROC["Processing"]
-    B --> C["Redis Queue"]
-    C --> D["Processor<br/>Java 17"]
-    D --> E["Redis Aggregates"]
+    RQ["Redis Queue"] --> PR["Processor<br/>Java 17"] --> RA["Redis Aggregates"]
+  end
+  subgraph SERV["Serving"]
+    DA["Dashboard API"] --> FE["Frontend<br/>React + Leaflet"]
   end
 
-  subgraph SERVE["Serving"]
-    E --> F["Dashboard API"]
-    F --> G["Frontend<br/>React + Leaflet"]
-  end
-
-  classDef ext fill:#e3f2fd,stroke:#1e88e5,color:#0d47a1;
-  classDef app fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20;
-  classDef data fill:#fff3e0,stroke:#ef6c00,color:#e65100;
-  class A ext;
-  class B,D,F,G app;
-  class C,E data;
+  IN --> RQ
+  RA --> DA
 ```
 
 ### Key Design Decisions

--- a/docs/architecture/application-architecture.md
+++ b/docs/architecture/application-architecture.md
@@ -472,6 +472,9 @@ sequenceDiagram
 
 All services are deployed via ArgoCD Applications in `k8s/apps/`:
 
+Reference for GitOps object semantics (Application CR vs runtime workloads) and the canonical mapping table:  
+[`k8s/README.md#argocd-applications-vs-kubernetes-workloads`](../../k8s/README.md#argocd-applications-vs-kubernetes-workloads)
+
 ```
 k8s/apps/
 ├── ingester/

--- a/docs/runbooks/ci-cd/ci-infra.md
+++ b/docs/runbooks/ci-cd/ci-infra.md
@@ -85,6 +85,17 @@ The manual dispatch runs a chained set of jobs (visible in the Actions graph):
    - Logs explicit decision and reason (`RUN` / `SKIPPED`) in both logs and Step Summary.
    - Uses signal-focused annotations (decision/outcome) instead of internal `command_id` noise.
 
+### ArgoCD semantics in this workflow
+
+- `argocd-platform` and `argocd-apps` create/update **ArgoCD Application CRs** (controllers), not pod workloads directly.
+- ArgoCD then reconciles those Applications into runtime Kubernetes workloads (Deployments/StatefulSets/Services/Ingress/CRs).
+- In practice:
+  - `cloudradar-platform` (source `k8s/platform`) installs platform prerequisites (notably ESO operator/config chain).
+  - `cloudradar` (source `k8s/apps`) reconciles product/data/monitoring workloads and child Applications.
+
+Canonical mapping table (Application -> source -> target namespace -> workloads):  
+[`k8s/README.md`](../../../k8s/README.md#argocd-applications-vs-kubernetes-workloads)
+
 All manual-dispatch jobs now emit a short Step Summary block (status + key signal) to make run diagnostics scannable from the workflow page.
 
 ## Workflow diagram (Mermaid)

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -32,6 +32,21 @@ k8s/
 - **Namespaces**: `apps` for workloads, `monitoring` for Prom/Grafana, `external-secrets` for ESO controllers; SecretStore is cluster-scoped, ExternalSecrets live in `default` unless specified.
 - **Ordering for ESO**: Operator installs CRDs first (wave 0), config applies SecretStore/ExternalSecrets second (wave 1) with `SkipDryRunOnMissingResource=true`.
 
+## ArgoCD Applications vs Kubernetes workloads
+
+In this repository, an **ArgoCD Application** is a GitOps controller object (kind `Application`) that points to a Git path or Helm chart.  
+It is **not** the runtime workload itself. Runtime objects are Kubernetes resources (Deployments, StatefulSets, Services, Ingresses, CRs) created by ArgoCD reconciliation.
+
+| ArgoCD Application | Source (path/chart) | Target namespace | Workloads created | Notes |
+|---|---|---|---|---|
+| `cloudradar-platform` (root, bootstrap-created) | Git path `k8s/platform` | `argocd` | Platform baseline resources + child apps (`external-secrets-operator`, `external-secrets-config`) | Root app created by `scripts/bootstrap-argocd-app.sh`; owns platform layer ordering |
+| `external-secrets-operator` | Helm `charts.external-secrets.io/external-secrets` (`0.10.2`) | `external-secrets` | ESO controller resources (Deployment/ServiceAccount/Service) + ESO CRDs | Sync wave `0` (CRDs first) |
+| `external-secrets-config` | Git path `k8s/apps/external-secrets` | `external-secrets` | `ClusterSecretStore` + `ExternalSecret` objects (`grafana-admin`, `grafana-domain`, `opensky-secret`, `processor-aircraft-db`, `cloudradar-alertmanager-config`) | Sync wave `1`; depends on ESO CRDs |
+| `cloudradar` (root, bootstrap-created) | Git path `k8s/apps` | `cloudradar` | Core app workloads (`admin-scale`, `frontend`, `health`, `dashboard`, `ingester`, `processor`), data workloads (`redis`, `redis-exporter`), monitoring manifests, storage class, and child apps (`ebs-csi-driver`, `prometheus`, `grafana`) | Root app for product workloads; may include `ignoreDifferences` on `ingester.spec.replicas` |
+| `ebs-csi-driver` | Helm `kubernetes-sigs/aws-ebs-csi-driver` (`2.34.0`) | `kube-system` | EBS CSI controller/node resources and related RBAC/CSI objects | Enables dynamic PVC provisioning for stateful workloads |
+| `prometheus` | Helm `prometheus-community/kube-prometheus-stack` (`81.4.2`) | `monitoring` | Prometheus Operator stack (Prometheus/Alertmanager/ServiceMonitors/PodMonitors/Rules and related resources) | `ServerSideApply=true` enabled in app sync options |
+| `grafana` | Helm `grafana-community/grafana` (`10.5.15`) | `monitoring` | Grafana Deployment/Service + datasources/dashboard provisioning | Grafana admin/domain secrets are provided by ESO |
+
 ## How to add a new app
 1) Create a subfolder under `k8s/apps/<app>` with its manifests and a `kustomization.yaml`.
 2) Reference the folder in `k8s/apps/kustomization.yaml`.

--- a/k8s/platform/external-secrets/config-application.yaml
+++ b/k8s/platform/external-secrets/config-application.yaml
@@ -13,7 +13,7 @@ spec:
     path: k8s/apps/external-secrets
   destination:
     server: https://kubernetes.default.svc
-    namespace: default
+    namespace: external-secrets
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Summary
- clarified ArgoCD Application CR vs runtime workload semantics in the Kubernetes docs
- added a canonical mapping table (Application -> source -> target namespace -> workloads -> notes)
- added short operational guidance in ci-infra runbook for argocd-platform and argocd-apps
- aligned external-secrets-config destination namespace to external-secrets for consistency/readability

## Validation
- docs links checked locally
- mapping entries verified against current manifests under k8s/apps and k8s/platform

Closes #215
Refs #57
