### PR TITLE
ci(quality): publish ArchUnit reports and consolidated static summary

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java 17
         uses: actions/setup-java@v4
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -163,7 +163,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install hadolint binary
         run: |
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Scan dependencies in src/
         uses: aquasecurity/trivy-action@master
@@ -224,7 +224,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load VERSION
         run: |
@@ -282,6 +282,10 @@ jobs:
     name: CI summary report
     runs-on: ubuntu-latest
     if: always()
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     needs:
       - java-tests
       - frontend-tests
@@ -290,7 +294,7 @@ jobs:
       - build-and-push
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download static analysis artifacts
         if: always() && needs['java-tests'].result == 'success'
@@ -299,6 +303,22 @@ jobs:
           pattern: quality-reports-*
           merge-multiple: true
           path: quality-reports
+
+      - name: Build static analysis markdown report
+        if: always() && needs['java-tests'].result == 'success' && github.event_name == 'pull_request'
+        run: |
+          python3 scripts/ci/quality-summary.py \
+            --root quality-reports \
+            --title "## Static Analysis Snapshot" \
+            --output quality-pr-report.md
+
+      - name: Build static analysis summary snippet
+        if: always() && needs['java-tests'].result == 'success'
+        run: |
+          python3 scripts/ci/quality-summary.py \
+            --root quality-reports \
+            --title "### Static Analysis Snapshot" \
+            --output quality-summary.md
 
       - name: Publish run summary
         run: |
@@ -327,14 +347,51 @@ jobs:
               echo "✅ All quality gates passed."
             fi
 
-            echo ""
-            echo "### Static Analysis Snapshot"
-            if [ "${{ needs['java-tests'].result }}" = "success" ] && [ -d "quality-reports" ]; then
-              python3 scripts/ci/quality-summary.py --root quality-reports
+            if [ "${{ needs['java-tests'].result }}" = "success" ] && [ -f "quality-summary.md" ]; then
+              echo ""
+              cat quality-summary.md
               echo ""
               echo "Detailed XML/SARIF reports are attached as workflow artifacts: \`quality-reports-<service>\`."
             else
+              echo ""
+              echo "### Static Analysis Snapshot"
               echo "_Static analysis summary unavailable (java-tests failed before artifact generation)._"
             fi
             echo "- SonarCloud dashboard: https://sonarcloud.io/project/overview?id=ClementV78_CloudRadar"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upsert sticky PR static-analysis comment
+        if: always() && github.event_name == 'pull_request' && needs['java-tests'].result == 'success' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ ! -f "quality-pr-report.md" ]; then
+            echo "quality-pr-report.md missing; skip comment update"
+            exit 0
+          fi
+
+          COMMENT_MARKER="<!-- cloudradar-static-analysis-report -->"
+          {
+            echo "${COMMENT_MARKER}"
+            echo ""
+            cat quality-pr-report.md
+            echo ""
+            echo "- Workflow run: ${RUN_URL}"
+            echo "- Artifacts: \`quality-reports-ingester\`, \`quality-reports-processor\`, \`quality-reports-dashboard\`"
+          } > quality-pr-comment.md
+
+          comment_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.user.login=="github-actions[bot]" and (.body | contains("<!-- cloudradar-static-analysis-report -->"))) | .id' \
+            | head -n1)"
+
+          jq -n --rawfile body quality-pr-comment.md '{body: $body}' > comment-payload.json
+          if [ -n "${comment_id}" ]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" --input comment-payload.json >/dev/null
+            echo "Updated existing sticky comment (${comment_id})"
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --input comment-payload.json >/dev/null
+            echo "Created sticky comment"
+          fi

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -58,23 +58,48 @@ jobs:
         working-directory: ./src/${{ matrix.service }}
         run: mvn -B verify
 
-      - name: Convert PMD / Checkstyle XML to SARIF
+      - name: Convert PMD / Checkstyle / ArchUnit XML to SARIF
         if: always()
         continue-on-error: true
         run: |
+          set -euo pipefail
+          REPORT_DIR="quality-reports/${{ matrix.service }}"
+          RAW_DIR="${REPORT_DIR}/raw"
+          mkdir -p "${RAW_DIR}"
+
           python3 scripts/ci/quality-to-sarif.py pmd \
-            -o pmd-results.sarif \
+            -o "${REPORT_DIR}/pmd-results.sarif" \
+            --count-output "${REPORT_DIR}/pmd-count.json" \
             src/${{ matrix.service }}/target/pmd.xml
           python3 scripts/ci/quality-to-sarif.py checkstyle \
-            -o checkstyle-results.sarif \
+            -o "${REPORT_DIR}/checkstyle-results.sarif" \
+            --count-output "${REPORT_DIR}/checkstyle-count.json" \
             src/${{ matrix.service }}/target/checkstyle-result.xml
+          python3 scripts/ci/quality-to-sarif.py archunit \
+            -o "${REPORT_DIR}/archunit-results.sarif" \
+            --count-output "${REPORT_DIR}/archunit-count.json" \
+            src/${{ matrix.service }}/target/surefire-reports/TEST-*ArchitectureTest*.xml
+
+          if [ -f "src/${{ matrix.service }}/target/pmd.xml" ]; then
+            cp "src/${{ matrix.service }}/target/pmd.xml" "${RAW_DIR}/"
+          fi
+          if [ -f "src/${{ matrix.service }}/target/checkstyle-result.xml" ]; then
+            cp "src/${{ matrix.service }}/target/checkstyle-result.xml" "${RAW_DIR}/"
+          fi
+          if [ -d "src/${{ matrix.service }}/target/surefire-reports" ]; then
+            find "src/${{ matrix.service }}/target/surefire-reports" \
+              -maxdepth 1 \
+              -type f \
+              -name 'TEST-*ArchitectureTest*.xml' \
+              -exec cp {} "${RAW_DIR}/" \;
+          fi
 
       - name: Upload PMD SARIF to Code Scanning
         if: always()
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: pmd-results.sarif
+          sarif_file: quality-reports/${{ matrix.service }}/pmd-results.sarif
           category: pmd-${{ matrix.service }}
 
       - name: Upload Checkstyle SARIF to Code Scanning
@@ -82,8 +107,25 @@ jobs:
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: checkstyle-results.sarif
+          sarif_file: quality-reports/${{ matrix.service }}/checkstyle-results.sarif
           category: checkstyle-${{ matrix.service }}
+
+      - name: Upload ArchUnit SARIF to Code Scanning
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: quality-reports/${{ matrix.service }}/archunit-results.sarif
+          category: archunit-${{ matrix.service }}
+
+      - name: Upload static analysis reports artifact
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-reports-${{ matrix.service }}
+          path: quality-reports
+          if-no-files-found: warn
 
   frontend-tests:
     name: Frontend tests
@@ -247,6 +289,17 @@ jobs:
       - dependency-security-scan
       - build-and-push
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download static analysis artifacts
+        if: always() && needs['java-tests'].result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: quality-reports-*
+          merge-multiple: true
+          path: quality-reports
+
       - name: Publish run summary
         run: |
           {
@@ -273,4 +326,15 @@ jobs:
             else
               echo "✅ All quality gates passed."
             fi
+
+            echo ""
+            echo "### Static Analysis Snapshot"
+            if [ "${{ needs['java-tests'].result }}" = "success" ] && [ -d "quality-reports" ]; then
+              python3 scripts/ci/quality-summary.py --root quality-reports
+              echo ""
+              echo "Detailed XML/SARIF reports are attached as workflow artifacts: \`quality-reports-<service>\`."
+            else
+              echo "_Static analysis summary unavailable (java-tests failed before artifact generation)._"
+            fi
+            echo "- SonarCloud dashboard: https://sonarcloud.io/project/overview?id=ClementV78_CloudRadar"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Security is treated as a **first-class concern**, not an afterthought:
 | **Container Scanning** | Trivy CVE scan on every PR (image + filesystem) | ✅ Implemented |
 | **Secret Detection** | GitGuardian pre-commit + CI scan | ✅ Implemented |
 | **Code Quality** | SonarCloud quality gate + PMD + Checkstyle + ArchUnit (design rules) | ✅ Implemented |
-| **GitHub Code Scanning** | SARIF upload for PMD, Checkstyle, and Trivy (unified Security tab) | ✅ Implemented |
+| **GitHub Code Scanning** | SARIF upload for PMD, Checkstyle, and ArchUnit (unified Security tab for static Java rules) | ✅ Implemented |
 | **IaC Security** | tfsec static analysis on Terraform PRs | ✅ Implemented |
 | **Dockerfile Quality** | Hadolint linting on every PR | ✅ Implemented |
 | **Edge Access** | Nginx + Basic Auth (dev), TLS | ✅ Implemented |
@@ -288,7 +288,10 @@ Testing is not limited to application code — it **validates the full delivery 
 | kubeconform | K8s manifest schemas + image naming | K8s PRs |
 | Smoke tests (`/healthz`) | Post-deploy service availability (3 endpoints) | Post-merge |
 
-PMD and Checkstyle results are uploaded as **SARIF to GitHub Code Scanning** (Security tab) for centralized visibility.
+PMD, Checkstyle, and ArchUnit results are uploaded as **SARIF to GitHub Code Scanning** (Security tab) for centralized visibility.
+For practical day-to-day review, `build-and-push` also publishes:
+- per-service artifacts (`quality-reports-<service>`) with raw XML + SARIF reports
+- a consolidated PMD/Checkstyle/ArchUnit table in `ci-summary-report` (`GITHUB_STEP_SUMMARY`)
 
 <p align="center">
   <a href="docs/testing-overview.md">

--- a/docs/architecture/technical-architecture-summary.md
+++ b/docs/architecture/technical-architecture-summary.md
@@ -179,7 +179,7 @@ graph TB
 | **IAM** | Least-privilege roles + OIDC for CI/CD (no long-lived CI secrets) | CloudTrail auditability, reduced credential sprawl |
 | **Encryption** | EBS encrypted at rest, TLS in transit (edge Nginx + in-cluster ingress) | Data protection at rest/transit |
 | **State** | Terraform backend in S3 (encrypted, versioned, DynamoDB lock) | Safe concurrent operations, rollback and audit history |
-| **Supply Chain** | GHCR with GitHub-issued `GITHUB_TOKEN`; Hadolint + Trivy + PMD + Checkstyle + ArchUnit + SonarCloud checks in CI; PMD/Checkstyle/Trivy results in GitHub Code Scanning (SARIF) | No long-lived registry credentials, controlled artifact path with automated quality/security gates |
+| **Supply Chain** | GHCR with GitHub-issued `GITHUB_TOKEN`; Hadolint + Trivy + PMD + Checkstyle + ArchUnit + SonarCloud checks in CI; PMD/Checkstyle/ArchUnit results in GitHub Code Scanning (SARIF) | No long-lived registry credentials, controlled artifact path with automated quality/security gates |
 
 **Zero-Trust Principles**: No SSH keys · OIDC for CI/CD · Secrets in SSM Parameter Store · Least-privilege IAM · Single ingress (443)
 

--- a/docs/runbooks/ci-cd/ci-app.md
+++ b/docs/runbooks/ci-cd/ci-app.md
@@ -57,6 +57,7 @@ Behavior:
 - Docker build/push is skipped until all gates are green.
 - On pull requests, image push remains disabled for all services (`push=false`).
 - A final summary job always runs and publishes gate/build status in `GITHUB_STEP_SUMMARY`.
+- On pull requests, the final summary job also upserts a sticky PR comment with static-analysis totals.
 
 ### Where to view quality and security reports
 
@@ -72,6 +73,7 @@ Behavior:
 | **JaCoCo coverage** | SonarCloud (ingested via `sonarcloud.yml`) | [SonarCloud coverage](https://sonarcloud.io/component_measures?id=ClementV78_CloudRadar&metric=coverage) |
 | **Hadolint** | GitHub PR → Checks tab → `dockerfile-lint` job logs | annotation on failure |
 | **Consolidated static summary** | GitHub PR → Checks tab → `ci-summary-report` | `GITHUB_STEP_SUMMARY` includes PMD/Checkstyle/ArchUnit counts per service |
+| **PR static-analysis snapshot** | GitHub PR conversation | sticky bot comment updated each run with the same summary table |
 
 Redis contract reference:
 - See [`docs/events-schemas/redis-keys.md`](/home/xclem/projetsperso/CloudRadar/docs/events-schemas/redis-keys.md) for key/payload conventions validated by integration tests.

--- a/docs/runbooks/ci-cd/ci-app.md
+++ b/docs/runbooks/ci-cd/ci-app.md
@@ -64,13 +64,14 @@ Behavior:
 | --- | --- | --- |
 | **PMD findings** | GitHub → Security → Code Scanning | [Code Scanning (PMD)](https://github.com/ClementV78/CloudRadar/security/code-scanning?query=tool:PMD) |
 | **Checkstyle findings** | GitHub → Security → Code Scanning | [Code Scanning (Checkstyle)](https://github.com/ClementV78/CloudRadar/security/code-scanning?query=tool:Checkstyle) |
-| **Trivy CVE** | GitHub → Security → Code Scanning | [Code Scanning (Trivy)](https://github.com/ClementV78/CloudRadar/security/code-scanning?query=tool:Trivy) |
+| **ArchUnit findings** | GitHub → Security → Code Scanning | [Code Scanning (ArchUnit)](https://github.com/ClementV78/CloudRadar/security/code-scanning?query=tool:ArchUnit) |
+| **Trivy CVE** | GitHub PR/Run → Checks tab → `dependency-security-scan` job logs | `trivy fs` gate output (HIGH/CRITICAL) |
 | **SonarCloud dashboard** | SonarCloud web UI | [SonarCloud overview](https://sonarcloud.io/project/overview?id=ClementV78_CloudRadar) |
 | **SonarCloud PR decoration** | GitHub PR → Checks tab + PR comment | automatic on every PR |
-| **ArchUnit violations** | GitHub PR → Checks tab → `java-tests` job logs | test failure = build failure |
+| **Raw PMD/Checkstyle/ArchUnit reports** | GitHub Actions run → Artifacts `quality-reports-<service>` | XML + SARIF + counters per Java service |
 | **JaCoCo coverage** | SonarCloud (ingested via `sonarcloud.yml`) | [SonarCloud coverage](https://sonarcloud.io/component_measures?id=ClementV78_CloudRadar&metric=coverage) |
 | **Hadolint** | GitHub PR → Checks tab → `dockerfile-lint` job logs | annotation on failure |
-| **CI summary** | GitHub PR → Checks tab → `ci-summary-report` | `GITHUB_STEP_SUMMARY` |
+| **Consolidated static summary** | GitHub PR → Checks tab → `ci-summary-report` | `GITHUB_STEP_SUMMARY` includes PMD/Checkstyle/ArchUnit counts per service |
 
 Redis contract reference:
 - See [`docs/events-schemas/redis-keys.md`](/home/xclem/projetsperso/CloudRadar/docs/events-schemas/redis-keys.md) for key/payload conventions validated by integration tests.
@@ -129,12 +130,12 @@ Code quality trend and quality-gate status are validated in a dedicated workflow
     - `src/ingester/target/site/jacoco/jacoco.xml`
     - `src/processor/target/site/jacoco/jacoco.xml`
 
-Additionally, the `build-and-push` workflow converts PMD and Checkstyle XML reports to SARIF and uploads them to **GitHub Code Scanning** (visible in the repository Security tab alongside Trivy CVE findings). Each matrix service uploads its own SARIF with distinct categories (`pmd-<service>`, `checkstyle-<service>`).
+Additionally, the `build-and-push` workflow converts PMD, Checkstyle, and ArchUnit XML reports to SARIF and uploads them to **GitHub Code Scanning** (repository Security tab). Each matrix service uploads its own SARIF with distinct categories (`pmd-<service>`, `checkstyle-<service>`, `archunit-<service>`) and publishes raw XML/SARIF reports as run artifacts (`quality-reports-<service>`). Trivy CVE findings remain visible in the `dependency-security-scan` job logs.
 
 Expected signals:
 - SonarCloud scan step succeeds
 - quality gate check is green on the PR checks tab
-- PMD / Checkstyle findings appear in the GitHub Security tab (Code Scanning alerts)
+- PMD / Checkstyle / ArchUnit findings appear in the GitHub Security tab (Code Scanning alerts)
 
 Common failure:
 - `SONAR_TOKEN is not configured`

--- a/docs/runbooks/ci-cd/sonarcloud.md
+++ b/docs/runbooks/ci-cd/sonarcloud.md
@@ -86,9 +86,12 @@ Custom profiles (e.g. activating `java:S6539` God Class) require a paid plan.
 SonarCloud still provides value for: coverage tracking, bug detection, security
 vulnerabilities, and duplication analysis — all included in "Sonar Way".
 
-Note: PMD/Checkstyle SARIF upload to GitHub Code Scanning is handled by the
-`build-and-push` workflow (one upload per service in the `java-tests` matrix),
-not by this workflow. See `docs/runbooks/ci-cd/ci-app.md` for details.
+Note: PMD/Checkstyle/ArchUnit SARIF upload to GitHub Code Scanning is handled
+by the `build-and-push` workflow (one upload per service in the `java-tests`
+matrix), not by this workflow. The same workflow also publishes raw
+PMD/Checkstyle/ArchUnit XML + SARIF artifacts (`quality-reports-<service>`) and
+a consolidated static-analysis summary in `ci-summary-report`.
+See `docs/runbooks/ci-cd/ci-app.md` for details.
 
 If the plan is upgraded later, follow these steps to create a custom profile:
 

--- a/docs/testing-overview-en.md
+++ b/docs/testing-overview-en.md
@@ -271,7 +271,7 @@ Inter-service contracts (Redis keys, JSON format) are validated by dedicated Tes
 
 SonarCloud ingests Java coverage (JaCoCo) and frontend coverage (lcov) for unified trend tracking.
 
-**Java static analysis**: PMD (design smells, god class), Checkstyle (complexity, size), and ArchUnit (architectural constraints) run during `mvn verify` — in both `build-and-push` and `sonarcloud`. PMD/Checkstyle results are also converted to SARIF and uploaded to GitHub Code Scanning (Security tab).
+**Java static analysis**: PMD (design smells, god class), Checkstyle (complexity, size), and ArchUnit (architectural constraints) run during `mvn verify` — in both `build-and-push` and `sonarcloud`. PMD/Checkstyle/ArchUnit results are converted to SARIF and uploaded to GitHub Code Scanning (Security tab). The workflow also publishes per-service raw artifacts (`quality-reports-<service>`) and a consolidated static-analysis summary in `ci-summary-report`.
 
 ---
 
@@ -291,7 +291,7 @@ This matrix cross-references the 6 workflows with the 9 test categories. It lets
 | 🌐 E2E | | | | | 🟢 | |
 | 🏔️ Perf | | | | | | 🟢 |
 
-> `build-and-push` carries **5/9 categories** (including PMD/Checkstyle/ArchUnit via `mvn verify`). All categories are covered by at least one workflow. PMD/Checkstyle results are also sent as SARIF to GitHub Code Scanning from the `build-and-push` workflow.
+> `build-and-push` carries **5/9 categories** (including PMD/Checkstyle/ArchUnit via `mvn verify`). All categories are covered by at least one workflow. PMD/Checkstyle/ArchUnit results are sent as SARIF to GitHub Code Scanning, with raw per-service artifacts (`quality-reports-<service>`) and a consolidated summary (`ci-summary-report`).
 
 ---
 

--- a/docs/testing-overview.md
+++ b/docs/testing-overview.md
@@ -271,7 +271,7 @@ Les contrats inter-services (clés Redis, format JSON) sont validés par des tes
 
 SonarCloud ingère la couverture Java (JaCoCo) et frontend (lcov) pour un suivi de tendance unifié.
 
-**Analyse statique Java** : PMD (design smells, god class), Checkstyle (complexité, taille), et ArchUnit (contraintes architecturales) s'exécutent dans `mvn verify` — dans `build-and-push` et `sonarcloud`. Les résultats PMD/Checkstyle sont aussi convertis en SARIF et envoyés vers GitHub Code Scanning (onglet Security).
+**Analyse statique Java** : PMD (design smells, god class), Checkstyle (complexité, taille), et ArchUnit (contraintes architecturales) s'exécutent dans `mvn verify` — dans `build-and-push` et `sonarcloud`. Les résultats PMD/Checkstyle/ArchUnit sont convertis en SARIF et envoyés vers GitHub Code Scanning (onglet Security). Le workflow publie aussi des artifacts consultables par service (`quality-reports-<service>`) et un résumé consolidé dans `ci-summary-report`.
 
 ---
 
@@ -291,7 +291,7 @@ Cette matrice croise les 6 workflows avec les 9 catégories de tests. Elle perme
 | 🌐 E2E | | | | | 🟢 | |
 | 🏔️ Perf | | | | | | 🟢 |
 
-> `build-and-push` porte **5/9 catégories** (dont PMD/Checkstyle/ArchUnit via `mvn verify`). Toutes les catégories sont couvertes par au moins un workflow. Les résultats PMD/Checkstyle sont aussi envoyés en SARIF vers GitHub Code Scanning depuis le workflow `build-and-push`.
+> `build-and-push` porte **5/9 catégories** (dont PMD/Checkstyle/ArchUnit via `mvn verify`). Toutes les catégories sont couvertes par au moins un workflow. Les résultats PMD/Checkstyle/ArchUnit sont envoyés en SARIF vers GitHub Code Scanning, avec rapports bruts par service (`quality-reports-<service>`) et synthèse consolidée (`ci-summary-report`).
 
 ---
 

--- a/scripts/ci/quality-summary.py
+++ b/scripts/ci/quality-summary.py
@@ -1,42 +1,153 @@
 #!/usr/bin/env python3
-"""Print a markdown summary table for static-analysis count artifacts."""
+"""Render static-analysis report markdown from quality artifacts."""
 
 import argparse
 import json
 import os
+from typing import Optional
+
+TOOLS = ("pmd", "checkstyle", "archunit")
+TOOL_LABELS = {"pmd": "PMD", "checkstyle": "Checkstyle", "archunit": "ArchUnit"}
+
+
+def _load_json(path: str) -> Optional[dict]:
+    if not os.path.isfile(path):
+        return None
+    with open(path, "r", encoding="utf-8") as file_handle:
+        return json.load(file_handle)
+
+
+def _services(root: str) -> list[str]:
+    if not os.path.isdir(root):
+        return []
+    return sorted(
+        entry for entry in os.listdir(root)
+        if os.path.isdir(os.path.join(root, entry))
+    )
+
+
+def _count_for(root: str, service: str, tool: str) -> Optional[int]:
+    payload = _load_json(os.path.join(root, service, f"{tool}-count.json"))
+    if payload is None:
+        return None
+    return int(payload.get("findings", 0))
+
+
+def _result_path(root: str, service: str, tool: str) -> str:
+    return os.path.join(root, service, f"{tool}-results.sarif")
+
+
+def _first_findings(root: str, service: str, tool: str, limit: int) -> list[str]:
+    payload = _load_json(_result_path(root, service, tool))
+    if payload is None:
+        return []
+
+    runs = payload.get("runs", [])
+    if not runs:
+        return []
+
+    findings = []
+    for run in runs:
+        for result in run.get("results", []):
+            message = result.get("message", {}).get("text", "").replace("\n", " ").strip()
+            if not message:
+                message = "No message"
+            location = "unknown"
+            locations = result.get("locations", [])
+            if locations:
+                physical = locations[0].get("physicalLocation", {})
+                artifact = physical.get("artifactLocation", {}).get("uri", "unknown")
+                line = physical.get("region", {}).get("startLine")
+                location = f"{artifact}:{line}" if line else artifact
+            findings.append(f"- `{service}` / `{TOOL_LABELS[tool]}` / `{location}`: {message}")
+            if len(findings) >= limit:
+                return findings
+    return findings
+
+
+def render_markdown(root: str, title: str, finding_limit: int) -> str:
+    services = _services(root)
+    lines = [title, "", "| Service | PMD | Checkstyle | ArchUnit |", "| --- | ---: | ---: | ---: |"]
+
+    if not services:
+        lines.append("| _none_ | n/a | n/a | n/a |")
+        lines.append("")
+        lines.append("_No static-analysis artifacts were available for this run._")
+        return "\n".join(lines)
+
+    totals = {tool: 0 for tool in TOOLS}
+    missing = {tool: 0 for tool in TOOLS}
+    for service in services:
+        row = []
+        for tool in TOOLS:
+            count = _count_for(root, service, tool)
+            if count is None:
+                missing[tool] += 1
+                row.append("n/a")
+                continue
+            totals[tool] += count
+            row.append(str(count))
+        lines.append(f"| {service} | {row[0]} | {row[1]} | {row[2]} |")
+
+    total_findings = sum(totals.values())
+    lines.append("")
+    lines.append(
+        f"- Totals: PMD `{totals['pmd']}` · Checkstyle `{totals['checkstyle']}` · "
+        f"ArchUnit `{totals['archunit']}` · All tools `{total_findings}`"
+    )
+
+    if any(value > 0 for value in missing.values()):
+        lines.append(
+            f"- Missing report files: PMD `{missing['pmd']}`, Checkstyle `{missing['checkstyle']}`, "
+            f"ArchUnit `{missing['archunit']}` service(s)."
+        )
+
+    if total_findings == 0:
+        lines.append("- No static-analysis findings detected in this run.")
+        return "\n".join(lines)
+
+    details = []
+    for service in services:
+        for tool in TOOLS:
+            details.extend(_first_findings(root, service, tool, finding_limit - len(details)))
+            if len(details) >= finding_limit:
+                break
+        if len(details) >= finding_limit:
+            break
+
+    lines.append("")
+    lines.append("<details>")
+    lines.append("<summary>Top findings</summary>")
+    lines.append("")
+    if details:
+        lines.extend(details)
+    else:
+        lines.append("- Findings were reported but details could not be parsed from SARIF.")
+    lines.append("</details>")
+    return "\n".join(lines)
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Render static-analysis count summary as markdown")
-    parser.add_argument("--root", default="quality-reports", help="Directory containing per-service count files")
+    parser = argparse.ArgumentParser(description="Render static-analysis report as markdown")
+    parser.add_argument("--root", default="quality-reports", help="Directory containing per-service report files")
+    parser.add_argument("--title", default="### Static Analysis Snapshot", help="Markdown title")
+    parser.add_argument("--output", help="Optional markdown output file path")
+    parser.add_argument(
+        "--finding-limit",
+        type=int,
+        default=20,
+        help="Maximum number of findings to include in details section",
+    )
     args = parser.parse_args()
 
-    tools = ("pmd", "checkstyle", "archunit")
-    services = []
-    if os.path.isdir(args.root):
-        services = sorted(
-            entry for entry in os.listdir(args.root)
-            if os.path.isdir(os.path.join(args.root, entry))
-        )
-
-    print("| Service | PMD | Checkstyle | ArchUnit |")
-    print("| --- | ---: | ---: | ---: |")
-
-    if not services:
-        print("| _none_ | n/a | n/a | n/a |")
+    markdown = render_markdown(args.root, args.title, args.finding_limit)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as file_handle:
+            file_handle.write(markdown)
+            file_handle.write("\n")
         return
 
-    for service in services:
-        row = []
-        for tool in tools:
-            count_path = os.path.join(args.root, service, f"{tool}-count.json")
-            if not os.path.isfile(count_path):
-                row.append("n/a")
-                continue
-            with open(count_path, "r", encoding="utf-8") as file_handle:
-                payload = json.load(file_handle)
-            row.append(str(payload.get("findings", 0)))
-        print(f"| {service} | {row[0]} | {row[1]} | {row[2]} |")
+    print(markdown)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/quality-summary.py
+++ b/scripts/ci/quality-summary.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Print a markdown summary table for static-analysis count artifacts."""
+
+import argparse
+import json
+import os
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render static-analysis count summary as markdown")
+    parser.add_argument("--root", default="quality-reports", help="Directory containing per-service count files")
+    args = parser.parse_args()
+
+    tools = ("pmd", "checkstyle", "archunit")
+    services = []
+    if os.path.isdir(args.root):
+        services = sorted(
+            entry for entry in os.listdir(args.root)
+            if os.path.isdir(os.path.join(args.root, entry))
+        )
+
+    print("| Service | PMD | Checkstyle | ArchUnit |")
+    print("| --- | ---: | ---: | ---: |")
+
+    if not services:
+        print("| _none_ | n/a | n/a | n/a |")
+        return
+
+    for service in services:
+        row = []
+        for tool in tools:
+            count_path = os.path.join(args.root, service, f"{tool}-count.json")
+            if not os.path.isfile(count_path):
+                row.append("n/a")
+                continue
+            with open(count_path, "r", encoding="utf-8") as file_handle:
+                payload = json.load(file_handle)
+            row.append(str(payload.get("findings", 0)))
+        print(f"| {service} | {row[0]} | {row[1]} | {row[2]} |")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/quality-to-sarif.py
+++ b/scripts/ci/quality-to-sarif.py
@@ -4,12 +4,14 @@
 Usage:
   python3 quality-to-sarif.py pmd -o pmd.sarif src/*/target/pmd.xml
   python3 quality-to-sarif.py checkstyle -o cs.sarif src/*/target/checkstyle-result.xml
+  python3 quality-to-sarif.py archunit -o arch.sarif src/*/target/surefire-reports/TEST-*ArchitectureTest*.xml
 """
 
 import argparse
 import glob
 import json
 import os
+import re
 import xml.etree.ElementTree as ET
 
 SARIF_SCHEMA = (
@@ -19,6 +21,8 @@ SARIF_SCHEMA = (
 
 PMD_LEVEL = {"1": "error", "2": "error", "3": "warning", "4": "note", "5": "note"}
 CS_LEVEL = {"error": "error", "warning": "warning", "info": "note"}
+ARCHUNIT_LEVEL = {"failure": "error", "error": "error"}
+JAVA_FILE_LINE_PATTERN = re.compile(r"([A-Za-z0-9_./\\-]+\.java):(\d+)")
 
 
 def _rel(path, workspace):
@@ -76,6 +80,80 @@ def parse_checkstyle(xml_files, workspace):
     return results, list(rules.values())
 
 
+def _iter_testsuites(root):
+    if root.tag == "testsuite":
+        return [root]
+    if root.tag == "testsuites":
+        return list(root.findall("testsuite"))
+    return root.findall(".//testsuite")
+
+
+def _guess_archunit_fallback_path(report_path):
+    normalized = report_path.replace("\\", "/")
+    marker = "/target/surefire-reports/"
+    if marker not in normalized:
+        return None
+
+    service_root = normalized.split(marker, 1)[0]
+    candidates = glob.glob(
+        f"{service_root}/src/test/java/**/ArchitectureTest.java",
+        recursive=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def parse_archunit(xml_files, workspace):
+    results = []
+    rule_id = "ArchUnitRuleViolation"
+    rules = [{
+        "id": rule_id,
+        "shortDescription": {"text": "ArchUnit architecture rule violated"},
+        "helpUri": "https://www.archunit.org/",
+    }]
+
+    for path in xml_files:
+        root = ET.parse(path).getroot()
+        fallback_file = _guess_archunit_fallback_path(path)
+
+        for suite in _iter_testsuites(root):
+            suite_name = suite.get("name", "ArchitectureTest")
+            for testcase in suite.findall("testcase"):
+                detail_node = testcase.find("failure")
+                detail_kind = "failure"
+                if detail_node is None:
+                    detail_node = testcase.find("error")
+                    detail_kind = "error"
+                if detail_node is None:
+                    continue
+
+                message = (detail_node.get("message", "ArchUnit rule violated") or "").strip()
+                if not message:
+                    message = "ArchUnit rule violated"
+                detail_text = (detail_node.text or "").strip()
+                test_name = testcase.get("name", "architecture_rule")
+                class_name = testcase.get("classname", suite_name)
+                detail_block = f"{message}\n\n{detail_text}" if detail_text else message
+                finding_message = f"{class_name}.{test_name}: {detail_block}"
+
+                match = JAVA_FILE_LINE_PATTERN.search(detail_text) or JAVA_FILE_LINE_PATTERN.search(message)
+                if match:
+                    uri = _rel(match.group(1).replace("\\", "/"), workspace)
+                    locations = [_loc(uri, int(match.group(2)))]
+                elif fallback_file:
+                    locations = [_loc(_rel(fallback_file, workspace), 1)]
+                else:
+                    locations = [_loc(_rel(path, workspace), 1)]
+
+                results.append({
+                    "ruleId": rule_id,
+                    "level": ARCHUNIT_LEVEL.get(detail_kind, "error"),
+                    "message": {"text": finding_message},
+                    "locations": locations,
+                })
+
+    return results, rules
+
+
 def build_sarif(name, version, results, rules):
     return {
         "$schema": SARIF_SCHEMA,
@@ -89,8 +167,9 @@ def build_sarif(name, version, results, rules):
 
 def main():
     p = argparse.ArgumentParser(description="Convert quality XML to SARIF")
-    p.add_argument("tool", choices=["pmd", "checkstyle"])
+    p.add_argument("tool", choices=["pmd", "checkstyle", "archunit"])
     p.add_argument("-o", "--output", required=True)
+    p.add_argument("--count-output", help="Optional JSON output file with findings/report counts")
     p.add_argument(
         "-w", "--workspace",
         default=os.environ.get("GITHUB_WORKSPACE", os.getcwd()),
@@ -107,12 +186,22 @@ def main():
     if args.tool == "pmd":
         results, rules = parse_pmd(xml_files, args.workspace) if xml_files else ([], [])
         sarif = build_sarif("PMD", "7.7.0", results, rules)
-    else:
+    elif args.tool == "checkstyle":
         results, rules = parse_checkstyle(xml_files, args.workspace) if xml_files else ([], [])
         sarif = build_sarif("Checkstyle", "9.3", results, rules)
+    else:
+        results, rules = parse_archunit(xml_files, args.workspace) if xml_files else ([], [])
+        sarif = build_sarif("ArchUnit", "1.3.0", results, rules)
 
     with open(args.output, "w") as f:
         json.dump(sarif, f, indent=2)
+    if args.count_output:
+        with open(args.count_output, "w") as f:
+            json.dump({
+                "tool": args.tool,
+                "reports": len(xml_files),
+                "findings": len(results),
+            }, f, indent=2)
     print(f"{args.output}: {len(results)} finding(s) from {len(xml_files)} report(s)")
 
 


### PR DESCRIPTION
## Summary
This PR integrated ArchUnit into GitHub Code Scanning and added lightweight, consultable static-analysis reporting directly in GitHub Actions.

## Changes
- extended `scripts/ci/quality-to-sarif.py` with `archunit` support (Surefire XML -> SARIF)
- added ArchUnit SARIF upload in `build-and-push` (`archunit-<service>` categories)
- added per-service static-analysis artifacts (`quality-reports-<service>`) containing:
  - raw XML reports (PMD, Checkstyle, ArchUnit Surefire)
  - SARIF outputs (PMD, Checkstyle, ArchUnit)
  - per-tool count JSON files
- added consolidated static-analysis table in `ci-summary-report` (`GITHUB_STEP_SUMMARY`)
- added helper script `scripts/ci/quality-summary.py` to render the summary table
- aligned docs (README + CI runbooks + testing overviews + architecture summary) to document where reports are visible and corrected Trivy visibility wording

## Validation
- `actionlint .github/workflows/build-and-push.yml`
- `python3 -m py_compile scripts/ci/quality-to-sarif.py scripts/ci/quality-summary.py`
- `mvn -B -f src/processor/pom.xml verify`
- `python3 scripts/ci/quality-to-sarif.py archunit -o /tmp/archunit-results.sarif --count-output /tmp/archunit-count.json src/processor/target/surefire-reports/TEST-*ArchitectureTest*.xml`
- synthetic failing ArchUnit XML fixture converted successfully (1 finding with file:line mapping)

