### PR TITLE
feat(frontend): redesign aircraft icons with multi-element SVG

### DIFF
--- a/src/frontend/src/aircraftVisuals.ts
+++ b/src/frontend/src/aircraftVisuals.ts
@@ -68,147 +68,162 @@ function sizeFactors(size: FlightMapItem['aircraftSize']): {
 } {
   switch (size) {
     case 'small':
-      return { wingSpan: 7.8, tailSpan: 3.8, fuselageHalf: 1.9 };
+      return { wingSpan: 7.8, tailSpan: 3.8, fuselageHalf: 2.2 };
     case 'large':
-      return { wingSpan: 12.6, tailSpan: 6.0, fuselageHalf: 2.7 };
+      return { wingSpan: 12.6, tailSpan: 6.0, fuselageHalf: 3.0 };
     case 'heavy':
-      return { wingSpan: 14.8, tailSpan: 7.3, fuselageHalf: 3.2 };
+      return { wingSpan: 14.8, tailSpan: 7.3, fuselageHalf: 3.4 };
     case 'medium':
-      return { wingSpan: 10.4, tailSpan: 4.9, fuselageHalf: 2.2 };
+      return { wingSpan: 10.4, tailSpan: 4.9, fuselageHalf: 2.6 };
     case 'unknown':
     default:
-      return { wingSpan: 9.3, tailSpan: 4.3, fuselageHalf: 2.1 };
+      return { wingSpan: 9.3, tailSpan: 4.3, fuselageHalf: 2.4 };
   }
 }
 
-function commercialPath(size: FlightMapItem['aircraftSize']): string {
-  const x = 20;
-  const { wingSpan, tailSpan } = sizeFactors(size);
-  return `
-    M ${x} 3
-    L ${x + 2.2} 12
-    L ${x + wingSpan} 16.8
-    L ${x + wingSpan - 0.9} 20.0
-    L ${x + 2.8} 18.8
-    L ${x + tailSpan} 31.2
-    L ${x + tailSpan - 1.0} 35.4
-    L ${x + 2.4} 35.4
-    L ${x + 2.4} 38
-    L ${x - 2.4} 38
-    L ${x - 2.4} 35.4
-    L ${x - tailSpan + 1.0} 35.4
-    L ${x - tailSpan} 31.2
-    L ${x - 2.8} 18.8
-    L ${x - wingSpan + 0.9} 20.0
-    L ${x - wingSpan} 16.8
-    L ${x - 2.2} 12
-    Z
-  `;
+// --- Multi-element airplane glyphs (fuselage + wings + stabilizer) ---
+
+interface AirplaneGeometry {
+  /** Fuselage pill: top-y, bottom-y, half-width */
+  fuseTop: number;
+  fuseBot: number;
+  fuseHalf: number;
+  /** Wings: leading-edge-y at root, tip-x offset, tip leading-edge-y, chord at tip */
+  wingRootY: number;
+  wingTipX: number;
+  wingTipY: number;
+  wingChord: number;
+  /** Stabilizer: same idea but smaller */
+  stabRootY: number;
+  stabTipX: number;
+  stabTipY: number;
+  stabChord: number;
 }
 
-function militaryPath(size: FlightMapItem['aircraftSize']): string {
-  const x = 20;
-  const { wingSpan, tailSpan } = sizeFactors(size);
-  return `
-    M ${x} 3
-    L ${x + 2.8} 10.5
-    L ${x + wingSpan + 0.4} 19.5
-    L ${x + wingSpan - 2.6} 22.4
-    L ${x + 4.2} 20.8
-    L ${x + tailSpan + 1.7} 31.8
-    L ${x + 3.0} 35.4
-    L ${x + 2.1} 38
-    L ${x - 2.1} 38
-    L ${x - 3.0} 35.4
-    L ${x - tailSpan - 1.7} 31.8
-    L ${x - 4.2} 20.8
-    L ${x - wingSpan + 2.6} 22.4
-    L ${x - wingSpan - 0.4} 19.5
-    L ${x - 2.8} 10.5
-    Z
-  `;
-}
+function airplaneGeometry(
+  flight: AircraftVisualInput
+): AirplaneGeometry {
+  const { wingSpan: ws, tailSpan: ts } = sizeFactors(flight.aircraftSize);
+  const shape = resolveFleetShape(flight);
 
-function privatePath(size: FlightMapItem['aircraftSize']): string {
-  const x = 20;
-  const { wingSpan, tailSpan } = sizeFactors(size);
-  return `
-    M ${x} 4
-    L ${x + 1.6} 12
-    L ${x + wingSpan - 1.8} 14
-    L ${x + wingSpan - 1.4} 17.1
-    L ${x + 2.0} 16.4
-    L ${x + tailSpan} 28.5
-    L ${x + 1.8} 34
-    L ${x + 1.8} 38
-    L ${x - 1.8} 38
-    L ${x - 1.8} 34
-    L ${x - tailSpan} 28.5
-    L ${x - 2.0} 16.4
-    L ${x - wingSpan + 1.4} 17.1
-    L ${x - wingSpan + 1.8} 14
-    L ${x - 1.6} 12
-    Z
-  `;
-}
-
-function rescuePath(size: FlightMapItem['aircraftSize']): string {
-  const x = 20;
-  const { wingSpan, tailSpan } = sizeFactors(size);
-  return `
-    M ${x} 3.5
-    L ${x + 2.1} 11.5
-    L ${x + wingSpan - 0.7} 16
-    L ${x + wingSpan - 0.2} 19.1
-    L ${x + 2.7} 18.1
-    L ${x + tailSpan + 0.4} 30
-    L ${x + 2.4} 35
-    L ${x + 2.4} 38
-    L ${x - 2.4} 38
-    L ${x - 2.4} 35
-    L ${x - tailSpan - 0.4} 30
-    L ${x - 2.7} 18.1
-    L ${x - wingSpan + 0.2} 19.1
-    L ${x - wingSpan + 0.7} 16
-    L ${x - 2.1} 11.5
-    Z
-  `;
-}
-
-function unknownPath(size: FlightMapItem['aircraftSize']): string {
-  const x = 20;
-  const { wingSpan, tailSpan } = sizeFactors(size);
-  return `
-    M ${x} 4
-    L ${x + 2} 12
-    L ${x + wingSpan - 0.6} 18
-    L ${x + 4} 22
-    L ${x + tailSpan + 0.8} 31
-    L ${x + 2} 36
-    L ${x} 38
-    L ${x - 2} 36
-    L ${x - tailSpan - 0.8} 31
-    L ${x - 4} 22
-    L ${x - wingSpan + 0.6} 18
-    L ${x - 2} 12
-    Z
-  `;
-}
-
-function airplanePath(flight: AircraftVisualInput): string {
-  switch (resolveFleetShape(flight)) {
-    case 'military':
-      return militaryPath(flight.aircraftSize);
-    case 'private':
-      return privatePath(flight.aircraftSize);
-    case 'rescue':
-      return rescuePath(flight.aircraftSize);
-    case 'unknown':
-      return unknownPath(flight.aircraftSize);
+  switch (shape) {
     case 'commercial':
+      return {
+        fuseTop: 2, fuseBot: 37, fuseHalf: 2.6,
+        wingRootY: 12, wingTipX: ws + 0.5, wingTipY: 19, wingChord: 3,
+        stabRootY: 29, stabTipX: ts + 1, stabTipY: 33, stabChord: 2,
+      };
+    case 'military':
+      return {
+        fuseTop: 2, fuseBot: 36, fuseHalf: 2.8,
+        wingRootY: 10, wingTipX: ws + 2, wingTipY: 22, wingChord: 4,
+        stabRootY: 28, stabTipX: ts + 1.5, stabTipY: 33, stabChord: 2,
+      };
+    case 'private':
+      return {
+        fuseTop: 5, fuseBot: 36, fuseHalf: 2.4,
+        wingRootY: 14, wingTipX: ws + 1, wingTipY: 14, wingChord: 5,
+        stabRootY: 29, stabTipX: ts + 0.5, stabTipY: 29, stabChord: 3,
+      };
+    case 'rescue':
+      return {
+        fuseTop: 4, fuseBot: 37, fuseHalf: 2.4,
+        wingRootY: 14, wingTipX: ws + 0.5, wingTipY: 14, wingChord: 5,
+        stabRootY: 30, stabTipX: ts + 0.3, stabTipY: 30, stabChord: 3,
+      };
+    case 'unknown':
     default:
-      return commercialPath(flight.aircraftSize);
+      return {
+        fuseTop: 3, fuseBot: 37, fuseHalf: 2.3,
+        wingRootY: 14, wingTipX: ws, wingTipY: 15, wingChord: 3.5,
+        stabRootY: 30, stabTipX: ts, stabTipY: 31, stabChord: 2.5,
+      };
   }
+}
+
+function airplaneGlyph(
+  flight: AircraftVisualInput,
+  size: number,
+  color: string,
+  stroke: string,
+  outerStroke: string,
+  outerSW: number,
+  innerSW: number,
+  fleetShape: FleetShape,
+): string {
+  const g = airplaneGeometry(flight);
+  const x = 20;
+
+  // Fuselage: pill/capsule shape
+  const fusePath = `M ${x} ${g.fuseTop}
+    C ${x + g.fuseHalf + 0.5} ${g.fuseTop} ${x + g.fuseHalf + 0.5} ${g.fuseTop + 3} ${x + g.fuseHalf} ${g.fuseTop + 5}
+    L ${x + g.fuseHalf} ${g.fuseBot - 2}
+    C ${x + g.fuseHalf} ${g.fuseBot} ${x + 0.5} ${g.fuseBot + 1} ${x} ${g.fuseBot + 1}
+    C ${x - 0.5} ${g.fuseBot + 1} ${x - g.fuseHalf} ${g.fuseBot} ${x - g.fuseHalf} ${g.fuseBot - 2}
+    L ${x - g.fuseHalf} ${g.fuseTop + 5}
+    C ${x - g.fuseHalf - 0.5} ${g.fuseTop + 3} ${x - g.fuseHalf - 0.5} ${g.fuseTop} ${x} ${g.fuseTop}
+    Z`;
+
+  // Wings: swept trapezoid (leading edge straight to tip, trailing edge sweeps back)
+  const wRootLE = g.wingRootY;
+  const wRootTE = g.wingRootY + g.wingChord + 2;
+  const wTipLE = g.wingTipY;
+  const wTipTE = g.wingTipY + g.wingChord;
+  const wingPath = `M ${x + g.fuseHalf} ${wRootLE}
+    L ${x + g.wingTipX} ${wTipLE}
+    L ${x + g.wingTipX} ${wTipTE}
+    L ${x + g.fuseHalf} ${wRootTE}
+    Z
+    M ${x - g.fuseHalf} ${wRootLE}
+    L ${x - g.wingTipX} ${wTipLE}
+    L ${x - g.wingTipX} ${wTipTE}
+    L ${x - g.fuseHalf} ${wRootTE}
+    Z`;
+
+  // Stabilizer: smaller swept trapezoid
+  const sRootLE = g.stabRootY;
+  const sRootTE = g.stabRootY + g.stabChord + 1;
+  const sTipLE = g.stabTipY;
+  const sTipTE = g.stabTipY + g.stabChord;
+  const stabPath = `M ${x + g.fuseHalf} ${sRootLE}
+    L ${x + g.stabTipX} ${sTipLE}
+    L ${x + g.stabTipX} ${sTipTE}
+    L ${x + g.fuseHalf} ${sRootTE}
+    Z
+    M ${x - g.fuseHalf} ${sRootLE}
+    L ${x - g.stabTipX} ${sTipLE}
+    L ${x - g.stabTipX} ${sTipTE}
+    L ${x - g.fuseHalf} ${sRootTE}
+    Z`;
+
+  // Fleet-specific badge
+  const fleetExtra = fleetShape === 'rescue'
+    ? `<rect x="18.2" y="10" width="3.6" height="9" rx="0.8" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.5"/>
+       <rect x="15" y="12.5" width="10" height="3.6" rx="0.8" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.5"/>`
+    : fleetShape === 'military'
+      ? (() => {
+          const mxL = x - g.wingTipX + 2.5;
+          const mxR = x + g.wingTipX - 2.5;
+          const my = (g.wingTipY + g.wingTipY + g.wingChord) / 2;
+          const ml = 4;
+          return `<rect x="${mxL - 0.5}" y="${my - ml / 2}" width="1" height="${ml}" rx="0.5" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.5"/>
+                  <path d="M ${mxL} ${my + ml / 2} l -0.7 1 l 1.4 0 Z" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.3"/>
+                  <rect x="${mxR - 0.5}" y="${my - ml / 2}" width="1" height="${ml}" rx="0.5" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.5"/>
+                  <path d="M ${mxR} ${my + ml / 2} l -0.7 1 l 1.4 0 Z" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.3"/>`;
+        })()
+      : '';
+
+  return `
+    <svg viewBox="0 0 40 40" width="${size}" height="${size}" aria-hidden="true" shape-rendering="geometricPrecision">
+      <path d="${fusePath}" fill="${color}" stroke="${outerStroke}" stroke-width="${outerSW}" stroke-linejoin="round"/>
+      <path d="${fusePath}" fill="none" stroke="${stroke}" stroke-width="${innerSW}" stroke-linejoin="round"/>
+      <path d="${wingPath}" fill="${color}" stroke="${outerStroke}" stroke-width="${outerSW - 0.5}" stroke-linejoin="round"/>
+      <path d="${wingPath}" fill="none" stroke="${stroke}" stroke-width="${innerSW - 0.4}" stroke-linejoin="round"/>
+      <path d="${stabPath}" fill="${color}" stroke="${outerStroke}" stroke-width="${outerSW - 0.7}" stroke-linejoin="round"/>
+      <path d="${stabPath}" fill="none" stroke="${stroke}" stroke-width="${innerSW - 0.5}" stroke-linejoin="round"/>
+      ${fleetExtra}
+    </svg>
+  `;
 }
 
 export function markerGlyph(flight: AircraftVisualInput, size: number, selected: boolean): string {
@@ -220,57 +235,32 @@ export function markerGlyph(flight: AircraftVisualInput, size: number, selected:
   const fleetShape = resolveFleetShape(flight);
   const isRescue = fleetShape === 'rescue';
 
-  if (flight.airframeType === 'helicopter') {
-    const rescueBadge = isRescue
+  if (flight.airframeType !== 'helicopter') {
+    return airplaneGlyph(flight, size, color, stroke, outerStroke, outerStrokeWidth, innerStrokeWidth, fleetShape);
+  }
+
+  const rescueBadge = isRescue
       ? `
-        <rect x="17.4" y="15.6" width="5.2" height="9.4" rx="1.2" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.7"/>
-        <rect x="15.3" y="17.7" width="9.4" height="5.2" rx="1.2" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.7"/>
+        <rect x="17.4" y="14.5" width="5.2" height="8.6" rx="1.2" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.7"/>
+        <rect x="15.6" y="16.3" width="8.8" height="5.0" rx="1.2" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.7"/>
       `
       : '';
+    const bodyPath = 'M20 9 C24 9 26.5 12 26.5 15.5 L26.5 19.5 C26.5 23.5 24 26 20 26 C16 26 13.5 23.5 13.5 19.5 L13.5 15.5 C13.5 12 16 9 20 9 Z';
     return `
       <svg viewBox="0 0 40 40" width="${size}" height="${size}" aria-hidden="true" shape-rendering="geometricPrecision">
-        <rect x="6" y="9.6" width="28" height="2.8" rx="1.4" fill="${color}" stroke="${outerStroke}" stroke-width="${outerStrokeWidth}" />
-        <rect x="6" y="9.6" width="28" height="2.8" rx="1.4" fill="none" stroke="${stroke}" stroke-width="${innerStrokeWidth}" />
-        <path d="M20 8.8 C23.8 8.8 26.3 11.2 26.3 15.4 L26.3 19.5 C26.3 23.8 23.9 27 20 27 C16.1 27 13.7 23.8 13.7 19.5 L13.7 15.4 C13.7 11.2 16.2 8.8 20 8.8 Z" fill="${color}" stroke="${outerStroke}" stroke-width="${outerStrokeWidth}" />
-        <path d="M20 8.8 C23.8 8.8 26.3 11.2 26.3 15.4 L26.3 19.5 C26.3 23.8 23.9 27 20 27 C16.1 27 13.7 23.8 13.7 19.5 L13.7 15.4 C13.7 11.2 16.2 8.8 20 8.8 Z" fill="none" stroke="${stroke}" stroke-width="${innerStrokeWidth}" />
-        <path d="M20 26.6 L20 34.6" stroke="${outerStroke}" stroke-width="${outerStrokeWidth}" stroke-linecap="round" />
-        <path d="M20 26.6 L20 34.6" stroke="${stroke}" stroke-width="${innerStrokeWidth}" stroke-linecap="round" />
-        <circle cx="20" cy="35.8" r="2.1" fill="${color}" stroke="${outerStroke}" stroke-width="${outerStrokeWidth - 0.3}" />
-        <line x1="16.8" y1="35.8" x2="23.2" y2="35.8" stroke="${stroke}" stroke-width="${innerStrokeWidth - 0.3}" stroke-linecap="round" />
-        <line x1="20" y1="32.6" x2="20" y2="39" stroke="${stroke}" stroke-width="${innerStrokeWidth - 0.3}" stroke-linecap="round" />
+        <path d="${bodyPath}" fill="${color}" stroke="${outerStroke}" stroke-width="${outerStrokeWidth}" />
+        <path d="${bodyPath}" fill="none" stroke="${stroke}" stroke-width="${innerStrokeWidth}" />
+        <path d="M20 25.5 L20 34.5" stroke="${outerStroke}" stroke-width="${outerStrokeWidth}" stroke-linecap="round" />
+        <path d="M20 25.5 L20 34.5" stroke="${color}" stroke-width="${innerStrokeWidth}" stroke-linecap="round" />
+        <line x1="15" y1="35" x2="25" y2="35" stroke="${outerStroke}" stroke-width="${outerStrokeWidth - 0.4}" stroke-linecap="round" />
+        <line x1="15" y1="35" x2="25" y2="35" stroke="${color}" stroke-width="${innerStrokeWidth - 0.2}" stroke-linecap="round" />
+        <line x1="6" y1="5" x2="34" y2="21" stroke="${outerStroke}" stroke-width="${outerStrokeWidth - 0.3}" stroke-linecap="round" />
+        <line x1="6" y1="5" x2="34" y2="21" stroke="${color}" stroke-width="${innerStrokeWidth}" stroke-linecap="round" />
+        <line x1="34" y1="5" x2="6" y2="21" stroke="${outerStroke}" stroke-width="${outerStrokeWidth - 0.3}" stroke-linecap="round" />
+        <line x1="34" y1="5" x2="6" y2="21" stroke="${color}" stroke-width="${innerStrokeWidth}" stroke-linecap="round" />
+        <circle cx="20" cy="13" r="2.5" fill="${outerStroke}" />
+        <circle cx="20" cy="13" r="1.5" fill="${color}" />
         ${rescueBadge}
       </svg>
     `;
-  }
-
-  const shapePath = airplanePath(flight);
-  const fleetExtra = fleetShape === 'private'
-    ? `
-        <line x1="16.4" y1="8.4" x2="23.6" y2="8.4" stroke="${stroke}" stroke-width="1.3" stroke-linecap="round"/>
-        <line x1="20" y1="6.1" x2="20" y2="10.7" stroke="${stroke}" stroke-width="1.2" stroke-linecap="round"/>
-      `
-    : fleetShape === 'military'
-      ? `
-        <circle cx="13.4" cy="20.8" r="1.2" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.7"/>
-        <circle cx="26.6" cy="20.8" r="1.2" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.7"/>
-      `
-      : fleetShape === 'rescue'
-        ? `
-        <rect x="18" y="15" width="4" height="10" rx="1" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.7"/>
-        <rect x="15" y="18" width="10" height="4" rx="1" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.7"/>
-        `
-        : fleetShape === 'commercial'
-          ? `
-        <circle cx="20" cy="15.4" r="1.5" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.7" />
-      `
-      : '';
-
-  return `
-    <svg viewBox="0 0 40 40" width="${size}" height="${size}" aria-hidden="true" shape-rendering="geometricPrecision">
-      <path d="${shapePath}" fill="${color}" stroke="${outerStroke}" stroke-width="${outerStrokeWidth}" stroke-linejoin="round"/>
-      <path d="${shapePath}" fill="none" stroke="${stroke}" stroke-width="${innerStrokeWidth}" stroke-linejoin="round"/>
-      <circle cx="20" cy="13.7" r="1.2" fill="${stroke}" stroke="${outerStroke}" stroke-width="0.6" />
-      ${fleetExtra}
-    </svg>
-  `;
 }


### PR DESCRIPTION
## Summary

Redesign all aircraft icon SVGs using multi-element rendering (separate fuselage, wings, stabilizer paths) instead of single continuous path.

## Changes

- **Commercial**: swept wings, airliner silhouette
- **Military**: delta wings with missile badges under wings
- **Private**: straight wide wings (Cessna-style turboprop)
- **Rescue**: straight wings with cross badge on fuselage
- **Helicopter**: unchanged (oval body, X-rotor, tail boom)
- Multi-element approach gives much better readability at small zoom levels

## Tests

- 31/31 frontend tests pass
- Visual validation done via dev server

Closes #553