### PR TITLE
ci(actions): refresh GitHub Actions versions

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
@@ -97,7 +97,7 @@ jobs:
       - name: Upload PMD SARIF to Code Scanning
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: quality-reports/${{ matrix.service }}/pmd-results.sarif
           category: pmd-${{ matrix.service }}
@@ -105,7 +105,7 @@ jobs:
       - name: Upload Checkstyle SARIF to Code Scanning
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: quality-reports/${{ matrix.service }}/checkstyle-results.sarif
           category: checkstyle-${{ matrix.service }}
@@ -113,7 +113,7 @@ jobs:
       - name: Upload ArchUnit SARIF to Code Scanning
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: quality-reports/${{ matrix.service }}/archunit-results.sarif
           category: archunit-${{ matrix.service }}
@@ -121,7 +121,7 @@ jobs:
       - name: Upload static analysis reports artifact
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: quality-reports-${{ matrix.service }}
           path: quality-reports
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -185,11 +185,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Scan dependencies in src/
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.35.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db:1
         with:
+          cache: false
           scanners: vuln
           scan-type: fs
           scan-ref: src
@@ -298,7 +299,7 @@ jobs:
 
       - name: Download static analysis artifacts
         if: always() && needs['java-tests'].result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: quality-reports-*
           merge-multiple: true

--- a/.github/workflows/k6-nightly-baseline.yml
+++ b/.github/workflows/k6-nightly-baseline.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload k6 artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: k6-baseline-${{ github.run_id }}
           path: artifacts/*

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Java 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: '17'
@@ -56,7 +56,7 @@ jobs:
           mvn -B -f src/processor/pom.xml -DskipTests dependency:copy-dependencies -DincludeScope=test
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
           cache: npm


### PR DESCRIPTION
## Summary
- bumped GitHub Actions versions in CI workflows (setup-java, setup-node, upload/download-artifact, CodeQL SARIF uploader)
- pinned aquasecurity/trivy-action to 0.35.0 instead of master
- disabled Trivy cache in build-and-push for deterministic behavior

## Files
- .github/workflows/build-and-push.yml
- .github/workflows/k6-nightly-baseline.yml
- .github/workflows/sonarcloud.yml

## Validation
- workflow syntax and action references updated only; no runtime code changes

Refs #559