### PR TITLE
refactor(ingester): extract FlightIngestJob collaborators and simplify OpenSky clients

### DIFF
--- a/config/quality/checkstyle-suppressions.xml
+++ b/config/quality/checkstyle-suppressions.xml
@@ -17,14 +17,8 @@
   <!-- ========== processor (#558) — RESOLVED ========== -->
   <!-- RedisAggregateProcessor refactored: suppressions removed -->
 
-  <!-- ========== ingester (#559) ========== -->
-  <!-- https://github.com/ClementV78/CloudRadar/issues/559 -->
-  <suppress checks="MethodCount|FileLength|CyclomaticComplexity"
-            files="FlightIngestJob\.java"/>
-  <suppress checks="CyclomaticComplexity"
-            files="OpenSkyTokenService\.java"/>
-  <suppress checks="CyclomaticComplexity"
-            files="OpenSkyClient\.java"/>
+  <!-- ========== ingester (#559) — RESOLVED ========== -->
+  <!-- FlightIngestJob/OpenSkyClient/OpenSkyTokenService refactored: suppressions removed -->
 
   <!-- ========== dashboard (#560) ========== -->
   <!-- https://github.com/ClementV78/CloudRadar/issues/560 -->

--- a/config/quality/pmd-ruleset.xml
+++ b/config/quality/pmd-ruleset.xml
@@ -13,10 +13,7 @@
   <!-- Known violations excluded until refactoring.
        Each exclusion links to a tracking issue. -->
   <!-- #558: RESOLVED — RedisAggregateProcessor refactored, exclusion removed -->
-  <!-- #559: https://github.com/ClementV78/CloudRadar/issues/559 -->
-  <exclude-pattern>.*/FlightIngestJob\.java</exclude-pattern>
-  <exclude-pattern>.*/OpenSkyTokenService\.java</exclude-pattern>
-  <exclude-pattern>.*/OpenSkyClient\.java</exclude-pattern>
+  <!-- #559: RESOLVED — ingester god-class/cyclomatic refactor completed -->
   <!-- #560: https://github.com/ClementV78/CloudRadar/issues/560 -->
   <exclude-pattern>.*/FlightQueryService\.java</exclude-pattern>
   <!-- Properties classes are getter/setter POJOs, not design-smell targets -->

--- a/docs/architecture/application-architecture.md
+++ b/docs/architecture/application-architecture.md
@@ -1,6 +1,6 @@
 # CloudRadar Application Architecture
 
-**Last updated**: 2026-03-11
+**Last updated**: 2026-03-12
 
 This document describes the architecture and design of all microservices in the CloudRadar platform. Each service is containerized and deployed to k3s via ArgoCD.
 
@@ -61,7 +61,7 @@ Fetches live flight states from OpenSky API every 10 seconds and publishes each 
 - **Language**: Java 17
 - **Framework**: Spring Boot 3.x
 - **Scheduler**: Spring `@Scheduled`
-- **HTTP Client**: RestTemplate / Spring WebClient
+- **HTTP Client**: Java `HttpClient` (`java.net.http`)
 - **Authentication**: OAuth2 (OpenSky credentials via SSM Parameter Store)
 - **Message Queue**: Redis List
 
@@ -69,48 +69,65 @@ Fetches live flight states from OpenSky API every 10 seconds and publishes each 
 
 ```mermaid
 flowchart LR
-    Scheduler["Spring Scheduler<br/>(10s interval)"]
+    Scheduler["Spring Scheduler<br/>(10s interval)"] --> Job["FlightIngestJob<br/>(orchestrator)"]
     OpenSkyClient["OpenSkyClient<br/>(REST)"]
     TokenService["OpenSkyTokenService<br/>(OAuth2)"]
-    Mapping["FlightState<br/>→ Event Map"]
+    Mapping["FlightEventMapper<br/>FlightState → Event Map"]
+    Backoff["IngestionBackoffController<br/>(progressive backoff)"]
+    RateLimit["OpenSkyRateLimitTracker<br/>(effective quota + delay)"]
+    MetricsHelper["IngesterMetrics<br/>(counters + gauges)"]
     Redis["Redis List<br/>(cloudradar:ingest:queue)"]
     
-    Scheduler -->|fetch states| OpenSkyClient
+    Job -->|fetch states| OpenSkyClient
     OpenSkyClient -->|get bearer token| TokenService
-    TokenService -->|cache refresh| OpenSkyClient
     OpenSkyClient -->|parse| Mapping
+    Job --> Backoff
+    Job --> RateLimit
+    Job --> MetricsHelper
     Mapping -->|push JSON| Redis
-    Scheduler -->|expose| Metrics["/metrics"]
-    Scheduler -->|expose| Health["/healthz"]
+    Job -->|expose| Metrics["/metrics"]
+    Job -->|expose| Health["/healthz"]
 ```
 
 ### Code Organization
 
 ```
 src/ingester/
-├── IngesterApplication.java              # Spring Boot entrypoint, scheduling enabled
-├── config/
-│   ├── IngesterProperties.java            # Configuration: refresh interval, Redis key, bbox
-│   ├── OpenSkyProperties.java             # OpenSky API URLs, token endpoint
-│   ├── AwsProperties.java                 # AWS region, SSM parameter names
-│   └── HttpClientConfig.java              # RestTemplate / WebClient beans
-├── opensky/
-│   ├── OpenSkyClient.java                 # Fetches /states/all, parses response
-│   ├── OpenSkyTokenService.java           # Manages OAuth2 bearer token (10m TTL)
-│   ├── OpenSkyCredentialsProvider.java    # Loads credentials from SSM
-│   └── FlightState.java                   # DTO for OpenSky state objects
-├── redis/
-│   └── RedisPublisher.java                # Serializes events as JSON, pushes to Redis List
-└── job/
-    └── FlightIngestJob.java               # Scheduled job (runs every INGESTER_REFRESH_MS)
+├── src/main/java/com/cloudradar/ingester/
+│   ├── IngesterApplication.java                # Spring Boot entrypoint, scheduling enabled
+│   ├── FlightIngestJob.java                    # Scheduled orchestrator (fetch/map/publish)
+│   ├── FlightEventMapper.java                  # FlightState -> Redis payload mapper
+│   ├── IngestionBackoffController.java         # Progressive backoff + disable policy
+│   ├── OpenSkyRateLimitTracker.java            # Effective quota and delay adaptation
+│   ├── OpenSkyRateLimitMetricCalculator.java   # Table-driven rate-limit metric helpers
+│   ├── IngesterMetrics.java                    # Ingestion/OpenSky gauges + counters
+│   ├── config/
+│   │   ├── AppConfig.java                      # Shared beans (HttpClient)
+│   │   ├── IngesterProperties.java             # Refresh interval, Redis key, bbox
+│   │   ├── OpenSkyProperties.java              # OpenSky routing + token settings
+│   │   └── AwsProperties.java                  # AWS region/SSM parameter names
+│   ├── opensky/
+│   │   ├── OpenSkyClient.java                  # /states/all request/response orchestration
+│   │   ├── OpenSkyTokenService.java            # OAuth token cache + cooldown
+│   │   ├── OpenSkyResponseParser.java          # JSON payload + headers parsing
+│   │   ├── OpenSkyBboxResolver.java            # Effective bbox resolution
+│   │   ├── OpenSkyStatesHttpMetrics.java       # States-call HTTP metrics
+│   │   ├── OpenSkyTokenHttpMetrics.java        # Token-call HTTP metrics
+│   │   ├── TokenCooldownPolicy.java            # Token failure cooldown state machine
+│   │   ├── OpenSkyEndpointProvider.java        # Routing mode endpoint selection
+│   │   ├── OpenSkyRateLimitHeaders.java        # Parsed rate-limit header record
+│   │   ├── FetchResult.java                    # Stable fetch contract
+│   │   └── FlightState.java                    # OpenSky state DTO
+│   └── redis/
+│       └── RedisPublisher.java                 # Serializes events and pushes to Redis List
 ```
 
 ### Flow
 
-1. `FlightIngestJob` runs every 10 seconds (configurable via `INGESTER_REFRESH_MS`)
-2. `OpenSkyClient` requests `/states/all` for the defined bounding box (Île-de-France by default)
-3. `OpenSkyTokenService` provides a cached OAuth2 bearer token (refreshed every ~10 minutes)
-4. Response is parsed into `FlightState` objects, then to a simple JSON map:
+1. `FlightIngestJob` runs every 10 seconds (configurable via `INGESTER_REFRESH_MS`) and orchestrates a full ingestion cycle.
+2. `OpenSkyClient` requests `/states/all` for the effective bounding box and uses an OAuth2 bearer token from `OpenSkyTokenService`.
+3. `OpenSkyRateLimitTracker` updates effective quota/remaining headers and computes the next refresh delay tier.
+4. `FlightEventMapper` converts `FlightState` objects into Redis-ready JSON maps:
    ```json
    {
      "icao24": "abc123",
@@ -125,8 +142,8 @@ src/ingester/
      "last_contact": 1704067200
    }
    ```
-5. `RedisPublisher` pushes the JSON to `cloudradar:ingest:queue` (Redis List)
-6. Metrics (`/metrics`) and health (`/healthz`) exposed via Actuator
+5. `RedisPublisher` pushes payloads to `cloudradar:ingest:queue` (Redis List).
+6. `IngesterMetrics` updates counters/gauges while `IngestionBackoffController` handles failure backoff and disable-after-threshold behavior.
 
 ### Error Handling
 
@@ -160,11 +177,12 @@ Details:
 
 ### Metrics Exposed
 
-- `opensky_requests_total` — Total API requests sent
-- `opensky_errors_total` — Total API errors
-- `ingester_events_published_total` — Total events pushed to Redis
-- `ingester_opensky_backoff_seconds` — Current OpenSky failure backoff duration in seconds
-- `ingester_opensky_disabled` — Ingester disabled flag (1 = disabled after repeated failures)
+- `ingester.fetch.total` — Total states fetched
+- `ingester.fetch.requests.total` — Total ingestion fetch cycles
+- `ingester.push.total` — Total events pushed to Redis
+- `ingester.errors.total` — Total failed ingestion cycles
+- `ingester.opensky.backoff.seconds` — Current OpenSky failure backoff duration in seconds
+- `ingester.opensky.disabled` — Ingester disabled flag (1 = disabled after repeated failures)
 
 ---
 

--- a/src/ingester/README.md
+++ b/src/ingester/README.md
@@ -6,14 +6,18 @@ OpenSky ingestion service (Java 17 / Spring Boot) that fetches live flight state
 
 ```mermaid
 flowchart LR
-  Scheduler["Spring Scheduler (10s)"] --> Fetch["OpenSkyClient (states/all)"]
+  Scheduler["Spring Scheduler (10s)"] --> Job["FlightIngestJob (orchestrator)"]
+  Job --> Fetch["OpenSkyClient (states/all)"]
   Fetch --> Token["OpenSkyTokenService (OAuth2)"]
   Token --> OpenSky["OpenSky API"]
-  Fetch --> Map["FlightState -> event map"]
-  Map --> Redis["Redis List (cloudradar:ingest:queue)"]
+  Job --> Mapper["FlightEventMapper"]
+  Job --> Backoff["IngestionBackoffController"]
+  Job --> RateLimit["OpenSkyRateLimitTracker"]
+  Job --> IMetrics["IngesterMetrics"]
+  Mapper --> Redis["Redis List (cloudradar:ingest:queue)"]
   Redis --> Processor["Processor (consumer)"]
-  Metrics["/metrics/prometheus"] --- Scheduler
-  Health["/healthz"] --- Scheduler
+  Metrics["/metrics/prometheus"] --- Job
+  Health["/healthz"] --- Job
 ```
 
 ### OpenSky Proxy Sequence (Ingester -> Worker -> OpenSky)
@@ -52,11 +56,19 @@ If OpenSky or the proxy path fails, the ingester tracks failures and applies pro
 - `com.cloudradar.ingester.config.*`  
   Configuration records and shared beans (HTTP client, OpenSkyProperties).
 - `com.cloudradar.ingester.opensky.*`  
-  OAuth2 token handling, API client, and data mapping into `FlightState`.
+  OAuth2 token handling and OpenSky API client helpers (`OpenSkyClient`, `OpenSkyTokenService`, HTTP metrics/request helpers).
 - `com.cloudradar.ingester.redis.RedisPublisher`  
   Serializes events as JSON and pushes them to a Redis List.
 - `com.cloudradar.ingester.FlightIngestJob`  
-  Scheduled job that pulls from OpenSky and pushes to Redis.
+  Scheduled orchestrator (fetch, map, publish, failure handling).
+- `com.cloudradar.ingester.FlightEventMapper`  
+  Maps `FlightState` into Redis payload (`opensky_fetch_epoch` included).
+- `com.cloudradar.ingester.IngestionBackoffController`  
+  Progressive backoff and disable-after-threshold policy.
+- `com.cloudradar.ingester.OpenSkyRateLimitTracker`  
+  Effective quota tracking and refresh-delay adaptation.
+- `com.cloudradar.ingester.IngesterMetrics`  
+  Ingestion counters/gauges registration and updates.
 
 ## Class diagram
 
@@ -67,6 +79,10 @@ If OpenSky or the proxy path fails, the ingester tracks failures and applies pro
 classDiagram
   class IngesterApplication
   class FlightIngestJob
+  class FlightEventMapper
+  class IngestionBackoffController
+  class OpenSkyRateLimitTracker
+  class IngesterMetrics
   class OpenSkyClient
   class OpenSkyTokenService
   class RedisPublisher
@@ -76,6 +92,10 @@ classDiagram
 
   IngesterApplication --> FlightIngestJob : schedules
   FlightIngestJob --> OpenSkyClient : fetch states
+  FlightIngestJob --> FlightEventMapper : map events
+  FlightIngestJob --> IngestionBackoffController : backoff/disable
+  FlightIngestJob --> OpenSkyRateLimitTracker : credits + delay
+  FlightIngestJob --> IngesterMetrics : counters/gauges
   FlightIngestJob --> RedisPublisher : push events
   OpenSkyClient --> OpenSkyTokenService : bearer token
   OpenSkyTokenService --> OpenSkyProperties : credentials + URLs
@@ -87,12 +107,12 @@ classDiagram
 
 ## How it works
 
-1. `FlightIngestJob` runs every `INGESTER_REFRESH_MS` (default 10s).
-2. `OpenSkyClient` requests `/states/all` for the IDF bbox, using an OAuth2 token.
-3. The response is mapped to `FlightState` objects, then to a simple JSON payload.
-4. `RedisPublisher` pushes each payload into a Redis List (`cloudradar:ingest:queue`).
-5. Metrics and health endpoints are exposed via Actuator (`/metrics/prometheus`, `/healthz`).
-6. When OpenSky is unreachable, the ingester applies progressive backoff and stops after the final tier until restart.
+1. `FlightIngestJob` runs every `INGESTER_REFRESH_MS` (default 10s) and orchestrates one ingestion cycle.
+2. `OpenSkyClient` requests `/states/all` for the configured bbox, using an OAuth2 token from `OpenSkyTokenService`.
+3. `OpenSkyRateLimitTracker` updates effective quota/credits and computes the next refresh delay tier.
+4. `FlightEventMapper` converts `FlightState` into Redis payloads (including `opensky_fetch_epoch`).
+5. `RedisPublisher` pushes payloads into `cloudradar:ingest:queue`.
+6. `IngesterMetrics` updates ingestion and OpenSky gauges/counters; `IngestionBackoffController` handles failure backoff/disable behavior.
 
 ### Failure backoff
 
@@ -121,7 +141,14 @@ mvn -B test
 
 Current Java test baseline:
 - `IngesterApplicationTests.contextLoads()` validates Spring wiring/startup.
+- `FlightIngestJobTest` validates orchestrator behavior (fetch -> map -> publish, error path/backoff).
+- `FlightEventMapperTest` validates `FlightState -> event` mapping (including `opensky_fetch_epoch`).
+- `IngestionBackoffControllerTest` validates progressive backoff tiers and disable-after-threshold behavior.
+- `OpenSkyRateLimitTrackerTest` validates effective quota headers, counters reset, and refresh-delay adaptation.
+- `IngesterMetricsTest` validates counter/gauge registration + updates.
 - `OpenSkyClientTest` validates OpenSky JSON row mapping (`states[]`) and rate-limit header parsing.
+- `OpenSkyTokenServiceTest` validates token caching/refresh and error propagation.
+- `TokenCooldownPolicyTest` validates token cooldown progression/reset independently.
 
 ## Optional env overrides
 - `INGESTER_REFRESH_MS` (default: 10000)

--- a/src/ingester/src/main/java/com/cloudradar/ingester/FlightEventMapper.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/FlightEventMapper.java
@@ -1,0 +1,33 @@
+package com.cloudradar.ingester;
+
+import com.cloudradar.ingester.opensky.FlightState;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class FlightEventMapper {
+
+  List<Map<String, Object>> toEvents(List<FlightState> states, long openskyFetchEpoch) {
+    return states.stream()
+        .map(state -> toEvent(state, openskyFetchEpoch))
+        .collect(Collectors.toList());
+  }
+
+  Map<String, Object> toEvent(FlightState state, long openskyFetchEpoch) {
+    Map<String, Object> event = new HashMap<>();
+    event.put("icao24", state.icao24());
+    event.put("callsign", state.callsign());
+    event.put("lat", state.latitude());
+    event.put("lon", state.longitude());
+    event.put("velocity", state.velocity());
+    event.put("heading", state.heading());
+    event.put("geo_altitude", state.geoAltitude());
+    event.put("baro_altitude", state.baroAltitude());
+    event.put("on_ground", state.onGround());
+    event.put("time_position", state.timePosition());
+    event.put("last_contact", state.lastContact());
+    event.put("opensky_fetch_epoch", openskyFetchEpoch);
+    return event;
+  }
+}

--- a/src/ingester/src/main/java/com/cloudradar/ingester/FlightIngestJob.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/FlightIngestJob.java
@@ -5,13 +5,10 @@ import com.cloudradar.ingester.opensky.FetchResult;
 import com.cloudradar.ingester.opensky.FlightState;
 import com.cloudradar.ingester.opensky.OpenSkyClient;
 import com.cloudradar.ingester.redis.RedisPublisher;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -21,65 +18,45 @@ import org.springframework.stereotype.Component;
 public class FlightIngestJob {
   private static final Logger log = LoggerFactory.getLogger(FlightIngestJob.class);
 
-  private enum RateLimitLevel {
-    NORMAL,
-    WARN_50,
-    WARN_80,
-    WARN_95
-  }
-
   private final OpenSkyClient openSkyClient;
   private final RedisPublisher redisPublisher;
-  private final Counter fetchCounter;
-  private final Counter requestCounter;
-  private final Counter pushCounter;
-  private final Counter errorCounter;
+  private final FlightEventMapper eventMapper;
+  private final OpenSkyRateLimitTracker rateLimitTracker;
+  private final IngestionBackoffController backoffController;
+  private final IngesterMetrics metrics;
   private final IngesterProperties properties;
-  private volatile long currentDelayMs;
-  private volatile long nextAllowedAtMs;
-  private volatile RateLimitLevel lastRateLevel = RateLimitLevel.NORMAL;
-  private volatile boolean disabled = false;
-  private final java.util.concurrent.atomic.AtomicInteger consecutiveFailures =
-      new java.util.concurrent.atomic.AtomicInteger(0);
-  private static final long[] FAILURE_BACKOFF_MS = {
-    1000L,      // 1s
-    2000L,      // 2s
-    5000L,      // 5s
-    10000L,     // 10s
-    30000L,     // 30s
-    60000L,     // 60s
-    300000L,    // 5m
-    600000L,    // 10m
-    1800000L,   // 30m
-    3600000L    // 1h
-  };
-  private final java.util.concurrent.atomic.AtomicLong remainingCredits = new java.util.concurrent.atomic.AtomicLong(-1);
-  private final java.util.concurrent.atomic.AtomicLong lastRemainingCredits = new java.util.concurrent.atomic.AtomicLong(-1);
-  private final java.util.concurrent.atomic.AtomicLong creditLimitOverride = new java.util.concurrent.atomic.AtomicLong(-1);
-  private final java.util.concurrent.atomic.AtomicLong resetAtEpochSeconds = new java.util.concurrent.atomic.AtomicLong(-1);
-  private final java.util.concurrent.atomic.AtomicLong requestsSinceReset = new java.util.concurrent.atomic.AtomicLong(0);
-  private final java.util.concurrent.atomic.AtomicLong creditsUsedSinceReset = new java.util.concurrent.atomic.AtomicLong(0);
-  private final java.util.concurrent.atomic.AtomicLong eventsSinceReset = new java.util.concurrent.atomic.AtomicLong(0);
-  private final java.util.concurrent.atomic.AtomicLong lastStatesCount = new java.util.concurrent.atomic.AtomicLong(0);
-  private final java.util.concurrent.atomic.AtomicLong currentBackoffSeconds = new java.util.concurrent.atomic.AtomicLong(0);
-  private final java.util.concurrent.atomic.AtomicInteger disabledGauge = new java.util.concurrent.atomic.AtomicInteger(0);
 
   public FlightIngestJob(
       OpenSkyClient openSkyClient,
       RedisPublisher redisPublisher,
       MeterRegistry meterRegistry,
       IngesterProperties properties) {
+    this(
+        openSkyClient,
+        redisPublisher,
+        new FlightEventMapper(),
+        new OpenSkyRateLimitTracker(properties),
+        new IngestionBackoffController(),
+        properties,
+        meterRegistry);
+  }
+
+  FlightIngestJob(
+      OpenSkyClient openSkyClient,
+      RedisPublisher redisPublisher,
+      FlightEventMapper eventMapper,
+      OpenSkyRateLimitTracker rateLimitTracker,
+      IngestionBackoffController backoffController,
+      IngesterProperties properties,
+      MeterRegistry meterRegistry) {
     this.openSkyClient = openSkyClient;
     this.redisPublisher = redisPublisher;
-    this.fetchCounter = meterRegistry.counter("ingester.fetch.total");
-    this.requestCounter = meterRegistry.counter("ingester.fetch.requests.total");
-    this.pushCounter = meterRegistry.counter("ingester.push.total");
-    this.errorCounter = meterRegistry.counter("ingester.errors.total");
+    this.eventMapper = eventMapper;
+    this.rateLimitTracker = rateLimitTracker;
+    this.backoffController = backoffController;
     this.properties = properties;
-    this.currentDelayMs = properties.refreshMs();
-    this.nextAllowedAtMs = 0;
-
-    registerGauges(meterRegistry);
+    this.metrics =
+        new IngesterMetrics(meterRegistry, properties, this.rateLimitTracker, this.backoffController);
   }
 
   @PostConstruct
@@ -95,341 +72,44 @@ public class FlightIngestJob {
 
   @Scheduled(fixedDelayString = "${ingester.refresh-ms}")
   public void ingest() {
-    if (disabled) {
-      return;
-    }
     long now = System.currentTimeMillis();
-    if (now < nextAllowedAtMs) {
+    if (backoffController.shouldSkipCycle(now)) {
       return;
     }
+
     try {
-      // Fetch current states inside the configured bbox, then push as JSON events.
       FetchResult result = openSkyClient.fetchStates();
       List<FlightState> states = result.states();
-      requestCounter.increment();
-      requestsSinceReset.incrementAndGet();
-      eventsSinceReset.addAndGet(states.size());
-      lastStatesCount.set(states.size());
-      fetchCounter.increment(states.size());
-      long openskyFetchEpoch = System.currentTimeMillis() / 1000;
+      rateLimitTracker.recordFetch(states.size());
+      metrics.recordFetch(states.size());
 
-      List<Map<String, Object>> payloads = states.stream()
-          .map(state -> toEvent(state, openskyFetchEpoch))
-          .collect(Collectors.toList());
+      long openskyFetchEpoch = System.currentTimeMillis() / 1000;
+      List<Map<String, Object>> payloads = eventMapper.toEvents(states, openskyFetchEpoch);
 
       int pushed = redisPublisher.pushEvents(payloads);
-      pushCounter.increment(pushed);
+      metrics.recordPush(pushed);
       log.info("Fetched {} states, pushed {} events", states.size(), pushed);
 
-      updateCreditTracking(result.remainingCredits());
-      updateResetTracking(result.creditLimit(), result.resetAtEpochSeconds());
-      updateRateLimit(result.remainingCredits());
-      consecutiveFailures.set(0);
-      currentBackoffSeconds.set(0);
-      disabledGauge.set(0);
-      nextAllowedAtMs = System.currentTimeMillis() + currentDelayMs;
+      rateLimitTracker.recordSuccessfulCycle(
+          result.remainingCredits(),
+          result.creditLimit(),
+          result.resetAtEpochSeconds());
+      backoffController.recordSuccess(System.currentTimeMillis(), rateLimitTracker.currentDelayMs());
     } catch (Exception ex) {
-      // Keep the scheduler running even if a cycle fails.
-      errorCounter.increment();
+      metrics.recordError();
       log.error("Ingestion cycle failed", ex);
-      int failureCount = consecutiveFailures.incrementAndGet();
-      if (failureCount <= FAILURE_BACKOFF_MS.length) {
-        long backoffMs = FAILURE_BACKOFF_MS[failureCount - 1];
-        nextAllowedAtMs = System.currentTimeMillis() + backoffMs;
-        currentBackoffSeconds.set(backoffMs / 1000);
-        log.warn("OpenSky fetch failed (attempt {}), backing off for {} ms", failureCount, backoffMs);
-      } else {
-        disabled = true;
-        currentBackoffSeconds.set(0);
-        disabledGauge.set(1);
-        nextAllowedAtMs = Long.MAX_VALUE;
-        log.error("OpenSky fetch failed {} times. Disabling ingestion until restart.", failureCount);
+      IngestionBackoffController.FailureDecision decision =
+          backoffController.recordFailure(System.currentTimeMillis());
+      if (decision.disabled()) {
+        log.error(
+            "OpenSky fetch failed {} times. Disabling ingestion until restart.",
+            decision.failureCount());
+        return;
       }
-    }
-  }
-
-  private Map<String, Object> toEvent(FlightState state, long openskyFetchEpoch) {
-    Map<String, Object> event = new HashMap<>();
-    event.put("icao24", state.icao24());
-    event.put("callsign", state.callsign());
-    event.put("lat", state.latitude());
-    event.put("lon", state.longitude());
-    event.put("velocity", state.velocity());
-    event.put("heading", state.heading());
-    event.put("geo_altitude", state.geoAltitude());
-    event.put("baro_altitude", state.baroAltitude());
-    event.put("on_ground", state.onGround());
-    event.put("time_position", state.timePosition());
-    event.put("last_contact", state.lastContact());
-    event.put("opensky_fetch_epoch", openskyFetchEpoch);
-    return event;
-  }
-
-  private void registerGauges(MeterRegistry meterRegistry) {
-    meterRegistry.gauge("ingester.opensky.credits.remaining", remainingCredits);
-    meterRegistry.gauge("ingester.opensky.credits.limit", creditLimitOverride);
-    meterRegistry.gauge("ingester.opensky.requests.since_reset", requestsSinceReset);
-    meterRegistry.gauge("ingester.opensky.credits.used.since_reset", creditsUsedSinceReset);
-    meterRegistry.gauge("ingester.opensky.credits.consumed.percent", this, job -> job.consumedPercent());
-    meterRegistry.gauge("ingester.opensky.events.since_reset", eventsSinceReset);
-    meterRegistry.gauge("ingester.opensky.states.last_count", lastStatesCount);
-    meterRegistry.gauge("ingester.opensky.credits.avg_per_request", this, job -> job.averageCreditsPerRequest());
-    meterRegistry.gauge("ingester.opensky.events.avg_per_request", this, job -> job.averageEventsPerRequest());
-    meterRegistry.gauge("ingester.opensky.bbox.area.square_degrees", this, job -> job.bboxAreaSquareDegrees());
-    // Approximate area in km2 (good enough for a density index on the dashboard).
-    meterRegistry.gauge("ingester.opensky.bbox.area.km2", this, job -> job.bboxAreaKm2());
-    meterRegistry.gauge("ingester.opensky.reset.eta_seconds", this, job -> job.resetEtaSeconds());
-    meterRegistry.gauge("ingester.opensky.quota", this, job -> job.quotaOrDefault());
-    meterRegistry.gauge("ingester.opensky.threshold.warn50", this, job -> job.thresholdPercent("warn50"));
-    meterRegistry.gauge("ingester.opensky.threshold.warn80", this, job -> job.thresholdPercent("warn80"));
-    meterRegistry.gauge("ingester.opensky.threshold.warn95", this, job -> job.thresholdPercent("warn95"));
-    meterRegistry.gauge("ingester.opensky.backoff.seconds", currentBackoffSeconds);
-    meterRegistry.gauge("ingester.opensky.disabled", disabledGauge);
-  }
-
-  private void updateCreditTracking(Integer remaining) {
-    if (remaining == null) {
-      return;
-    }
-
-    long previous = lastRemainingCredits.getAndSet(remaining);
-    remainingCredits.set(remaining);
-
-    if (previous < 0) {
-      return;
-    }
-
-    if (remaining > previous) {
-      // Credits replenished (daily reset). Reset per-period counters.
-      requestsSinceReset.set(0);
-      creditsUsedSinceReset.set(0);
-      eventsSinceReset.set(0);
-      // The API may not provide reset headers; still keep a best-effort local marker.
-      resetAtEpochSeconds.set(-1);
-      return;
-    }
-
-    long delta = previous - remaining;
-    if (delta > 0) {
-      creditsUsedSinceReset.addAndGet(delta);
-    }
-  }
-
-  private void updateResetTracking(Integer creditLimit, Long resetAt) {
-    applyEffectiveCreditLimit(creditLimit);
-    applyResetAtHeader(resetAt);
-  }
-
-  private void applyEffectiveCreditLimit(Integer creditLimit) {
-    if (creditLimit != null && creditLimit > 0) {
-      applyCreditLimitFromHeader(creditLimit);
-      return;
-    }
-
-    long configuredQuota = configuredQuota();
-    if (configuredQuota > 0) {
-      creditLimitOverride.set(configuredQuota);
-    }
-  }
-
-  private void applyCreditLimitFromHeader(long creditLimit) {
-    long previous = creditLimitOverride.getAndSet(creditLimit);
-    if (previous == creditLimit) {
-      return;
-    }
-
-    long configuredQuota = configuredQuota();
-    log.info(
-        "OpenSky rate-limit header detected: limit={} (configured quota={})",
-        creditLimit,
-        configuredQuota);
-    if (configuredQuota > 0 && configuredQuota != creditLimit) {
       log.warn(
-          "OpenSky header limit ({}) differs from configured OPENSKY_CREDITS_QUOTA ({}). Throttling now uses header limit.",
-          creditLimit,
-          configuredQuota);
+          "OpenSky fetch failed (attempt {}), backing off for {} ms",
+          decision.failureCount(),
+          decision.backoffMs());
     }
-  }
-
-  private void applyResetAtHeader(Long resetAt) {
-    if (resetAt == null || resetAt <= 0) {
-      return;
-    }
-    long previousResetAt = resetAtEpochSeconds.getAndSet(resetAt);
-    if (previousResetAt != resetAt) {
-      log.info("OpenSky rate-limit reset header updated: reset_at_epoch_seconds={}", resetAt);
-    }
-  }
-
-  private long configuredQuota() {
-    IngesterProperties.RateLimit rateLimit = properties.rateLimit();
-    if (rateLimit == null || rateLimit.quota() <= 0) {
-      return 0;
-    }
-    return rateLimit.quota();
-  }
-
-  private double resetEtaSeconds() {
-    long resetAt = resetAtEpochSeconds.get();
-    if (resetAt <= 0) {
-      return 0.0;
-    }
-    long now = System.currentTimeMillis() / 1000;
-    long eta = resetAt - now;
-    return Math.max(0.0, (double) eta);
-  }
-
-  private double consumedPercent() {
-    long limit = creditLimitOverride.get();
-    long remaining = remainingCredits.get();
-    if (limit <= 0 || remaining < 0) {
-      return 0.0;
-    }
-    long used = Math.max(0L, limit - remaining);
-    double pct = ((double) used / (double) limit) * 100.0;
-    if (pct < 0.0) {
-      return 0.0;
-    }
-    if (pct > 100.0) {
-      return 100.0;
-    }
-    return pct;
-  }
-
-  private double averageCreditsPerRequest() {
-    long requests = requestsSinceReset.get();
-    if (requests == 0) {
-      return 0.0;
-    }
-    return (double) creditsUsedSinceReset.get() / (double) requests;
-  }
-
-  private double averageEventsPerRequest() {
-    long requests = requestsSinceReset.get();
-    if (requests == 0) {
-      return 0.0;
-    }
-    return (double) eventsSinceReset.get() / (double) requests;
-  }
-
-  private double bboxAreaSquareDegrees() {
-    IngesterProperties.Bbox bbox = properties.bbox();
-    return Math.max(0.0, (bbox.latMax() - bbox.latMin()) * (bbox.lonMax() - bbox.lonMin()));
-  }
-
-  private double bboxAreaKm2() {
-    // Very lightweight approximation for a lat/lon bbox (sufficient for an at-a-glance dashboard gauge).
-    // 1 deg lat ~= 110.574 km; 1 deg lon ~= 111.320 km * cos(lat).
-    IngesterProperties.Bbox bbox = properties.bbox();
-    double latMin = bbox.latMin();
-    double latMax = bbox.latMax();
-    double lonMin = bbox.lonMin();
-    double lonMax = bbox.lonMax();
-
-    double dLat = Math.max(0.0, latMax - latMin);
-    double dLon = Math.max(0.0, lonMax - lonMin);
-
-    double latMidRad = Math.toRadians((latMin + latMax) / 2.0);
-    double heightKm = dLat * 110.574;
-    double widthKm = dLon * 111.320 * Math.cos(latMidRad);
-    return Math.max(0.0, widthKm * heightKm);
-  }
-
-  private double quotaOrDefault() {
-    return effectiveQuota(properties.rateLimit());
-  }
-
-  private double thresholdPercent(String threshold) {
-    IngesterProperties.RateLimit rateLimit = properties.rateLimit();
-    if (rateLimit == null) {
-      return 0.0;
-    }
-    return switch (threshold) {
-      case "warn50" -> rateLimit.warn50();
-      case "warn80" -> rateLimit.warn80();
-      case "warn95" -> rateLimit.warn95();
-      default -> 0.0;
-    };
-  }
-
-  private void updateRateLimit(Integer remainingCredits) {
-    IngesterProperties.RateLimit rateLimit = properties.rateLimit();
-    if (rateLimit == null || remainingCredits == null) {
-      return;
-    }
-
-    long quota = effectiveQuota(rateLimit);
-    if (quota <= 0) {
-      return;
-    }
-
-    long remaining = remainingCredits;
-    double consumed = ((double) (quota - remaining) / (double) quota) * 100.0;
-    if (consumed < 0) {
-      consumed = 0;
-    }
-    if (consumed > 100) {
-      consumed = 100;
-    }
-
-    RateLimitLevel level = resolveLevel(consumed, rateLimit);
-    if (level != lastRateLevel) {
-      log.warn(
-          "OpenSky credits consumed {}% (remaining: {}/{}). Threshold reached: {}%",
-          String.format("%.1f", consumed),
-          remaining,
-          quota,
-          levelToPercent(level, rateLimit));
-      lastRateLevel = level;
-    }
-
-    long newDelayMs = resolveDelay(level, rateLimit);
-    if (newDelayMs != currentDelayMs) {
-      log.info("Adjusting refresh interval to {}s based on OpenSky credit usage", newDelayMs / 1000);
-      currentDelayMs = newDelayMs;
-    }
-  }
-
-  private long effectiveQuota(IngesterProperties.RateLimit rateLimit) {
-    long limitFromHeaders = creditLimitOverride.get();
-    if (limitFromHeaders > 0) {
-      return limitFromHeaders;
-    }
-    if (rateLimit == null || rateLimit.quota() <= 0) {
-      return 0;
-    }
-    return rateLimit.quota();
-  }
-
-  private RateLimitLevel resolveLevel(double consumed, IngesterProperties.RateLimit rateLimit) {
-    if (consumed >= rateLimit.warn95()) {
-      return RateLimitLevel.WARN_95;
-    }
-    if (consumed >= rateLimit.warn80()) {
-      return RateLimitLevel.WARN_80;
-    }
-    if (consumed >= rateLimit.warn50()) {
-      return RateLimitLevel.WARN_50;
-    }
-    return RateLimitLevel.NORMAL;
-  }
-
-  private int levelToPercent(RateLimitLevel level, IngesterProperties.RateLimit rateLimit) {
-    return switch (level) {
-      case WARN_95 -> rateLimit.warn95();
-      case WARN_80 -> rateLimit.warn80();
-      case WARN_50 -> rateLimit.warn50();
-      default -> 0;
-    };
-  }
-
-  private long resolveDelay(RateLimitLevel level, IngesterProperties.RateLimit rateLimit) {
-    if (level == RateLimitLevel.WARN_95) {
-      return rateLimit.refreshCriticalMs();
-    }
-    if (level == RateLimitLevel.WARN_80) {
-      return rateLimit.refreshWarnMs();
-    }
-    return properties.refreshMs();
   }
 }

--- a/src/ingester/src/main/java/com/cloudradar/ingester/IngesterMetrics.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/IngesterMetrics.java
@@ -1,0 +1,126 @@
+package com.cloudradar.ingester;
+
+import com.cloudradar.ingester.config.IngesterProperties;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+class IngesterMetrics {
+  private final Counter fetchCounter;
+  private final Counter requestCounter;
+  private final Counter pushCounter;
+  private final Counter errorCounter;
+  private final IngesterProperties properties;
+
+  IngesterMetrics(
+      MeterRegistry meterRegistry,
+      IngesterProperties properties,
+      OpenSkyRateLimitTracker rateLimitTracker,
+      IngestionBackoffController backoffController) {
+    this.fetchCounter = meterRegistry.counter("ingester.fetch.total");
+    this.requestCounter = meterRegistry.counter("ingester.fetch.requests.total");
+    this.pushCounter = meterRegistry.counter("ingester.push.total");
+    this.errorCounter = meterRegistry.counter("ingester.errors.total");
+    this.properties = properties;
+
+    meterRegistry.gauge(
+        "ingester.opensky.credits.remaining",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.REMAINING_CREDITS));
+    meterRegistry.gauge(
+        "ingester.opensky.credits.limit",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.CREDIT_LIMIT));
+    meterRegistry.gauge(
+        "ingester.opensky.requests.since_reset",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.REQUESTS_SINCE_RESET));
+    meterRegistry.gauge(
+        "ingester.opensky.credits.used.since_reset",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.CREDITS_USED_SINCE_RESET));
+    meterRegistry.gauge(
+        "ingester.opensky.credits.consumed.percent",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.CONSUMED_PERCENT));
+    meterRegistry.gauge(
+        "ingester.opensky.events.since_reset",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.EVENTS_SINCE_RESET));
+    meterRegistry.gauge(
+        "ingester.opensky.states.last_count",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.LAST_STATES_COUNT));
+    meterRegistry.gauge(
+        "ingester.opensky.credits.avg_per_request",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.AVERAGE_CREDITS_PER_REQUEST));
+    meterRegistry.gauge(
+        "ingester.opensky.events.avg_per_request",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.AVERAGE_EVENTS_PER_REQUEST));
+    meterRegistry.gauge("ingester.opensky.bbox.area.square_degrees", this, IngesterMetrics::bboxAreaSquareDegrees);
+    meterRegistry.gauge("ingester.opensky.bbox.area.km2", this, IngesterMetrics::bboxAreaKm2);
+    meterRegistry.gauge(
+        "ingester.opensky.reset.eta_seconds",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.RESET_ETA_SECONDS));
+    meterRegistry.gauge(
+        "ingester.opensky.quota",
+        rateLimitTracker,
+        tracker -> tracker.metric(OpenSkyRateLimitTracker.Metric.QUOTA));
+    meterRegistry.gauge(
+        "ingester.opensky.threshold.warn50",
+        rateLimitTracker,
+        tracker -> tracker.thresholdPercent(OpenSkyRateLimitTracker.Threshold.WARN50));
+    meterRegistry.gauge(
+        "ingester.opensky.threshold.warn80",
+        rateLimitTracker,
+        tracker -> tracker.thresholdPercent(OpenSkyRateLimitTracker.Threshold.WARN80));
+    meterRegistry.gauge(
+        "ingester.opensky.threshold.warn95",
+        rateLimitTracker,
+        tracker -> tracker.thresholdPercent(OpenSkyRateLimitTracker.Threshold.WARN95));
+    meterRegistry.gauge(
+        "ingester.opensky.backoff.seconds",
+        backoffController,
+        controller -> (double) controller.currentBackoffSeconds());
+    meterRegistry.gauge(
+        "ingester.opensky.disabled",
+        backoffController,
+        controller -> (double) controller.disabledGaugeValue());
+  }
+
+  void recordFetch(int statesCount) {
+    fetchCounter.increment(statesCount);
+    requestCounter.increment();
+  }
+
+  void recordPush(int pushedCount) {
+    pushCounter.increment(pushedCount);
+  }
+
+  void recordError() {
+    errorCounter.increment();
+  }
+
+  private double bboxAreaSquareDegrees() {
+    IngesterProperties.Bbox bbox = properties.bbox();
+    return Math.max(0.0, (bbox.latMax() - bbox.latMin()) * (bbox.lonMax() - bbox.lonMin()));
+  }
+
+  private double bboxAreaKm2() {
+    IngesterProperties.Bbox bbox = properties.bbox();
+    double latMin = bbox.latMin();
+    double latMax = bbox.latMax();
+    double lonMin = bbox.lonMin();
+    double lonMax = bbox.lonMax();
+
+    double dLat = Math.max(0.0, latMax - latMin);
+    double dLon = Math.max(0.0, lonMax - lonMin);
+
+    double latMidRad = Math.toRadians((latMin + latMax) / 2.0);
+    double heightKm = dLat * 110.574;
+    double widthKm = dLon * 111.320 * Math.cos(latMidRad);
+    return Math.max(0.0, widthKm * heightKm);
+  }
+}

--- a/src/ingester/src/main/java/com/cloudradar/ingester/IngestionBackoffController.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/IngestionBackoffController.java
@@ -1,0 +1,59 @@
+package com.cloudradar.ingester;
+
+class IngestionBackoffController {
+  private static final long[] FAILURE_BACKOFF_MS = {
+    1000L,     // 1s
+    2000L,     // 2s
+    5000L,     // 5s
+    10000L,    // 10s
+    30000L,    // 30s
+    60000L,    // 60s
+    300000L,   // 5m
+    600000L,   // 10m
+    1800000L,  // 30m
+    3600000L   // 1h
+  };
+
+  private long nextAllowedAtMs = 0L;
+  private int consecutiveFailures = 0;
+  private long currentBackoffSeconds = 0L;
+  private boolean disabled = false;
+
+  synchronized boolean shouldSkipCycle(long nowMs) {
+    if (disabled) {
+      return true;
+    }
+    return nowMs < nextAllowedAtMs;
+  }
+
+  synchronized void recordSuccess(long nowMs, long nextDelayMs) {
+    consecutiveFailures = 0;
+    currentBackoffSeconds = 0L;
+    nextAllowedAtMs = nowMs + nextDelayMs;
+  }
+
+  synchronized FailureDecision recordFailure(long nowMs) {
+    consecutiveFailures++;
+    if (consecutiveFailures <= FAILURE_BACKOFF_MS.length) {
+      long backoffMs = FAILURE_BACKOFF_MS[consecutiveFailures - 1];
+      nextAllowedAtMs = nowMs + backoffMs;
+      currentBackoffSeconds = backoffMs / 1000L;
+      return new FailureDecision(consecutiveFailures, false, backoffMs);
+    }
+
+    disabled = true;
+    currentBackoffSeconds = 0L;
+    nextAllowedAtMs = Long.MAX_VALUE;
+    return new FailureDecision(consecutiveFailures, true, 0L);
+  }
+
+  synchronized long currentBackoffSeconds() {
+    return currentBackoffSeconds;
+  }
+
+  synchronized int disabledGaugeValue() {
+    return disabled ? 1 : 0;
+  }
+
+  record FailureDecision(int failureCount, boolean disabled, long backoffMs) {}
+}

--- a/src/ingester/src/main/java/com/cloudradar/ingester/OpenSkyRateLimitMetricCalculator.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/OpenSkyRateLimitMetricCalculator.java
@@ -1,0 +1,112 @@
+package com.cloudradar.ingester;
+
+import com.cloudradar.ingester.config.IngesterProperties;
+import java.util.EnumMap;
+
+final class OpenSkyRateLimitMetricCalculator {
+  private interface MetricReader {
+    double read(State state);
+  }
+
+  private record State(
+      long remainingCredits,
+      long creditLimitOverride,
+      long requestsSinceReset,
+      long creditsUsedSinceReset,
+      long eventsSinceReset,
+      long lastStatesCount,
+      long resetAtEpochSeconds,
+      IngesterProperties.RateLimit rateLimit) {}
+
+  private static final EnumMap<OpenSkyRateLimitTracker.Metric, MetricReader> READERS =
+      new EnumMap<>(OpenSkyRateLimitTracker.Metric.class);
+
+  static {
+    READERS.put(OpenSkyRateLimitTracker.Metric.REMAINING_CREDITS, State::remainingCredits);
+    READERS.put(OpenSkyRateLimitTracker.Metric.CREDIT_LIMIT, State::creditLimitOverride);
+    READERS.put(OpenSkyRateLimitTracker.Metric.REQUESTS_SINCE_RESET, State::requestsSinceReset);
+    READERS.put(OpenSkyRateLimitTracker.Metric.CREDITS_USED_SINCE_RESET, State::creditsUsedSinceReset);
+    READERS.put(OpenSkyRateLimitTracker.Metric.CONSUMED_PERCENT, state -> consumedPercent(
+        state.remainingCredits(),
+        state.creditLimitOverride()));
+    READERS.put(OpenSkyRateLimitTracker.Metric.EVENTS_SINCE_RESET, State::eventsSinceReset);
+    READERS.put(OpenSkyRateLimitTracker.Metric.LAST_STATES_COUNT, State::lastStatesCount);
+    READERS.put(OpenSkyRateLimitTracker.Metric.AVERAGE_CREDITS_PER_REQUEST, state -> average(
+        state.creditsUsedSinceReset(),
+        state.requestsSinceReset()));
+    READERS.put(OpenSkyRateLimitTracker.Metric.AVERAGE_EVENTS_PER_REQUEST, state -> average(
+        state.eventsSinceReset(),
+        state.requestsSinceReset()));
+    READERS.put(OpenSkyRateLimitTracker.Metric.RESET_ETA_SECONDS, state -> resetEtaSeconds(state.resetAtEpochSeconds()));
+    READERS.put(OpenSkyRateLimitTracker.Metric.QUOTA, state -> effectiveQuota(
+        state.rateLimit(),
+        state.creditLimitOverride()));
+  }
+
+  private OpenSkyRateLimitMetricCalculator() {}
+
+  static double value(
+      OpenSkyRateLimitTracker.Metric metric,
+      long remainingCredits,
+      long creditLimitOverride,
+      long requestsSinceReset,
+      long creditsUsedSinceReset,
+      long eventsSinceReset,
+      long lastStatesCount,
+      long resetAtEpochSeconds,
+      IngesterProperties.RateLimit rateLimit) {
+    MetricReader reader = READERS.get(metric);
+    if (reader == null) {
+      return 0.0;
+    }
+    return reader.read(new State(
+        remainingCredits,
+        creditLimitOverride,
+        requestsSinceReset,
+        creditsUsedSinceReset,
+        eventsSinceReset,
+        lastStatesCount,
+        resetAtEpochSeconds,
+        rateLimit));
+  }
+
+  private static double consumedPercent(long remainingCredits, long creditLimitOverride) {
+    if (creditLimitOverride <= 0 || remainingCredits < 0) {
+      return 0.0;
+    }
+    long used = Math.max(0L, creditLimitOverride - remainingCredits);
+    double consumed = ((double) used / (double) creditLimitOverride) * 100.0;
+    if (consumed < 0.0) {
+      return 0.0;
+    }
+    if (consumed > 100.0) {
+      return 100.0;
+    }
+    return consumed;
+  }
+
+  private static double average(long total, long count) {
+    if (count == 0L) {
+      return 0.0;
+    }
+    return (double) total / (double) count;
+  }
+
+  private static double resetEtaSeconds(long resetAtEpochSeconds) {
+    if (resetAtEpochSeconds <= 0) {
+      return 0.0;
+    }
+    long now = System.currentTimeMillis() / 1000L;
+    return Math.max(0.0, (double) (resetAtEpochSeconds - now));
+  }
+
+  private static long effectiveQuota(IngesterProperties.RateLimit rateLimit, long creditLimitOverride) {
+    if (creditLimitOverride > 0) {
+      return creditLimitOverride;
+    }
+    if (rateLimit == null || rateLimit.quota() <= 0) {
+      return 0L;
+    }
+    return rateLimit.quota();
+  }
+}

--- a/src/ingester/src/main/java/com/cloudradar/ingester/OpenSkyRateLimitTracker.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/OpenSkyRateLimitTracker.java
@@ -1,0 +1,237 @@
+package com.cloudradar.ingester;
+
+import com.cloudradar.ingester.config.IngesterProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class OpenSkyRateLimitTracker {
+  private static final Logger log = LoggerFactory.getLogger(OpenSkyRateLimitTracker.class);
+
+  enum Metric {
+    REMAINING_CREDITS,
+    CREDIT_LIMIT,
+    REQUESTS_SINCE_RESET,
+    CREDITS_USED_SINCE_RESET,
+    CONSUMED_PERCENT,
+    EVENTS_SINCE_RESET,
+    LAST_STATES_COUNT,
+    AVERAGE_CREDITS_PER_REQUEST,
+    AVERAGE_EVENTS_PER_REQUEST,
+    RESET_ETA_SECONDS,
+    QUOTA
+  }
+
+  enum Threshold {
+    WARN50,
+    WARN80,
+    WARN95
+  }
+
+  private enum RateLimitLevel {
+    NORMAL,
+    WARN_50,
+    WARN_80,
+    WARN_95
+  }
+
+  private final IngesterProperties properties;
+  private long currentDelayMs;
+  private RateLimitLevel lastRateLevel = RateLimitLevel.NORMAL;
+  private long remainingCredits = -1L;
+  private long lastRemainingCredits = -1L;
+  private long creditLimitOverride = -1L;
+  private long resetAtEpochSeconds = -1L;
+  private long requestsSinceReset = 0L;
+  private long creditsUsedSinceReset = 0L;
+  private long eventsSinceReset = 0L;
+  private long lastStatesCount = 0L;
+
+  OpenSkyRateLimitTracker(IngesterProperties properties) {
+    this.properties = properties;
+    this.currentDelayMs = properties.refreshMs();
+  }
+
+  synchronized void recordFetch(int statesCount) {
+    requestsSinceReset++;
+    eventsSinceReset += statesCount;
+    lastStatesCount = statesCount;
+  }
+
+  synchronized void recordSuccessfulCycle(Integer remaining, Integer creditLimit, Long resetAt) {
+    updateCreditTracking(remaining);
+    applyHeaders(creditLimit, resetAt);
+    updateRateLimit(remaining);
+  }
+
+  synchronized long currentDelayMs() {
+    return currentDelayMs;
+  }
+
+  synchronized double metric(Metric metric) {
+    return OpenSkyRateLimitMetricCalculator.value(
+        metric,
+        remainingCredits,
+        creditLimitOverride,
+        requestsSinceReset,
+        creditsUsedSinceReset,
+        eventsSinceReset,
+        lastStatesCount,
+        resetAtEpochSeconds,
+        properties.rateLimit());
+  }
+
+  synchronized double thresholdPercent(Threshold threshold) {
+    IngesterProperties.RateLimit rateLimit = properties.rateLimit();
+    if (rateLimit == null) {
+      return 0.0;
+    }
+    return switch (threshold) {
+      case WARN50 -> rateLimit.warn50();
+      case WARN80 -> rateLimit.warn80();
+      case WARN95 -> rateLimit.warn95();
+    };
+  }
+
+  private void updateCreditTracking(Integer remaining) {
+    if (remaining == null) {
+      return;
+    }
+
+    long previous = lastRemainingCredits;
+    lastRemainingCredits = remaining;
+    remainingCredits = remaining;
+
+    if (previous < 0) {
+      return;
+    }
+
+    if (remaining > previous) {
+      requestsSinceReset = 0L;
+      creditsUsedSinceReset = 0L;
+      eventsSinceReset = 0L;
+      resetAtEpochSeconds = -1L;
+      return;
+    }
+
+    long delta = previous - remaining;
+    if (delta > 0) {
+      creditsUsedSinceReset += delta;
+    }
+  }
+
+  private void applyHeaders(Integer creditLimit, Long resetAt) {
+    if (creditLimit != null && creditLimit > 0) {
+      applyCreditLimitFromHeader(creditLimit);
+    } else {
+      IngesterProperties.RateLimit configured = properties.rateLimit();
+      if (configured != null && configured.quota() > 0) {
+        creditLimitOverride = configured.quota();
+      }
+    }
+
+    if (resetAt != null && resetAt > 0) {
+      long previous = resetAtEpochSeconds;
+      resetAtEpochSeconds = resetAt;
+      if (previous != resetAt) {
+        log.info("OpenSky rate-limit reset header updated: reset_at_epoch_seconds={}", resetAt);
+      }
+    }
+  }
+
+  private void applyCreditLimitFromHeader(long creditLimit) {
+    long previous = creditLimitOverride;
+    creditLimitOverride = creditLimit;
+    if (previous == creditLimit) {
+      return;
+    }
+
+    IngesterProperties.RateLimit configured = properties.rateLimit();
+    long configuredQuota = configured == null ? 0L : Math.max(0L, configured.quota());
+    log.info(
+        "OpenSky rate-limit header detected: limit={} (configured quota={})",
+        creditLimit,
+        configuredQuota);
+    if (configuredQuota > 0 && configuredQuota != creditLimit) {
+      log.warn(
+          "OpenSky header limit ({}) differs from configured OPENSKY_CREDITS_QUOTA ({}). Throttling now uses header limit.",
+          creditLimit,
+          configuredQuota);
+    }
+  }
+
+  private void updateRateLimit(Integer remaining) {
+    IngesterProperties.RateLimit rateLimit = properties.rateLimit();
+    if (rateLimit == null || remaining == null) {
+      return;
+    }
+
+    long quota = effectiveQuota(rateLimit);
+    if (quota <= 0) {
+      return;
+    }
+
+    double consumed = ((double) (quota - remaining) / (double) quota) * 100.0;
+    consumed = clampPercent(consumed);
+
+    RateLimitLevel level = resolveLevel(consumed, rateLimit);
+    if (level != lastRateLevel) {
+      log.warn(
+          "OpenSky credits consumed {}% (remaining: {}/{}). Threshold reached: {}%",
+          String.format("%.1f", consumed),
+          remaining,
+          quota,
+          thresholdPercentForLevel(level, rateLimit));
+      lastRateLevel = level;
+    }
+
+    long newDelayMs = level == RateLimitLevel.WARN_95
+        ? rateLimit.refreshCriticalMs()
+        : (level == RateLimitLevel.WARN_80 ? rateLimit.refreshWarnMs() : properties.refreshMs());
+    if (newDelayMs != currentDelayMs) {
+      log.info("Adjusting refresh interval to {}s based on OpenSky credit usage", newDelayMs / 1000L);
+      currentDelayMs = newDelayMs;
+    }
+  }
+
+  private long effectiveQuota(IngesterProperties.RateLimit rateLimit) {
+    if (creditLimitOverride > 0) {
+      return creditLimitOverride;
+    }
+    if (rateLimit == null || rateLimit.quota() <= 0) {
+      return 0L;
+    }
+    return rateLimit.quota();
+  }
+
+  private RateLimitLevel resolveLevel(double consumed, IngesterProperties.RateLimit rateLimit) {
+    if (consumed >= rateLimit.warn95()) {
+      return RateLimitLevel.WARN_95;
+    }
+    if (consumed >= rateLimit.warn80()) {
+      return RateLimitLevel.WARN_80;
+    }
+    if (consumed >= rateLimit.warn50()) {
+      return RateLimitLevel.WARN_50;
+    }
+    return RateLimitLevel.NORMAL;
+  }
+
+  private int thresholdPercentForLevel(RateLimitLevel level, IngesterProperties.RateLimit rateLimit) {
+    return switch (level) {
+      case WARN_95 -> rateLimit.warn95();
+      case WARN_80 -> rateLimit.warn80();
+      case WARN_50 -> rateLimit.warn50();
+      default -> 0;
+    };
+  }
+
+  private double clampPercent(double value) {
+    if (value < 0.0) {
+      return 0.0;
+    }
+    if (value > 100.0) {
+      return 100.0;
+    }
+    return value;
+  }
+}

--- a/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyBboxResolver.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyBboxResolver.java
@@ -1,0 +1,63 @@
+package com.cloudradar.ingester.opensky;
+
+import com.cloudradar.ingester.config.IngesterProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+class OpenSkyBboxResolver {
+  private static final Logger log = LoggerFactory.getLogger(OpenSkyBboxResolver.class);
+
+  private final IngesterProperties ingesterProperties;
+  private final StringRedisTemplate redisTemplate;
+
+  OpenSkyBboxResolver(IngesterProperties ingesterProperties, StringRedisTemplate redisTemplate) {
+    this.ingesterProperties = ingesterProperties;
+    this.redisTemplate = redisTemplate;
+  }
+
+  IngesterProperties.Bbox resolveEffectiveBbox() {
+    IngesterProperties.Bbox base = ingesterProperties.bbox();
+    IngesterProperties.BboxBoost boost = ingesterProperties.bboxBoost();
+    if (boost == null || boost.factor() <= 1.0 || !isPresent(boost.redisKey())) {
+      return base;
+    }
+
+    try {
+      String active = redisTemplate.opsForValue().get(boost.redisKey());
+      if (!isPresent(active)) {
+        return base;
+      }
+      return scaleBboxByArea(base, boost.factor());
+    } catch (Exception ex) {
+      log.debug("Unable to read bbox boost key from Redis, using base bbox", ex);
+      return base;
+    }
+  }
+
+  private IngesterProperties.Bbox scaleBboxByArea(IngesterProperties.Bbox bbox, double areaFactor) {
+    double factor = Math.max(1.0, areaFactor);
+    double linearScale = Math.sqrt(factor);
+
+    double centerLat = (bbox.latMin() + bbox.latMax()) / 2.0;
+    double centerLon = (bbox.lonMin() + bbox.lonMax()) / 2.0;
+    double halfLat = (bbox.latMax() - bbox.latMin()) / 2.0 * linearScale;
+    double halfLon = (bbox.lonMax() - bbox.lonMin()) / 2.0 * linearScale;
+
+    return new IngesterProperties.Bbox(
+        clamp(centerLat - halfLat, -90.0, 90.0),
+        clamp(centerLat + halfLat, -90.0, 90.0),
+        clamp(centerLon - halfLon, -180.0, 180.0),
+        clamp(centerLon + halfLon, -180.0, 180.0));
+  }
+
+  private double clamp(double value, double min, double max) {
+    return Math.max(min, Math.min(max, value));
+  }
+
+  private boolean isPresent(String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyClient.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyClient.java
@@ -1,24 +1,13 @@
 package com.cloudradar.ingester.opensky;
 
 import com.cloudradar.ingester.config.IngesterProperties;
-import com.cloudradar.ingester.config.OpenSkyProperties;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -26,270 +15,111 @@ public class OpenSkyClient {
   private static final Logger log = LoggerFactory.getLogger(OpenSkyClient.class);
 
   private final OpenSkyEndpointProvider endpointProvider;
-  private final IngesterProperties ingesterProperties;
-  private final StringRedisTemplate redisTemplate;
   private final OpenSkyTokenService tokenService;
   private final HttpClient httpClient;
-  private final ObjectMapper objectMapper;
-  private final Timer statesRequestTimer;
-  private final Counter statesRequestSuccessCounter;
-  private final Counter statesRequestRateLimitedCounter;
-  private final Counter statesRequestClientErrorCounter;
-  private final Counter statesRequestServerErrorCounter;
-  private final Counter statesRequestExceptionCounter;
-  private final AtomicInteger lastStatusCode = new AtomicInteger(0);
+  private final OpenSkyBboxResolver bboxResolver;
+  private final OpenSkyResponseParser responseParser;
+  private final OpenSkyStatesHttpMetrics httpMetrics;
 
   public OpenSkyClient(
       OpenSkyEndpointProvider endpointProvider,
-      IngesterProperties ingesterProperties,
-      StringRedisTemplate redisTemplate,
       OpenSkyTokenService tokenService,
-      MeterRegistry meterRegistry,
       HttpClient httpClient,
-      ObjectMapper objectMapper) {
+      OpenSkyBboxResolver bboxResolver,
+      OpenSkyResponseParser responseParser,
+      OpenSkyStatesHttpMetrics httpMetrics) {
     this.endpointProvider = endpointProvider;
-    this.ingesterProperties = ingesterProperties;
-    this.redisTemplate = redisTemplate;
     this.tokenService = tokenService;
     this.httpClient = httpClient;
-    this.objectMapper = objectMapper;
-
-    this.statesRequestTimer = Timer.builder("ingester.opensky.states.http.duration")
-        .description("OpenSky /states/all HTTP request duration (seconds)")
-        .publishPercentileHistogram(true)
-        .register(meterRegistry);
-
-    // Keep cardinality low: a handful of outcomes, no URL labels.
-    this.statesRequestSuccessCounter = Counter.builder("ingester.opensky.states.http.requests.total")
-        .description("OpenSky /states/all HTTP requests (by outcome)")
-        .tag("outcome", "success")
-        .register(meterRegistry);
-    this.statesRequestRateLimitedCounter = Counter.builder("ingester.opensky.states.http.requests.total")
-        .description("OpenSky /states/all HTTP requests (by outcome)")
-        .tag("outcome", "rate_limited")
-        .register(meterRegistry);
-    this.statesRequestClientErrorCounter = Counter.builder("ingester.opensky.states.http.requests.total")
-        .description("OpenSky /states/all HTTP requests (by outcome)")
-        .tag("outcome", "client_error")
-        .register(meterRegistry);
-    this.statesRequestServerErrorCounter = Counter.builder("ingester.opensky.states.http.requests.total")
-        .description("OpenSky /states/all HTTP requests (by outcome)")
-        .tag("outcome", "server_error")
-        .register(meterRegistry);
-    this.statesRequestExceptionCounter = Counter.builder("ingester.opensky.states.http.requests.total")
-        .description("OpenSky /states/all HTTP requests (by outcome)")
-        .tag("outcome", "exception")
-        .register(meterRegistry);
-
-    meterRegistry.gauge("ingester.opensky.states.http.last_status", lastStatusCode);
+    this.bboxResolver = bboxResolver;
+    this.responseParser = responseParser;
+    this.httpMetrics = httpMetrics;
   }
 
   public FetchResult fetchStates() {
     long httpStartNs = -1L;
-    boolean recorded = false;
+    boolean requestRecorded = false;
     try {
-      // Query OpenSky states endpoint within the configured bbox.
-      IngesterProperties.Bbox bbox = resolveEffectiveBbox();
-      String baseUrl = endpointProvider.baseUrl();
-      if (baseUrl == null || baseUrl.isBlank()) {
-        throw new IllegalStateException("OpenSky base URL is missing.");
-      }
-      String url = String.format(
-          "%s/states/all?lamin=%s&lamax=%s&lomin=%s&lomax=%s",
-          baseUrl, bbox.latMin(), bbox.latMax(), bbox.lonMin(), bbox.lonMax());
-
-      HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-          .uri(URI.create(url))
-          .header("Authorization", "Bearer " + tokenService.getToken());
-      addRelayAuthHeader(requestBuilder);
-      HttpRequest request = requestBuilder.GET().build();
-
+      HttpRequest request = buildStatesRequest();
       httpStartNs = System.nanoTime();
       HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-      lastStatusCode.set(response.statusCode());
-      statesRequestTimer.record(System.nanoTime() - httpStartNs, TimeUnit.NANOSECONDS);
-      recorded = true;
-      Integer remainingCredits = parseRemainingCredits(response.headers().firstValue("X-Rate-Limit-Remaining"));
-      Integer creditLimit = parseIntHeader(response.headers().firstValue("X-Rate-Limit-Limit"));
-      Long resetAtEpochSeconds = parseResetAtEpochSeconds(response.headers().firstValue("X-Rate-Limit-Reset"));
-
-      if (response.statusCode() == 429) {
-        statesRequestRateLimitedCounter.increment();
-        log.warn("OpenSky rate limit hit (429)");
-        return new FetchResult(List.of(), remainingCredits, creditLimit, resetAtEpochSeconds);
-      }
-      if (response.statusCode() >= 400) {
-        if (response.statusCode() >= 500) {
-          statesRequestServerErrorCounter.increment();
-        } else {
-          statesRequestClientErrorCounter.increment();
-        }
-        log.warn("OpenSky fetch failed: status={}", response.statusCode());
-        return new FetchResult(List.of(), remainingCredits, creditLimit, resetAtEpochSeconds);
-      }
-      statesRequestSuccessCounter.increment();
-
-      JsonNode root = objectMapper.readTree(response.body());
-      JsonNode states = root.path("states");
-      if (!states.isArray()) {
-        return new FetchResult(List.of(), remainingCredits, creditLimit, resetAtEpochSeconds);
-      }
-
-      // Each row is a fixed-position array defined by OpenSky; we map selected fields.
-      List<FlightState> results = new ArrayList<>();
-      for (JsonNode row : states) {
-        if (!row.isArray()) {
-          continue;
-        }
-        results.add(parseState(row));
-      }
-      return new FetchResult(results, remainingCredits, creditLimit, resetAtEpochSeconds);
+      requestRecorded = true;
+      return handleResponse(response, httpStartNs);
     } catch (OpenSkyTokenService.TokenRefreshException ex) {
-      lastStatusCode.set(0);
-      if (!recorded && httpStartNs > 0) {
-        statesRequestTimer.record(System.nanoTime() - httpStartNs, TimeUnit.NANOSECONDS);
-      }
-      statesRequestExceptionCounter.increment();
-      log.error("Failed to fetch OpenSky states", ex);
+      handleRequestException(httpStartNs, requestRecorded, ex, false);
       throw ex;
     } catch (InterruptedException ex) {
-      lastStatusCode.set(0);
-      if (!recorded && httpStartNs > 0) {
-        statesRequestTimer.record(System.nanoTime() - httpStartNs, TimeUnit.NANOSECONDS);
-      }
-      statesRequestExceptionCounter.increment();
+      handleRequestException(httpStartNs, requestRecorded, ex, true);
+      return new FetchResult(List.of(), null, null, null);
+    } catch (Exception ex) {
+      handleRequestException(httpStartNs, requestRecorded, ex, false);
+      return new FetchResult(List.of(), null, null, null);
+    }
+  }
+
+  private HttpRequest buildStatesRequest() {
+    IngesterProperties.Bbox bbox = bboxResolver.resolveEffectiveBbox();
+    String baseUrl = endpointProvider.baseUrl();
+    if (!isPresent(baseUrl)) {
+      throw new IllegalStateException("OpenSky base URL is missing.");
+    }
+
+    String url = String.format(
+        "%s/states/all?lamin=%s&lamax=%s&lomin=%s&lomax=%s",
+        baseUrl,
+        bbox.latMin(),
+        bbox.latMax(),
+        bbox.lonMin(),
+        bbox.lonMax());
+
+    HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .header("Authorization", "Bearer " + tokenService.getToken());
+    addRelayAuthHeader(requestBuilder);
+    return requestBuilder.GET().build();
+  }
+
+  private FetchResult handleResponse(HttpResponse<String> response, long httpStartNs) throws Exception {
+    int statusCode = response.statusCode();
+    OpenSkyRateLimitHeaders headers = responseParser.parseHeaders(response);
+
+    if (statusCode == 429) {
+      httpMetrics.recordResponse(httpStartNs, statusCode, OpenSkyStatesHttpMetrics.Outcome.RATE_LIMITED);
+      log.warn("OpenSky rate limit hit (429)");
+      return emptyResult(headers);
+    }
+
+    if (statusCode >= 400) {
+      OpenSkyStatesHttpMetrics.Outcome outcome =
+          statusCode >= 500
+              ? OpenSkyStatesHttpMetrics.Outcome.SERVER_ERROR
+              : OpenSkyStatesHttpMetrics.Outcome.CLIENT_ERROR;
+      httpMetrics.recordResponse(httpStartNs, statusCode, outcome);
+      log.warn("OpenSky fetch failed: status={}", statusCode);
+      return emptyResult(headers);
+    }
+
+    httpMetrics.recordResponse(httpStartNs, statusCode, OpenSkyStatesHttpMetrics.Outcome.SUCCESS);
+    return responseParser.parseStatesResponse(response.body(), headers);
+  }
+
+  private FetchResult emptyResult(OpenSkyRateLimitHeaders headers) {
+    return new FetchResult(List.of(), headers.remainingCredits(), headers.creditLimit(), headers.resetAtEpochSeconds());
+  }
+
+  private void handleRequestException(
+      long httpStartNs,
+      boolean requestRecorded,
+      Exception exception,
+      boolean interrupted) {
+    httpMetrics.recordException(httpStartNs, requestRecorded);
+
+    if (interrupted) {
       Thread.currentThread().interrupt();
-      log.error("Failed to fetch OpenSky states: request interrupted", ex);
-      return new FetchResult(List.of(), null, null, null);
-    } catch (Exception ex) {
-      lastStatusCode.set(0);
-      if (!recorded && httpStartNs > 0) {
-        statesRequestTimer.record(System.nanoTime() - httpStartNs, TimeUnit.NANOSECONDS);
-      }
-      statesRequestExceptionCounter.increment();
-      log.error("Failed to fetch OpenSky states", ex);
-      return new FetchResult(List.of(), null, null, null);
+      log.error("Failed to fetch OpenSky states: request interrupted", exception);
+      return;
     }
-  }
-
-  private FlightState parseState(JsonNode row) {
-    return new FlightState(
-        text(row, 0),
-        text(row, 1),
-        number(row, 6),
-        number(row, 5),
-        number(row, 9),
-        number(row, 10),
-        number(row, 13),
-        number(row, 7),
-        bool(row, 8),
-        longNumber(row, 3),
-        longNumber(row, 4));
-  }
-
-  private IngesterProperties.Bbox resolveEffectiveBbox() {
-    IngesterProperties.Bbox base = ingesterProperties.bbox();
-    IngesterProperties.BboxBoost boost = ingesterProperties.bboxBoost();
-    if (boost == null || boost.factor() <= 1.0 || boost.redisKey() == null || boost.redisKey().isBlank()) {
-      return base;
-    }
-
-    try {
-      String active = redisTemplate.opsForValue().get(boost.redisKey());
-      if (active == null || active.isBlank()) {
-        return base;
-      }
-      return scaleBboxByArea(base, boost.factor());
-    } catch (Exception ex) {
-      log.debug("Unable to read bbox boost key from Redis, using base bbox", ex);
-      return base;
-    }
-  }
-
-  private IngesterProperties.Bbox scaleBboxByArea(IngesterProperties.Bbox bbox, double areaFactor) {
-    double factor = Math.max(1.0, areaFactor);
-    double linearScale = Math.sqrt(factor);
-
-    double centerLat = (bbox.latMin() + bbox.latMax()) / 2.0;
-    double centerLon = (bbox.lonMin() + bbox.lonMax()) / 2.0;
-    double halfLat = (bbox.latMax() - bbox.latMin()) / 2.0 * linearScale;
-    double halfLon = (bbox.lonMax() - bbox.lonMin()) / 2.0 * linearScale;
-
-    return new IngesterProperties.Bbox(
-        clamp(centerLat - halfLat, -90.0, 90.0),
-        clamp(centerLat + halfLat, -90.0, 90.0),
-        clamp(centerLon - halfLon, -180.0, 180.0),
-        clamp(centerLon + halfLon, -180.0, 180.0));
-  }
-
-  private double clamp(double value, double min, double max) {
-    return Math.max(min, Math.min(max, value));
-  }
-
-  private String text(JsonNode row, int idx) {
-    JsonNode node = row.get(idx);
-    return node == null || node.isNull() ? null : node.asText().trim();
-  }
-
-  private Double number(JsonNode row, int idx) {
-    JsonNode node = row.get(idx);
-    return node == null || node.isNull() ? null : node.asDouble();
-  }
-
-  private Long longNumber(JsonNode row, int idx) {
-    JsonNode node = row.get(idx);
-    return node == null || node.isNull() ? null : node.asLong();
-  }
-
-  private Boolean bool(JsonNode row, int idx) {
-    JsonNode node = row.get(idx);
-    return node == null || node.isNull() ? null : node.asBoolean();
-  }
-
-  private Integer parseRemainingCredits(Optional<String> header) {
-    if (header.isEmpty()) {
-      return null;
-    }
-    try {
-      return Integer.parseInt(header.get());
-    } catch (NumberFormatException ex) {
-      log.debug("Unable to parse X-Rate-Limit-Remaining header value: {}", header.get());
-      return null;
-    }
-  }
-
-  private Integer parseIntHeader(Optional<String> header) {
-    if (header.isEmpty()) {
-      return null;
-    }
-    try {
-      return Integer.parseInt(header.get());
-    } catch (NumberFormatException ex) {
-      log.debug("Unable to parse int header value: {}", header.get());
-      return null;
-    }
-  }
-
-  private Long parseResetAtEpochSeconds(Optional<String> header) {
-    if (header.isEmpty()) {
-      return null;
-    }
-    try {
-      long value = Long.parseLong(header.get());
-      long now = System.currentTimeMillis() / 1000;
-      // Heuristic: if it's a small number, assume it's a delta in seconds; else assume it's epoch seconds.
-      if (value > 0 && value < 1_000_000_000L) {
-        return now + value;
-      }
-      // Sanity check: ignore obviously wrong values.
-      if (value < now - 86400L || value > now + 7L * 86400L) {
-        return null;
-      }
-      return value;
-    } catch (NumberFormatException ex) {
-      log.debug("Unable to parse X-Rate-Limit-Reset header value: {}", header.get());
-      return null;
-    }
+    log.error("Failed to fetch OpenSky states", exception);
   }
 
   private void addRelayAuthHeader(HttpRequest.Builder requestBuilder) {

--- a/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyRateLimitHeaders.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyRateLimitHeaders.java
@@ -1,0 +1,6 @@
+package com.cloudradar.ingester.opensky;
+
+record OpenSkyRateLimitHeaders(
+    Integer remainingCredits,
+    Integer creditLimit,
+    Long resetAtEpochSeconds) {}

--- a/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyResponseParser.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyResponseParser.java
@@ -1,0 +1,132 @@
+package com.cloudradar.ingester.opensky;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+class OpenSkyResponseParser {
+  private static final Logger log = LoggerFactory.getLogger(OpenSkyResponseParser.class);
+
+  private final ObjectMapper objectMapper;
+
+  OpenSkyResponseParser(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  OpenSkyRateLimitHeaders parseHeaders(HttpResponse<String> response) {
+    Integer remainingCredits = parseRemainingCredits(response.headers().firstValue("X-Rate-Limit-Remaining"));
+    Integer creditLimit = parseIntHeader(response.headers().firstValue("X-Rate-Limit-Limit"));
+    Long resetAtEpochSeconds = parseResetAtEpochSeconds(response.headers().firstValue("X-Rate-Limit-Reset"));
+    return new OpenSkyRateLimitHeaders(remainingCredits, creditLimit, resetAtEpochSeconds);
+  }
+
+  FetchResult parseStatesResponse(String responseBody, OpenSkyRateLimitHeaders headers) throws Exception {
+    JsonNode root = objectMapper.readTree(responseBody);
+    JsonNode states = root.path("states");
+    if (!states.isArray()) {
+      return emptyResult(headers);
+    }
+
+    List<FlightState> results = new ArrayList<>();
+    for (JsonNode row : states) {
+      if (row.isArray()) {
+        results.add(parseState(row));
+      }
+    }
+    return new FetchResult(
+        results,
+        headers.remainingCredits(),
+        headers.creditLimit(),
+        headers.resetAtEpochSeconds());
+  }
+
+  private FetchResult emptyResult(OpenSkyRateLimitHeaders headers) {
+    return new FetchResult(List.of(), headers.remainingCredits(), headers.creditLimit(), headers.resetAtEpochSeconds());
+  }
+
+  private FlightState parseState(JsonNode row) {
+    return new FlightState(
+        text(row, 0),
+        text(row, 1),
+        number(row, 6),
+        number(row, 5),
+        number(row, 9),
+        number(row, 10),
+        number(row, 13),
+        number(row, 7),
+        bool(row, 8),
+        longNumber(row, 3),
+        longNumber(row, 4));
+  }
+
+  private String text(JsonNode row, int idx) {
+    JsonNode node = row.get(idx);
+    return node == null || node.isNull() ? null : node.asText().trim();
+  }
+
+  private Double number(JsonNode row, int idx) {
+    JsonNode node = row.get(idx);
+    return node == null || node.isNull() ? null : node.asDouble();
+  }
+
+  private Long longNumber(JsonNode row, int idx) {
+    JsonNode node = row.get(idx);
+    return node == null || node.isNull() ? null : node.asLong();
+  }
+
+  private Boolean bool(JsonNode row, int idx) {
+    JsonNode node = row.get(idx);
+    return node == null || node.isNull() ? null : node.asBoolean();
+  }
+
+  private Integer parseRemainingCredits(Optional<String> header) {
+    if (header.isEmpty()) {
+      return null;
+    }
+    try {
+      return Integer.parseInt(header.get());
+    } catch (NumberFormatException ex) {
+      log.debug("Unable to parse X-Rate-Limit-Remaining header value: {}", header.get());
+      return null;
+    }
+  }
+
+  private Integer parseIntHeader(Optional<String> header) {
+    if (header.isEmpty()) {
+      return null;
+    }
+    try {
+      return Integer.parseInt(header.get());
+    } catch (NumberFormatException ex) {
+      log.debug("Unable to parse int header value: {}", header.get());
+      return null;
+    }
+  }
+
+  private Long parseResetAtEpochSeconds(Optional<String> header) {
+    if (header.isEmpty()) {
+      return null;
+    }
+    try {
+      long value = Long.parseLong(header.get());
+      long now = System.currentTimeMillis() / 1000L;
+      if (value > 0 && value < 1_000_000_000L) {
+        return now + value;
+      }
+      if (value < now - 86400L || value > now + 7L * 86400L) {
+        return null;
+      }
+      return value;
+    } catch (NumberFormatException ex) {
+      log.debug("Unable to parse X-Rate-Limit-Reset header value: {}", header.get());
+      return null;
+    }
+  }
+}

--- a/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyStatesHttpMetrics.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyStatesHttpMetrics.java
@@ -1,0 +1,79 @@
+package com.cloudradar.ingester.opensky;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.stereotype.Component;
+
+@Component
+final class OpenSkyStatesHttpMetrics {
+  enum Outcome {
+    SUCCESS,
+    RATE_LIMITED,
+    CLIENT_ERROR,
+    SERVER_ERROR
+  }
+
+  private final Timer statesRequestTimer;
+  private final Counter statesRequestSuccessCounter;
+  private final Counter statesRequestRateLimitedCounter;
+  private final Counter statesRequestClientErrorCounter;
+  private final Counter statesRequestServerErrorCounter;
+  private final Counter statesRequestExceptionCounter;
+  private final AtomicInteger lastStatusCode = new AtomicInteger(0);
+
+  OpenSkyStatesHttpMetrics(MeterRegistry meterRegistry) {
+    this.statesRequestTimer = Timer.builder("ingester.opensky.states.http.duration")
+        .description("OpenSky /states/all HTTP request duration (seconds)")
+        .publishPercentileHistogram(true)
+        .register(meterRegistry);
+
+    this.statesRequestSuccessCounter = Counter.builder("ingester.opensky.states.http.requests.total")
+        .description("OpenSky /states/all HTTP requests (by outcome)")
+        .tag("outcome", "success")
+        .register(meterRegistry);
+    this.statesRequestRateLimitedCounter = Counter.builder("ingester.opensky.states.http.requests.total")
+        .description("OpenSky /states/all HTTP requests (by outcome)")
+        .tag("outcome", "rate_limited")
+        .register(meterRegistry);
+    this.statesRequestClientErrorCounter = Counter.builder("ingester.opensky.states.http.requests.total")
+        .description("OpenSky /states/all HTTP requests (by outcome)")
+        .tag("outcome", "client_error")
+        .register(meterRegistry);
+    this.statesRequestServerErrorCounter = Counter.builder("ingester.opensky.states.http.requests.total")
+        .description("OpenSky /states/all HTTP requests (by outcome)")
+        .tag("outcome", "server_error")
+        .register(meterRegistry);
+    this.statesRequestExceptionCounter = Counter.builder("ingester.opensky.states.http.requests.total")
+        .description("OpenSky /states/all HTTP requests (by outcome)")
+        .tag("outcome", "exception")
+        .register(meterRegistry);
+
+    meterRegistry.gauge("ingester.opensky.states.http.last_status", lastStatusCode);
+  }
+
+  void recordResponse(long httpStartNs, int statusCode, Outcome outcome) {
+    lastStatusCode.set(statusCode);
+    recordDuration(httpStartNs);
+    switch (outcome) {
+      case SUCCESS -> statesRequestSuccessCounter.increment();
+      case RATE_LIMITED -> statesRequestRateLimitedCounter.increment();
+      case CLIENT_ERROR -> statesRequestClientErrorCounter.increment();
+      case SERVER_ERROR -> statesRequestServerErrorCounter.increment();
+    }
+  }
+
+  void recordException(long httpStartNs, boolean requestRecorded) {
+    lastStatusCode.set(0);
+    if (!requestRecorded && httpStartNs > 0) {
+      recordDuration(httpStartNs);
+    }
+    statesRequestExceptionCounter.increment();
+  }
+
+  private void recordDuration(long httpStartNs) {
+    statesRequestTimer.record(System.nanoTime() - httpStartNs, TimeUnit.NANOSECONDS);
+  }
+}

--- a/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyTokenHttpMetrics.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyTokenHttpMetrics.java
@@ -1,0 +1,68 @@
+package com.cloudradar.ingester.opensky;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+@Component
+final class OpenSkyTokenHttpMetrics {
+  private final Timer tokenRequestTimer;
+  private final Counter tokenRequestSuccessCounter;
+  private final Counter tokenRequestClientErrorCounter;
+  private final Counter tokenRequestServerErrorCounter;
+  private final Counter tokenRequestExceptionCounter;
+
+  OpenSkyTokenHttpMetrics(MeterRegistry meterRegistry) {
+    this.tokenRequestTimer = Timer.builder("ingester.opensky.token.http.duration")
+        .description("OpenSky token HTTP request duration (seconds)")
+        .publishPercentileHistogram(true)
+        .register(meterRegistry);
+
+    this.tokenRequestSuccessCounter = Counter.builder("ingester.opensky.token.http.requests.total")
+        .description("OpenSky token HTTP requests (by outcome)")
+        .tag("outcome", "success")
+        .register(meterRegistry);
+    this.tokenRequestClientErrorCounter = Counter.builder("ingester.opensky.token.http.requests.total")
+        .description("OpenSky token HTTP requests (by outcome)")
+        .tag("outcome", "client_error")
+        .register(meterRegistry);
+    this.tokenRequestServerErrorCounter = Counter.builder("ingester.opensky.token.http.requests.total")
+        .description("OpenSky token HTTP requests (by outcome)")
+        .tag("outcome", "server_error")
+        .register(meterRegistry);
+    this.tokenRequestExceptionCounter = Counter.builder("ingester.opensky.token.http.requests.total")
+        .description("OpenSky token HTTP requests (by outcome)")
+        .tag("outcome", "exception")
+        .register(meterRegistry);
+  }
+
+  void recordResponse(long httpStartNs, int statusCode) {
+    recordDuration(httpStartNs);
+    if (statusCode == 200) {
+      tokenRequestSuccessCounter.increment();
+      return;
+    }
+    if (statusCode >= 500) {
+      tokenRequestServerErrorCounter.increment();
+      return;
+    }
+    tokenRequestClientErrorCounter.increment();
+  }
+
+  void recordException(long httpStartNs, boolean requestRecorded) {
+    if (!requestRecorded && httpStartNs > 0) {
+      recordDuration(httpStartNs);
+    }
+    tokenRequestExceptionCounter.increment();
+  }
+
+  void incrementException() {
+    tokenRequestExceptionCounter.increment();
+  }
+
+  private void recordDuration(long httpStartNs) {
+    tokenRequestTimer.record(System.nanoTime() - httpStartNs, TimeUnit.NANOSECONDS);
+  }
+}

--- a/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyTokenService.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/opensky/OpenSkyTokenService.java
@@ -3,18 +3,13 @@ package com.cloudradar.ingester.opensky;
 import com.cloudradar.ingester.config.OpenSkyProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.time.Instant;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -22,22 +17,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class OpenSkyTokenService {
   private static final Logger log = LoggerFactory.getLogger(OpenSkyTokenService.class);
-  private static final long[] TOKEN_FAILURE_BACKOFF_SECONDS = {15L, 30L, 60L, 120L, 300L, 600L};
 
   private final OpenSkyEndpointProvider endpointProvider;
   private final OpenSkyProperties properties;
   private final HttpClient httpClient;
   private final ObjectMapper objectMapper;
-  private final Timer tokenRequestTimer;
-  private final Counter tokenRequestSuccessCounter;
-  private final Counter tokenRequestClientErrorCounter;
-  private final Counter tokenRequestServerErrorCounter;
-  private final Counter tokenRequestExceptionCounter;
+  private final OpenSkyTokenHttpMetrics httpMetrics;
+  private final TokenCooldownPolicy cooldownPolicy = new TokenCooldownPolicy();
 
   private String accessToken;
   private Instant expiry;
-  private int tokenFailureCount;
-  private Instant nextTokenAttemptAt = Instant.EPOCH;
 
   public static class TokenRefreshException extends RuntimeException {
     private TokenRefreshException(String message) {
@@ -52,139 +41,121 @@ public class OpenSkyTokenService {
   public OpenSkyTokenService(
       OpenSkyEndpointProvider endpointProvider,
       OpenSkyProperties properties,
-      MeterRegistry meterRegistry,
       HttpClient httpClient,
-      ObjectMapper objectMapper) {
+      ObjectMapper objectMapper,
+      OpenSkyTokenHttpMetrics httpMetrics) {
     this.endpointProvider = endpointProvider;
     this.properties = properties;
     this.httpClient = httpClient;
     this.objectMapper = objectMapper;
-
-    this.tokenRequestTimer = Timer.builder("ingester.opensky.token.http.duration")
-        .description("OpenSky token HTTP request duration (seconds)")
-        .publishPercentileHistogram(true)
-        .register(meterRegistry);
-
-    this.tokenRequestSuccessCounter = Counter.builder("ingester.opensky.token.http.requests.total")
-        .description("OpenSky token HTTP requests (by outcome)")
-        .tag("outcome", "success")
-        .register(meterRegistry);
-    this.tokenRequestClientErrorCounter = Counter.builder("ingester.opensky.token.http.requests.total")
-        .description("OpenSky token HTTP requests (by outcome)")
-        .tag("outcome", "client_error")
-        .register(meterRegistry);
-    this.tokenRequestServerErrorCounter = Counter.builder("ingester.opensky.token.http.requests.total")
-        .description("OpenSky token HTTP requests (by outcome)")
-        .tag("outcome", "server_error")
-        .register(meterRegistry);
-    this.tokenRequestExceptionCounter = Counter.builder("ingester.opensky.token.http.requests.total")
-        .description("OpenSky token HTTP requests (by outcome)")
-        .tag("outcome", "exception")
-        .register(meterRegistry);
+    this.httpMetrics = httpMetrics;
   }
 
   public synchronized String getToken() {
-    // Cache token until near expiry to avoid unnecessary auth calls.
-    if (accessToken != null && expiry != null && expiry.isAfter(Instant.now().plusSeconds(15))) {
+    if (hasValidCachedToken()) {
       return accessToken;
     }
 
     Instant now = Instant.now();
-    if (nextTokenAttemptAt != null && now.isBefore(nextTokenAttemptAt)) {
-      long waitSeconds = Math.max(1L, Duration.between(now, nextTokenAttemptAt).toSeconds());
-      String message = "Token refresh cooldown active (" + waitSeconds + "s remaining)";
-      tokenRequestExceptionCounter.increment();
-      throw new TokenRefreshException(message);
-    }
+    ensureCooldownAllowsRequest(now);
 
     long httpStartNs = -1L;
-    boolean recorded = false;
+    boolean requestRecorded = false;
     try {
-      String clientId = properties.clientId();
-      String clientSecret = properties.clientSecret();
-      
-      if (clientId == null || clientId.isBlank() || clientSecret == null || clientSecret.isBlank()) {
-        throw new IllegalStateException("OpenSky credentials missing (OPENSKY_CLIENT_ID, OPENSKY_CLIENT_SECRET)");
-      }
-      
-      String tokenUrl = endpointProvider.tokenUrl();
-      if (tokenUrl == null || tokenUrl.isBlank()) {
-        throw new IllegalStateException("OpenSky token URL is missing.");
-      }
-
-      // OAuth2 token request
-      String body = "grant_type=client_credentials&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8) +
-          "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8);
-
-      HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-          .uri(URI.create(tokenUrl))
-          .header("Content-Type", "application/x-www-form-urlencoded");
-      addRelayAuthHeader(requestBuilder);
-      HttpRequest request =
-          requestBuilder.POST(HttpRequest.BodyPublishers.ofString(body)).build();
+      OpenSkyCredentials credentials = resolveCredentials();
+      HttpRequest request = buildTokenRequest(credentials);
 
       httpStartNs = System.nanoTime();
       HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-      tokenRequestTimer.record(System.nanoTime() - httpStartNs, TimeUnit.NANOSECONDS);
-      recorded = true;
+      httpMetrics.recordResponse(httpStartNs, response.statusCode());
+      requestRecorded = true;
 
-      if (response.statusCode() != 200) {
-        if (response.statusCode() >= 500) {
-          tokenRequestServerErrorCounter.increment();
-        } else {
-          tokenRequestClientErrorCounter.increment();
-        }
-        throw registerTokenFailure("Failed to get token from " + tokenUrl + ": " + response.statusCode(), null);
-      }
-      tokenRequestSuccessCounter.increment();
-
-      JsonNode json = objectMapper.readTree(response.body());
-      accessToken = json.get("access_token").asText();
-      long expiresIn = json.get("expires_in").asLong();
-      expiry = Instant.now().plusSeconds(expiresIn);
-      tokenFailureCount = 0;
-      nextTokenAttemptAt = Instant.EPOCH;
-
-      log.info("OpenSky token refreshed, expires in {} seconds", expiresIn);
-      return accessToken;
-
-    } catch (TokenRefreshException e) {
-      if (!recorded && httpStartNs > 0) {
-        tokenRequestTimer.record(System.nanoTime() - httpStartNs, TimeUnit.NANOSECONDS);
-      }
-      log.error("Failed to get OpenSky token", e);
-      throw e;
-    } catch (InterruptedException e) {
-      if (!recorded && httpStartNs > 0) {
-        tokenRequestTimer.record(System.nanoTime() - httpStartNs, TimeUnit.NANOSECONDS);
-      }
+      handleNonSuccessResponse(response.statusCode(), request.uri().toString());
+      return cacheToken(response.body());
+    } catch (TokenRefreshException ex) {
+      log.error("Failed to get OpenSky token", ex);
+      throw ex;
+    } catch (InterruptedException ex) {
+      httpMetrics.recordException(httpStartNs, requestRecorded);
       Thread.currentThread().interrupt();
-      tokenRequestExceptionCounter.increment();
-      TokenRefreshException failure =
-          registerTokenFailure("Token refresh request interrupted", e);
+      TokenRefreshException failure = registerTokenFailure("Token refresh request interrupted", ex);
       log.error("Failed to get OpenSky token", failure);
       throw failure;
-    } catch (Exception e) {
-      if (!recorded && httpStartNs > 0) {
-        tokenRequestTimer.record(System.nanoTime() - httpStartNs, TimeUnit.NANOSECONDS);
-      }
-      tokenRequestExceptionCounter.increment();
+    } catch (Exception ex) {
+      httpMetrics.recordException(httpStartNs, requestRecorded);
       TokenRefreshException failure =
-          registerTokenFailure("Token refresh request failed: " + e.getMessage(), e);
+          registerTokenFailure("Token refresh request failed: " + ex.getMessage(), ex);
       log.error("Failed to get OpenSky token", failure);
       throw failure;
     }
   }
 
+  private boolean hasValidCachedToken() {
+    return accessToken != null && expiry != null && expiry.isAfter(Instant.now().plusSeconds(15));
+  }
+
+  private void ensureCooldownAllowsRequest(Instant now) {
+    if (!cooldownPolicy.isBlocked(now)) {
+      return;
+    }
+
+    long waitSeconds = cooldownPolicy.remainingSeconds(now);
+    httpMetrics.incrementException();
+    throw new TokenRefreshException("Token refresh cooldown active (" + waitSeconds + "s remaining)");
+  }
+
+  private OpenSkyCredentials resolveCredentials() {
+    String clientId = properties.clientId();
+    String clientSecret = properties.clientSecret();
+    if (!isPresent(clientId) || !isPresent(clientSecret)) {
+      throw new IllegalStateException(
+          "OpenSky credentials missing (OPENSKY_CLIENT_ID, OPENSKY_CLIENT_SECRET)");
+    }
+    return new OpenSkyCredentials(clientId, clientSecret);
+  }
+
+  private HttpRequest buildTokenRequest(OpenSkyCredentials credentials) {
+    String tokenUrl = endpointProvider.tokenUrl();
+    if (!isPresent(tokenUrl)) {
+      throw new IllegalStateException("OpenSky token URL is missing.");
+    }
+
+    String body = "grant_type=client_credentials"
+        + "&client_id=" + URLEncoder.encode(credentials.clientId(), StandardCharsets.UTF_8)
+        + "&client_secret=" + URLEncoder.encode(credentials.clientSecret(), StandardCharsets.UTF_8);
+
+    HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+        .uri(URI.create(tokenUrl))
+        .header("Content-Type", "application/x-www-form-urlencoded");
+    addRelayAuthHeader(requestBuilder);
+    return requestBuilder.POST(HttpRequest.BodyPublishers.ofString(body)).build();
+  }
+
+  private void handleNonSuccessResponse(int statusCode, String tokenUrl) {
+    if (statusCode == 200) {
+      return;
+    }
+
+    throw registerTokenFailure("Failed to get token from " + tokenUrl + ": " + statusCode, null);
+  }
+
+  private String cacheToken(String responseBody) throws Exception {
+    JsonNode json = objectMapper.readTree(responseBody);
+    accessToken = json.get("access_token").asText();
+    long expiresIn = json.get("expires_in").asLong();
+    expiry = Instant.now().plusSeconds(expiresIn);
+    cooldownPolicy.reset();
+    log.info("OpenSky token refreshed, expires in {} seconds", expiresIn);
+    return accessToken;
+  }
+
   private TokenRefreshException registerTokenFailure(String message, Throwable cause) {
-    tokenFailureCount++;
-    int index = Math.min(tokenFailureCount - 1, TOKEN_FAILURE_BACKOFF_SECONDS.length - 1);
-    long cooldownSeconds = TOKEN_FAILURE_BACKOFF_SECONDS[index];
-    nextTokenAttemptAt = Instant.now().plusSeconds(cooldownSeconds);
+    TokenCooldownPolicy.FailureState failureState = cooldownPolicy.registerFailure(Instant.now());
     log.warn(
         "OpenSky token refresh failed (attempt {}), cooldown {}s",
-        tokenFailureCount,
-        cooldownSeconds);
+        failureState.failureCount(),
+        failureState.cooldownSeconds());
+
     if (cause == null) {
       return new TokenRefreshException("Token refresh failed: " + message);
     }

--- a/src/ingester/src/main/java/com/cloudradar/ingester/opensky/TokenCooldownPolicy.java
+++ b/src/ingester/src/main/java/com/cloudradar/ingester/opensky/TokenCooldownPolicy.java
@@ -1,0 +1,34 @@
+package com.cloudradar.ingester.opensky;
+
+import java.time.Duration;
+import java.time.Instant;
+
+class TokenCooldownPolicy {
+  private static final long[] TOKEN_FAILURE_BACKOFF_SECONDS = {15L, 30L, 60L, 120L, 300L, 600L};
+
+  private int failureCount;
+  private Instant nextAttemptAt = Instant.EPOCH;
+
+  synchronized boolean isBlocked(Instant now) {
+    return now.isBefore(nextAttemptAt);
+  }
+
+  synchronized long remainingSeconds(Instant now) {
+    return Math.max(1L, Duration.between(now, nextAttemptAt).toSeconds());
+  }
+
+  synchronized FailureState registerFailure(Instant now) {
+    failureCount++;
+    int index = Math.min(failureCount - 1, TOKEN_FAILURE_BACKOFF_SECONDS.length - 1);
+    long cooldownSeconds = TOKEN_FAILURE_BACKOFF_SECONDS[index];
+    nextAttemptAt = now.plusSeconds(cooldownSeconds);
+    return new FailureState(failureCount, cooldownSeconds);
+  }
+
+  synchronized void reset() {
+    failureCount = 0;
+    nextAttemptAt = Instant.EPOCH;
+  }
+
+  record FailureState(int failureCount, long cooldownSeconds) {}
+}

--- a/src/ingester/src/test/java/com/cloudradar/ingester/FlightEventMapperTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/FlightEventMapperTest.java
@@ -1,0 +1,58 @@
+package com.cloudradar.ingester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cloudradar.ingester.opensky.FlightState;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class FlightEventMapperTest {
+
+  @Test
+  void toEventMapsExpectedContractFields() {
+    FlightEventMapper mapper = new FlightEventMapper();
+    FlightState state = new FlightState(
+        "abc123",
+        "AFR123",
+        48.8566,
+        2.3522,
+        230.5,
+        180.0,
+        11300.0,
+        11000.0,
+        false,
+        1_700_000_001L,
+        1_700_000_002L);
+
+    Map<String, Object> event = mapper.toEvent(state, 1_700_000_000L);
+
+    assertThat(event)
+        .containsEntry("icao24", "abc123")
+        .containsEntry("callsign", "AFR123")
+        .containsEntry("lat", 48.8566)
+        .containsEntry("lon", 2.3522)
+        .containsEntry("velocity", 230.5)
+        .containsEntry("heading", 180.0)
+        .containsEntry("geo_altitude", 11300.0)
+        .containsEntry("baro_altitude", 11000.0)
+        .containsEntry("on_ground", false)
+        .containsEntry("time_position", 1_700_000_001L)
+        .containsEntry("last_contact", 1_700_000_002L)
+        .containsEntry("opensky_fetch_epoch", 1_700_000_000L);
+  }
+
+  @Test
+  void toEventsMapsAllStates() {
+    FlightEventMapper mapper = new FlightEventMapper();
+    List<FlightState> states = List.of(
+        new FlightState("abc123", "AFR123", 48.0, 2.0, null, null, null, null, null, null, null),
+        new FlightState("def456", "BAW987", 49.0, 3.0, null, null, null, null, null, null, null));
+
+    List<Map<String, Object>> events = mapper.toEvents(states, 1_700_000_000L);
+
+    assertThat(events).hasSize(2);
+    assertThat(events.get(0)).containsEntry("icao24", "abc123");
+    assertThat(events.get(1)).containsEntry("icao24", "def456");
+  }
+}

--- a/src/ingester/src/test/java/com/cloudradar/ingester/FlightIngestJobTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/FlightIngestJobTest.java
@@ -3,320 +3,132 @@ package com.cloudradar.ingester;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import com.cloudradar.ingester.config.IngesterProperties;
 import com.cloudradar.ingester.opensky.FetchResult;
+import com.cloudradar.ingester.opensky.FlightState;
 import com.cloudradar.ingester.opensky.OpenSkyClient;
 import com.cloudradar.ingester.redis.RedisPublisher;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class FlightIngestJobTest {
 
   @Test
-  void ingestUsesOpenSkyLimitHeaderForThrottlingWhenAvailable() {
+  void ingestPublishesMappedEventsOnSuccessfulCycle() {
     OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
     RedisPublisher redisPublisher = mock(RedisPublisher.class);
-    when(openSkyClient.fetchStates()).thenReturn(new FetchResult(List.of(), 399, 400, null));
-    when(redisPublisher.pushEvents(anyList())).thenReturn(0);
+    when(openSkyClient.fetchStates()).thenReturn(new FetchResult(
+        List.of(new FlightState("abc123", "AFR123", 48.0, 2.0, 230.0, 180.0, 11000.0, 10900.0, false, 1700L, 1701L)),
+        399,
+        400,
+        2000L));
+    when(redisPublisher.pushEvents(anyList())).thenReturn(1);
 
+    IngestionBackoffController backoffController = new IngestionBackoffController();
     FlightIngestJob job = new FlightIngestJob(
         openSkyClient,
         redisPublisher,
-        new SimpleMeterRegistry(),
-        buildProperties());
+        new FlightEventMapper(),
+        new OpenSkyRateLimitTracker(buildProperties()),
+        backoffController,
+        buildProperties(),
+        new SimpleMeterRegistry());
 
     job.ingest();
 
-    assertThat(readLongField(job, "currentDelayMs")).isEqualTo(10_000L);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Map<String, Object>>> payloadCaptor = ArgumentCaptor.forClass(List.class);
+    verify(redisPublisher).pushEvents(payloadCaptor.capture());
+    assertThat(payloadCaptor.getValue()).hasSize(1);
+    assertThat(payloadCaptor.getValue().get(0))
+        .containsEntry("icao24", "abc123")
+        .containsEntry("callsign", "AFR123")
+        .containsKey("opensky_fetch_epoch");
+    assertThat(backoffController.currentBackoffSeconds()).isZero();
   }
 
   @Test
-  void ingestFallsBackToConfiguredQuotaWhenLimitHeaderMissing() {
-    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
-    RedisPublisher redisPublisher = mock(RedisPublisher.class);
-    when(openSkyClient.fetchStates()).thenReturn(new FetchResult(List.of(), 399, null, null));
-    when(redisPublisher.pushEvents(anyList())).thenReturn(0);
-
-    FlightIngestJob job = new FlightIngestJob(
-        openSkyClient,
-        redisPublisher,
-        new SimpleMeterRegistry(),
-        buildProperties());
-
-    job.ingest();
-
-    assertThat(readLongField(job, "currentDelayMs")).isEqualTo(30_000L);
-  }
-
-  @Test
-  void ingestStoresResetEpochWhenHeaderPresent() {
-    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
-    RedisPublisher redisPublisher = mock(RedisPublisher.class);
-    when(openSkyClient.fetchStates()).thenReturn(new FetchResult(List.of(), 390, 400, 12345L));
-    when(redisPublisher.pushEvents(anyList())).thenReturn(0);
-
-    FlightIngestJob job = new FlightIngestJob(
-        openSkyClient,
-        redisPublisher,
-        new SimpleMeterRegistry(),
-        buildProperties());
-
-    job.ingest();
-
-    assertThat(readAtomicLongField(job, "resetAtEpochSeconds")).isEqualTo(12345L);
-  }
-
-  @Test
-  void ingestHandlesUnchangedHeaderLimitAcrossCycles() {
-    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
-    RedisPublisher redisPublisher = mock(RedisPublisher.class);
-    when(openSkyClient.fetchStates())
-        .thenReturn(new FetchResult(List.of(), 399, 400, null))
-        .thenReturn(new FetchResult(List.of(), 398, 400, null));
-    when(redisPublisher.pushEvents(anyList())).thenReturn(0);
-
-    FlightIngestJob job = new FlightIngestJob(
-        openSkyClient,
-        redisPublisher,
-        new SimpleMeterRegistry(),
-        buildProperties());
-
-    job.ingest();
-    forceNextCycle(job);
-    job.ingest();
-
-    assertThat(readAtomicLongField(job, "creditLimitOverride")).isEqualTo(400L);
-    assertThat(readLongField(job, "currentDelayMs")).isEqualTo(10_000L);
-  }
-
-  @Test
-  void ingestKeepsBaseDelayWhenEffectiveQuotaIsZero() {
-    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
-    RedisPublisher redisPublisher = mock(RedisPublisher.class);
-    when(openSkyClient.fetchStates()).thenReturn(new FetchResult(List.of(), 399, null, null));
-    when(redisPublisher.pushEvents(anyList())).thenReturn(0);
-
-    FlightIngestJob job = new FlightIngestJob(
-        openSkyClient,
-        redisPublisher,
-        new SimpleMeterRegistry(),
-        buildPropertiesWithQuota(0L));
-
-    job.ingest();
-
-    assertThat(readLongField(job, "currentDelayMs")).isEqualTo(10_000L);
-    assertThat(readAtomicLongField(job, "creditLimitOverride")).isEqualTo(-1L);
-  }
-
-  @Test
-  void ingestKeepsBaseDelayWhenRemainingCreditsMissing() {
-    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
-    RedisPublisher redisPublisher = mock(RedisPublisher.class);
-    when(openSkyClient.fetchStates()).thenReturn(new FetchResult(List.of(), null, null, null));
-    when(redisPublisher.pushEvents(anyList())).thenReturn(0);
-
-    FlightIngestJob job = new FlightIngestJob(
-        openSkyClient,
-        redisPublisher,
-        new SimpleMeterRegistry(),
-        buildProperties());
-
-    job.ingest();
-
-    assertThat(readLongField(job, "currentDelayMs")).isEqualTo(10_000L);
-  }
-
-  @Test
-  void effectiveQuotaFallsBackToConfiguredQuotaWithoutHeaderOverride() {
-    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
-    RedisPublisher redisPublisher = mock(RedisPublisher.class);
-
-    FlightIngestJob job = new FlightIngestJob(
-        openSkyClient,
-        redisPublisher,
-        new SimpleMeterRegistry(),
-        buildPropertiesWithQuota(4000L));
-
-    assertThat(invokeEffectiveQuota(job, buildPropertiesWithQuota(4000L).rateLimit())).isEqualTo(4000L);
-  }
-
-  @Test
-  void ingestKeepsBaseDelayWhenRateLimitConfigMissing() {
-    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
-    RedisPublisher redisPublisher = mock(RedisPublisher.class);
-    when(openSkyClient.fetchStates()).thenReturn(new FetchResult(List.of(), 399, 400, null));
-    when(redisPublisher.pushEvents(anyList())).thenReturn(0);
-
-    FlightIngestJob job = new FlightIngestJob(
-        openSkyClient,
-        redisPublisher,
-        new SimpleMeterRegistry(),
-        buildPropertiesWithoutRateLimit());
-
-    job.ingest();
-
-    assertThat(readLongField(job, "currentDelayMs")).isEqualTo(10_000L);
-  }
-
-  @Test
-  void quotaOrDefaultUsesConfiguredQuotaWhenNoHeaderOverride() {
-    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
-    RedisPublisher redisPublisher = mock(RedisPublisher.class);
-
-    FlightIngestJob job = new FlightIngestJob(
-        openSkyClient,
-        redisPublisher,
-        new SimpleMeterRegistry(),
-        buildPropertiesWithQuota(4000L));
-
-    assertThat(invokeQuotaOrDefault(job)).isEqualTo(4000.0);
-  }
-
-  @Test
-  void ingestAppliesProgressiveBackoffOnConsecutiveFailures() {
+  void ingestAppliesBackoffWhenFetchThrows() {
     OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
     RedisPublisher redisPublisher = mock(RedisPublisher.class);
     when(openSkyClient.fetchStates()).thenThrow(new RuntimeException("opensky down"));
 
+    IngestionBackoffController backoffController = new IngestionBackoffController();
     FlightIngestJob job = new FlightIngestJob(
         openSkyClient,
         redisPublisher,
-        new SimpleMeterRegistry(),
-        buildProperties());
+        new FlightEventMapper(),
+        new OpenSkyRateLimitTracker(buildProperties()),
+        backoffController,
+        buildProperties(),
+        new SimpleMeterRegistry());
 
     job.ingest();
-    assertThat(readAtomicLongField(job, "currentBackoffSeconds")).isEqualTo(1L);
-    assertThat(readBooleanField(job, "disabled")).isFalse();
 
-    forceNextCycle(job);
-    job.ingest();
-    assertThat(readAtomicLongField(job, "currentBackoffSeconds")).isEqualTo(2L);
-    assertThat(readBooleanField(job, "disabled")).isFalse();
+    assertThat(backoffController.currentBackoffSeconds()).isEqualTo(1L);
+    verify(redisPublisher, never()).pushEvents(anyList());
   }
 
   @Test
-  void ingestDisablesAfterTooManyFailures() {
+  void ingestSkipsWhenBackoffWindowIsActive() {
     OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
     RedisPublisher redisPublisher = mock(RedisPublisher.class);
-    when(openSkyClient.fetchStates()).thenThrow(new RuntimeException("still down"));
+
+    IngestionBackoffController backoffController = new IngestionBackoffController();
+    backoffController.recordFailure(System.currentTimeMillis());
 
     FlightIngestJob job = new FlightIngestJob(
         openSkyClient,
         redisPublisher,
-        new SimpleMeterRegistry(),
-        buildProperties());
+        new FlightEventMapper(),
+        new OpenSkyRateLimitTracker(buildProperties()),
+        backoffController,
+        buildProperties(),
+        new SimpleMeterRegistry());
 
-    setAtomicIntField(job, "consecutiveFailures", 10);
-    forceNextCycle(job);
     job.ingest();
 
-    assertThat(readBooleanField(job, "disabled")).isTrue();
-    assertThat(readAtomicLongField(job, "currentBackoffSeconds")).isZero();
-    assertThat(readLongField(job, "nextAllowedAtMs")).isEqualTo(Long.MAX_VALUE);
+    verify(openSkyClient, never()).fetchStates();
+  }
 
-    // Once disabled, ingest should return immediately.
+  @Test
+  void ingestSkipsWhenBackoffControllerIsDisabled() {
+    OpenSkyClient openSkyClient = mock(OpenSkyClient.class);
+    RedisPublisher redisPublisher = mock(RedisPublisher.class);
+
+    IngestionBackoffController backoffController = new IngestionBackoffController();
+    for (int i = 0; i < 11; i++) {
+      backoffController.recordFailure(System.currentTimeMillis());
+    }
+
+    FlightIngestJob job = new FlightIngestJob(
+        openSkyClient,
+        redisPublisher,
+        new FlightEventMapper(),
+        new OpenSkyRateLimitTracker(buildProperties()),
+        backoffController,
+        buildProperties(),
+        new SimpleMeterRegistry());
+
     job.ingest();
-    verify(openSkyClient, times(1)).fetchStates();
+
+    verify(openSkyClient, never()).fetchStates();
+    assertThat(backoffController.disabledGaugeValue()).isEqualTo(1);
   }
 
   private IngesterProperties buildProperties() {
-    return buildPropertiesWithQuota(4000L);
-  }
-
-  private IngesterProperties buildPropertiesWithQuota(long quota) {
     return new IngesterProperties(
         10_000L,
         new IngesterProperties.Redis("cloudradar:ingest:queue"),
         new IngesterProperties.Bbox(46.0, 50.0, 2.0, 4.0),
-        new IngesterProperties.RateLimit(quota, 50, 80, 95, 30_000L, 300_000L),
+        new IngesterProperties.RateLimit(4_000L, 50, 80, 95, 30_000L, 300_000L),
         new IngesterProperties.BboxBoost("cloudradar:opensky:bbox:boost:active", 1.0));
-  }
-
-  private IngesterProperties buildPropertiesWithoutRateLimit() {
-    return new IngesterProperties(
-        10_000L,
-        new IngesterProperties.Redis("cloudradar:ingest:queue"),
-        new IngesterProperties.Bbox(46.0, 50.0, 2.0, 4.0),
-        null,
-        new IngesterProperties.BboxBoost("cloudradar:opensky:bbox:boost:active", 1.0));
-  }
-
-  private void forceNextCycle(FlightIngestJob job) {
-    try {
-      Field field = FlightIngestJob.class.getDeclaredField("nextAllowedAtMs");
-      field.setAccessible(true);
-      field.setLong(job, 0L);
-    } catch (ReflectiveOperationException ex) {
-      throw new IllegalStateException("Unable to set test field: nextAllowedAtMs", ex);
-    }
-  }
-
-  private long readAtomicLongField(Object target, String fieldName) {
-    try {
-      Field field = FlightIngestJob.class.getDeclaredField(fieldName);
-      field.setAccessible(true);
-      return ((java.util.concurrent.atomic.AtomicLong) field.get(target)).get();
-    } catch (ReflectiveOperationException ex) {
-      throw new IllegalStateException("Unable to read test field: " + fieldName, ex);
-    }
-  }
-
-  private long invokeEffectiveQuota(FlightIngestJob job, IngesterProperties.RateLimit rateLimit) {
-    try {
-      Method method = FlightIngestJob.class.getDeclaredMethod(
-          "effectiveQuota",
-          IngesterProperties.RateLimit.class);
-      method.setAccessible(true);
-      return (long) method.invoke(job, rateLimit);
-    } catch (ReflectiveOperationException ex) {
-      throw new IllegalStateException("Unable to invoke effectiveQuota for test coverage", ex);
-    }
-  }
-
-  private double invokeQuotaOrDefault(FlightIngestJob job) {
-    try {
-      Method method = FlightIngestJob.class.getDeclaredMethod("quotaOrDefault");
-      method.setAccessible(true);
-      return (double) method.invoke(job);
-    } catch (ReflectiveOperationException ex) {
-      throw new IllegalStateException("Unable to invoke quotaOrDefault for test coverage", ex);
-    }
-  }
-
-  private long readLongField(Object target, String fieldName) {
-    try {
-      Field field = FlightIngestJob.class.getDeclaredField(fieldName);
-      field.setAccessible(true);
-      return field.getLong(target);
-    } catch (ReflectiveOperationException ex) {
-      throw new IllegalStateException("Unable to read test field: " + fieldName, ex);
-    }
-  }
-
-  private boolean readBooleanField(Object target, String fieldName) {
-    try {
-      Field field = FlightIngestJob.class.getDeclaredField(fieldName);
-      field.setAccessible(true);
-      return field.getBoolean(target);
-    } catch (ReflectiveOperationException ex) {
-      throw new IllegalStateException("Unable to read test field: " + fieldName, ex);
-    }
-  }
-
-  private void setAtomicIntField(Object target, String fieldName, int value) {
-    try {
-      Field field = FlightIngestJob.class.getDeclaredField(fieldName);
-      field.setAccessible(true);
-      ((java.util.concurrent.atomic.AtomicInteger) field.get(target)).set(value);
-    } catch (ReflectiveOperationException ex) {
-      throw new IllegalStateException("Unable to set test field: " + fieldName, ex);
-    }
   }
 }

--- a/src/ingester/src/test/java/com/cloudradar/ingester/IngesterMetricsTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/IngesterMetricsTest.java
@@ -1,0 +1,42 @@
+package com.cloudradar.ingester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cloudradar.ingester.config.IngesterProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+class IngesterMetricsTest {
+
+  @Test
+  void recordsCountersAndExposesDynamicGauges() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    IngestionBackoffController backoffController = new IngestionBackoffController();
+    OpenSkyRateLimitTracker rateLimitTracker = new OpenSkyRateLimitTracker(buildProperties());
+    IngesterMetrics metrics =
+        new IngesterMetrics(registry, buildProperties(), rateLimitTracker, backoffController);
+
+    metrics.recordFetch(4);
+    metrics.recordPush(3);
+    metrics.recordError();
+    rateLimitTracker.recordFetch(4);
+    rateLimitTracker.recordSuccessfulCycle(390, 400, null);
+    backoffController.recordFailure(System.currentTimeMillis());
+
+    assertThat(registry.get("ingester.fetch.total").counter().count()).isEqualTo(4.0);
+    assertThat(registry.get("ingester.fetch.requests.total").counter().count()).isEqualTo(1.0);
+    assertThat(registry.get("ingester.push.total").counter().count()).isEqualTo(3.0);
+    assertThat(registry.get("ingester.errors.total").counter().count()).isEqualTo(1.0);
+    assertThat(registry.get("ingester.opensky.backoff.seconds").gauge().value()).isEqualTo(1.0);
+    assertThat(registry.get("ingester.opensky.bbox.area.km2").gauge().value()).isGreaterThan(0.0);
+  }
+
+  private IngesterProperties buildProperties() {
+    return new IngesterProperties(
+        10_000L,
+        new IngesterProperties.Redis("cloudradar:ingest:queue"),
+        new IngesterProperties.Bbox(46.0, 50.0, 2.0, 4.0),
+        new IngesterProperties.RateLimit(4_000L, 50, 80, 95, 30_000L, 300_000L),
+        new IngesterProperties.BboxBoost("cloudradar:opensky:bbox:boost:active", 1.0));
+  }
+}

--- a/src/ingester/src/test/java/com/cloudradar/ingester/IngestionBackoffControllerTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/IngestionBackoffControllerTest.java
@@ -1,0 +1,51 @@
+package com.cloudradar.ingester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class IngestionBackoffControllerTest {
+
+  @Test
+  void recordFailureAppliesProgressiveBackoff() {
+    IngestionBackoffController controller = new IngestionBackoffController();
+
+    IngestionBackoffController.FailureDecision first = controller.recordFailure(System.currentTimeMillis());
+    IngestionBackoffController.FailureDecision second = controller.recordFailure(System.currentTimeMillis());
+
+    assertThat(first.failureCount()).isEqualTo(1);
+    assertThat(first.backoffMs()).isEqualTo(1_000L);
+    assertThat(second.failureCount()).isEqualTo(2);
+    assertThat(second.backoffMs()).isEqualTo(2_000L);
+    assertThat(controller.currentBackoffSeconds()).isEqualTo(2L);
+  }
+
+  @Test
+  void recordFailureDisablesAfterMaxAttempts() {
+    IngestionBackoffController controller = new IngestionBackoffController();
+
+    IngestionBackoffController.FailureDecision decision = null;
+    for (int i = 0; i < 11; i++) {
+      decision = controller.recordFailure(System.currentTimeMillis());
+    }
+
+    assertThat(decision).isNotNull();
+    assertThat(decision.disabled()).isTrue();
+    assertThat(controller.disabledGaugeValue()).isEqualTo(1);
+    assertThat(controller.shouldSkipCycle(System.currentTimeMillis())).isTrue();
+  }
+
+  @Test
+  void recordSuccessResetsFailureStateAndSchedulesNextCycle() {
+    IngestionBackoffController controller = new IngestionBackoffController();
+    controller.recordFailure(System.currentTimeMillis());
+
+    long now = System.currentTimeMillis();
+    controller.recordSuccess(now, 10_000L);
+
+    assertThat(controller.currentBackoffSeconds()).isZero();
+    assertThat(controller.disabledGaugeValue()).isZero();
+    assertThat(controller.shouldSkipCycle(now)).isTrue();
+    assertThat(controller.shouldSkipCycle(now + 11_000L)).isFalse();
+  }
+}

--- a/src/ingester/src/test/java/com/cloudradar/ingester/OpenSkyRateLimitMetricCalculatorTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/OpenSkyRateLimitMetricCalculatorTest.java
@@ -1,0 +1,81 @@
+package com.cloudradar.ingester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cloudradar.ingester.config.IngesterProperties;
+import org.junit.jupiter.api.Test;
+
+class OpenSkyRateLimitMetricCalculatorTest {
+
+  @Test
+  void computesCoreMetricsFromState() {
+    IngesterProperties.RateLimit rateLimit = new IngesterProperties.RateLimit(4_000L, 50, 80, 95, 30_000L, 300_000L);
+    long resetAt = (System.currentTimeMillis() / 1000L) + 5L;
+
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.REMAINING_CREDITS, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isEqualTo(350.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.CREDIT_LIMIT, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isEqualTo(400.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.REQUESTS_SINCE_RESET, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isEqualTo(10.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.CREDITS_USED_SINCE_RESET, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isEqualTo(50.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.EVENTS_SINCE_RESET, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isEqualTo(100.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.LAST_STATES_COUNT, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isEqualTo(25.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.CONSUMED_PERCENT, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isEqualTo(12.5);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.AVERAGE_CREDITS_PER_REQUEST, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isEqualTo(5.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.AVERAGE_EVENTS_PER_REQUEST, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isEqualTo(10.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.RESET_ETA_SECONDS, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isBetween(0.0, 6.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.QUOTA, 350L, 400L, 10L, 50L, 100L, 25L, resetAt, rateLimit))
+        .isEqualTo(400.0);
+  }
+
+  @Test
+  void appliesSafeFallbacksForInvalidOrMissingValues() {
+    IngesterProperties.RateLimit rateLimit = new IngesterProperties.RateLimit(4_000L, 50, 80, 95, 30_000L, 300_000L);
+
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.CONSUMED_PERCENT, -1L, 400L, 0L, 0L, 0L, 0L, 0L, rateLimit))
+        .isEqualTo(0.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.CONSUMED_PERCENT, 100L, 0L, 0L, 0L, 0L, 0L, 0L, rateLimit))
+        .isEqualTo(0.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.AVERAGE_CREDITS_PER_REQUEST, 100L, 400L, 0L, 10L, 0L, 0L, 0L, rateLimit))
+        .isEqualTo(0.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.AVERAGE_EVENTS_PER_REQUEST, 100L, 400L, 0L, 0L, 10L, 0L, 0L, rateLimit))
+        .isEqualTo(0.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.RESET_ETA_SECONDS, 100L, 400L, 0L, 0L, 0L, 0L, 0L, rateLimit))
+        .isEqualTo(0.0);
+
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.QUOTA, 100L, 0L, 0L, 0L, 0L, 0L, 0L, rateLimit))
+        .isEqualTo(4_000.0);
+    assertThat(metric(OpenSkyRateLimitTracker.Metric.QUOTA, 100L, 0L, 0L, 0L, 0L, 0L, 0L, null))
+        .isEqualTo(0.0);
+  }
+
+  private double metric(
+      OpenSkyRateLimitTracker.Metric metric,
+      long remainingCredits,
+      long creditLimitOverride,
+      long requestsSinceReset,
+      long creditsUsedSinceReset,
+      long eventsSinceReset,
+      long lastStatesCount,
+      long resetAtEpochSeconds,
+      IngesterProperties.RateLimit rateLimit) {
+    return OpenSkyRateLimitMetricCalculator.value(
+        metric,
+        remainingCredits,
+        creditLimitOverride,
+        requestsSinceReset,
+        creditsUsedSinceReset,
+        eventsSinceReset,
+        lastStatesCount,
+        resetAtEpochSeconds,
+        rateLimit);
+  }
+}

--- a/src/ingester/src/test/java/com/cloudradar/ingester/OpenSkyRateLimitTrackerTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/OpenSkyRateLimitTrackerTest.java
@@ -1,0 +1,94 @@
+package com.cloudradar.ingester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cloudradar.ingester.config.IngesterProperties;
+import org.junit.jupiter.api.Test;
+
+class OpenSkyRateLimitTrackerTest {
+
+  @Test
+  void usesHeaderLimitForDelayCalculationWhenAvailable() {
+    OpenSkyRateLimitTracker tracker = new OpenSkyRateLimitTracker(buildProperties(4_000L));
+
+    tracker.recordFetch(0);
+    tracker.recordSuccessfulCycle(399, 400, null);
+
+    assertThat(tracker.currentDelayMs()).isEqualTo(10_000L);
+    assertThat(tracker.metric(OpenSkyRateLimitTracker.Metric.CREDIT_LIMIT)).isEqualTo(400.0);
+  }
+
+  @Test
+  void fallsBackToConfiguredQuotaWhenHeaderLimitMissing() {
+    OpenSkyRateLimitTracker tracker = new OpenSkyRateLimitTracker(buildProperties(4_000L));
+
+    tracker.recordFetch(0);
+    tracker.recordSuccessfulCycle(399, null, null);
+
+    assertThat(tracker.currentDelayMs()).isEqualTo(30_000L);
+    assertThat(tracker.metric(OpenSkyRateLimitTracker.Metric.CREDIT_LIMIT)).isEqualTo(4_000.0);
+  }
+
+  @Test
+  void storesResetEpochWhenHeaderPresent() {
+    OpenSkyRateLimitTracker tracker = new OpenSkyRateLimitTracker(buildProperties(4_000L));
+    long futureReset = (System.currentTimeMillis() / 1000L) + 300L;
+
+    tracker.recordFetch(0);
+    tracker.recordSuccessfulCycle(390, 400, futureReset);
+
+    assertThat(tracker.metric(OpenSkyRateLimitTracker.Metric.RESET_ETA_SECONDS)).isGreaterThan(0.0);
+  }
+
+  @Test
+  void keepsBaseDelayWhenRateLimitConfigMissing() {
+    OpenSkyRateLimitTracker tracker = new OpenSkyRateLimitTracker(buildPropertiesWithoutRateLimit());
+
+    tracker.recordFetch(0);
+    tracker.recordSuccessfulCycle(399, 400, null);
+
+    assertThat(tracker.currentDelayMs()).isEqualTo(10_000L);
+  }
+
+  @Test
+  void keepsBaseDelayWhenRemainingCreditsMissing() {
+    OpenSkyRateLimitTracker tracker = new OpenSkyRateLimitTracker(buildProperties(4_000L));
+
+    tracker.recordFetch(0);
+    tracker.recordSuccessfulCycle(null, null, null);
+
+    assertThat(tracker.currentDelayMs()).isEqualTo(10_000L);
+  }
+
+  @Test
+  void resetsPeriodCountersWhenCreditsIncrease() {
+    OpenSkyRateLimitTracker tracker = new OpenSkyRateLimitTracker(buildProperties(4_000L));
+
+    tracker.recordFetch(10);
+    tracker.recordSuccessfulCycle(300, 4_000, null);
+    tracker.recordFetch(5);
+    tracker.recordSuccessfulCycle(350, 4_000, null);
+
+    assertThat(tracker.metric(OpenSkyRateLimitTracker.Metric.REQUESTS_SINCE_RESET)).isEqualTo(0.0);
+    assertThat(tracker.metric(OpenSkyRateLimitTracker.Metric.CREDITS_USED_SINCE_RESET)).isEqualTo(0.0);
+    assertThat(tracker.metric(OpenSkyRateLimitTracker.Metric.EVENTS_SINCE_RESET)).isEqualTo(0.0);
+  }
+
+  private IngesterProperties buildProperties(long quota) {
+    return new IngesterProperties(
+        10_000L,
+        new IngesterProperties.Redis("cloudradar:ingest:queue"),
+        new IngesterProperties.Bbox(46.0, 50.0, 2.0, 4.0),
+        new IngesterProperties.RateLimit(quota, 50, 80, 95, 30_000L, 300_000L),
+        new IngesterProperties.BboxBoost("cloudradar:opensky:bbox:boost:active", 1.0));
+  }
+
+  private IngesterProperties buildPropertiesWithoutRateLimit() {
+    return new IngesterProperties(
+        10_000L,
+        new IngesterProperties.Redis("cloudradar:ingest:queue"),
+        new IngesterProperties.Bbox(46.0, 50.0, 2.0, 4.0),
+        null,
+        new IngesterProperties.BboxBoost("cloudradar:opensky:bbox:boost:active", 1.0));
+  }
+}

--- a/src/ingester/src/test/java/com/cloudradar/ingester/opensky/OpenSkyClientTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/opensky/OpenSkyClientTest.java
@@ -64,12 +64,11 @@ class OpenSkyClientTest {
 
     OpenSkyClient client = new OpenSkyClient(
         endpointProvider,
-        properties,
-        redisTemplate,
         tokenService,
-        new SimpleMeterRegistry(),
         httpClient,
-        new ObjectMapper());
+        new OpenSkyBboxResolver(properties, redisTemplate),
+        new OpenSkyResponseParser(new ObjectMapper()),
+        new OpenSkyStatesHttpMetrics(new SimpleMeterRegistry()));
 
     long beforeCallEpoch = System.currentTimeMillis() / 1000;
     FetchResult result = client.fetchStates();
@@ -126,12 +125,11 @@ class OpenSkyClientTest {
 
     OpenSkyClient client = new OpenSkyClient(
         endpointProvider,
-        properties,
-        redisTemplate,
         tokenService,
-        new SimpleMeterRegistry(),
         httpClient,
-        new ObjectMapper());
+        new OpenSkyBboxResolver(properties, redisTemplate),
+        new OpenSkyResponseParser(new ObjectMapper()),
+        new OpenSkyStatesHttpMetrics(new SimpleMeterRegistry()));
 
     FetchResult result = client.fetchStates();
 
@@ -176,12 +174,11 @@ class OpenSkyClientTest {
 
     OpenSkyClient client = new OpenSkyClient(
         endpointProvider,
-        properties,
-        redisTemplate,
         tokenService,
-        new SimpleMeterRegistry(),
         httpClient,
-        new ObjectMapper());
+        new OpenSkyBboxResolver(properties, redisTemplate),
+        new OpenSkyResponseParser(new ObjectMapper()),
+        new OpenSkyStatesHttpMetrics(new SimpleMeterRegistry()));
 
     FetchResult result = client.fetchStates();
 
@@ -225,12 +222,11 @@ class OpenSkyClientTest {
 
     OpenSkyClient client = new OpenSkyClient(
         endpointProvider,
-        properties,
-        redisTemplate,
         tokenService,
-        new SimpleMeterRegistry(),
         httpClient,
-        new ObjectMapper());
+        new OpenSkyBboxResolver(properties, redisTemplate),
+        new OpenSkyResponseParser(new ObjectMapper()),
+        new OpenSkyStatesHttpMetrics(new SimpleMeterRegistry()));
 
     client.fetchStates();
 

--- a/src/ingester/src/test/java/com/cloudradar/ingester/opensky/OpenSkyResponseParserTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/opensky/OpenSkyResponseParserTest.java
@@ -1,0 +1,33 @@
+package com.cloudradar.ingester.opensky;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class OpenSkyResponseParserTest {
+
+  @Test
+  void parseStatesResponseThrowsWhenPayloadIsMalformedJson() {
+    OpenSkyResponseParser parser = new OpenSkyResponseParser(new ObjectMapper());
+    OpenSkyRateLimitHeaders headers = new OpenSkyRateLimitHeaders(100, 4000, 1_700_000_000L);
+
+    assertThatThrownBy(() -> parser.parseStatesResponse("{\"states\":[", headers))
+        .isInstanceOf(JsonProcessingException.class);
+  }
+
+  @Test
+  void parseStatesResponseReturnsEmptyResultWhenStatesNodeIsNotArray() throws Exception {
+    OpenSkyResponseParser parser = new OpenSkyResponseParser(new ObjectMapper());
+    OpenSkyRateLimitHeaders headers = new OpenSkyRateLimitHeaders(100, 4000, 1_700_000_000L);
+
+    FetchResult result = parser.parseStatesResponse("{\"states\":{}}", headers);
+
+    assertThat(result.states()).isEmpty();
+    assertThat(result.remainingCredits()).isEqualTo(100);
+    assertThat(result.creditLimit()).isEqualTo(4000);
+    assertThat(result.resetAtEpochSeconds()).isEqualTo(1_700_000_000L);
+  }
+}

--- a/src/ingester/src/test/java/com/cloudradar/ingester/opensky/OpenSkyStatesHttpMetricsTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/opensky/OpenSkyStatesHttpMetricsTest.java
@@ -1,0 +1,45 @@
+package com.cloudradar.ingester.opensky;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class OpenSkyStatesHttpMetricsTest {
+
+  @Test
+  void recordsResponsesAndExceptionsByOutcome() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    OpenSkyStatesHttpMetrics metrics = new OpenSkyStatesHttpMetrics(registry);
+    long startNs = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(10);
+
+    metrics.recordResponse(startNs, 200, OpenSkyStatesHttpMetrics.Outcome.SUCCESS);
+    metrics.recordResponse(startNs, 429, OpenSkyStatesHttpMetrics.Outcome.RATE_LIMITED);
+    metrics.recordResponse(startNs, 404, OpenSkyStatesHttpMetrics.Outcome.CLIENT_ERROR);
+    metrics.recordResponse(startNs, 503, OpenSkyStatesHttpMetrics.Outcome.SERVER_ERROR);
+
+    assertThat(counter(registry, "success")).isEqualTo(1.0);
+    assertThat(counter(registry, "rate_limited")).isEqualTo(1.0);
+    assertThat(counter(registry, "client_error")).isEqualTo(1.0);
+    assertThat(counter(registry, "server_error")).isEqualTo(1.0);
+    assertThat(registry.get("ingester.opensky.states.http.last_status").gauge().value()).isEqualTo(503.0);
+    assertThat(registry.get("ingester.opensky.states.http.duration").timer().count()).isEqualTo(4L);
+
+    metrics.recordException(startNs, false);
+    assertThat(counter(registry, "exception")).isEqualTo(1.0);
+    assertThat(registry.get("ingester.opensky.states.http.last_status").gauge().value()).isEqualTo(0.0);
+    assertThat(registry.get("ingester.opensky.states.http.duration").timer().count()).isEqualTo(5L);
+
+    metrics.recordException(startNs, true);
+    assertThat(counter(registry, "exception")).isEqualTo(2.0);
+    assertThat(registry.get("ingester.opensky.states.http.duration").timer().count()).isEqualTo(5L);
+  }
+
+  private double counter(SimpleMeterRegistry registry, String outcome) {
+    return registry.get("ingester.opensky.states.http.requests.total")
+        .tag("outcome", outcome)
+        .counter()
+        .count();
+  }
+}

--- a/src/ingester/src/test/java/com/cloudradar/ingester/opensky/OpenSkyTokenHttpMetricsTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/opensky/OpenSkyTokenHttpMetricsTest.java
@@ -1,0 +1,44 @@
+package com.cloudradar.ingester.opensky;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class OpenSkyTokenHttpMetricsTest {
+
+  @Test
+  void recordsTokenResponsesAndExceptions() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    OpenSkyTokenHttpMetrics metrics = new OpenSkyTokenHttpMetrics(registry);
+    long startNs = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(10);
+
+    metrics.recordResponse(startNs, 200);
+    metrics.recordResponse(startNs, 401);
+    metrics.recordResponse(startNs, 503);
+
+    assertThat(counter(registry, "success")).isEqualTo(1.0);
+    assertThat(counter(registry, "client_error")).isEqualTo(1.0);
+    assertThat(counter(registry, "server_error")).isEqualTo(1.0);
+    assertThat(registry.get("ingester.opensky.token.http.duration").timer().count()).isEqualTo(3L);
+
+    metrics.recordException(startNs, false);
+    assertThat(counter(registry, "exception")).isEqualTo(1.0);
+    assertThat(registry.get("ingester.opensky.token.http.duration").timer().count()).isEqualTo(4L);
+
+    metrics.recordException(startNs, true);
+    assertThat(counter(registry, "exception")).isEqualTo(2.0);
+    assertThat(registry.get("ingester.opensky.token.http.duration").timer().count()).isEqualTo(4L);
+
+    metrics.incrementException();
+    assertThat(counter(registry, "exception")).isEqualTo(3.0);
+  }
+
+  private double counter(SimpleMeterRegistry registry, String outcome) {
+    return registry.get("ingester.opensky.token.http.requests.total")
+        .tag("outcome", outcome)
+        .counter()
+        .count();
+  }
+}

--- a/src/ingester/src/test/java/com/cloudradar/ingester/opensky/OpenSkyTokenServiceTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/opensky/OpenSkyTokenServiceTest.java
@@ -43,7 +43,11 @@ class OpenSkyTokenServiceTest {
 
     OpenSkyTokenService service =
         new OpenSkyTokenService(
-            endpointProvider, properties, new SimpleMeterRegistry(), httpClient, new ObjectMapper());
+            endpointProvider,
+            properties,
+            httpClient,
+            new ObjectMapper(),
+            new OpenSkyTokenHttpMetrics(new SimpleMeterRegistry()));
 
     assertThatThrownBy(service::getToken)
         .isInstanceOf(OpenSkyTokenService.TokenRefreshException.class)
@@ -80,7 +84,11 @@ class OpenSkyTokenServiceTest {
 
     OpenSkyTokenService service =
         new OpenSkyTokenService(
-            endpointProvider, properties, new SimpleMeterRegistry(), httpClient, new ObjectMapper());
+            endpointProvider,
+            properties,
+            httpClient,
+            new ObjectMapper(),
+            new OpenSkyTokenHttpMetrics(new SimpleMeterRegistry()));
 
     String token = service.getToken();
 
@@ -122,7 +130,11 @@ class OpenSkyTokenServiceTest {
 
     OpenSkyTokenService service =
         new OpenSkyTokenService(
-            endpointProvider, properties, new SimpleMeterRegistry(), httpClient, new ObjectMapper());
+            endpointProvider,
+            properties,
+            httpClient,
+            new ObjectMapper(),
+            new OpenSkyTokenHttpMetrics(new SimpleMeterRegistry()));
 
     assertThat(service.getToken()).isEqualTo("cached");
     assertThat(service.getToken()).isEqualTo("cached");
@@ -157,7 +169,11 @@ class OpenSkyTokenServiceTest {
 
     OpenSkyTokenService service =
         new OpenSkyTokenService(
-            endpointProvider, properties, new SimpleMeterRegistry(), httpClient, new ObjectMapper());
+            endpointProvider,
+            properties,
+            httpClient,
+            new ObjectMapper(),
+            new OpenSkyTokenHttpMetrics(new SimpleMeterRegistry()));
 
     assertThatThrownBy(service::getToken)
         .isInstanceOf(OpenSkyTokenService.TokenRefreshException.class)

--- a/src/ingester/src/test/java/com/cloudradar/ingester/opensky/TokenCooldownPolicyTest.java
+++ b/src/ingester/src/test/java/com/cloudradar/ingester/opensky/TokenCooldownPolicyTest.java
@@ -1,0 +1,45 @@
+package com.cloudradar.ingester.opensky;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class TokenCooldownPolicyTest {
+
+  @Test
+  void registerFailureUsesProgressiveCooldown() {
+    TokenCooldownPolicy policy = new TokenCooldownPolicy();
+    Instant now = Instant.now();
+
+    TokenCooldownPolicy.FailureState first = policy.registerFailure(now);
+    TokenCooldownPolicy.FailureState second = policy.registerFailure(now.plusSeconds(20));
+
+    assertThat(first.failureCount()).isEqualTo(1);
+    assertThat(first.cooldownSeconds()).isEqualTo(15L);
+    assertThat(second.failureCount()).isEqualTo(2);
+    assertThat(second.cooldownSeconds()).isEqualTo(30L);
+  }
+
+  @Test
+  void resetClearsCooldownWindow() {
+    TokenCooldownPolicy policy = new TokenCooldownPolicy();
+    Instant now = Instant.now();
+    policy.registerFailure(now);
+
+    assertThat(policy.isBlocked(now.plusSeconds(1))).isTrue();
+
+    policy.reset();
+
+    assertThat(policy.isBlocked(now.plusSeconds(1))).isFalse();
+  }
+
+  @Test
+  void remainingSecondsIsAtLeastOneSecond() {
+    TokenCooldownPolicy policy = new TokenCooldownPolicy();
+    Instant now = Instant.now();
+    policy.registerFailure(now);
+
+    assertThat(policy.remainingSeconds(now.plusSeconds(14))).isEqualTo(1L);
+  }
+}


### PR DESCRIPTION
## Summary
- Refactored `FlightIngestJob` into an orchestration-focused component and extracted dedicated collaborators for backoff, rate-limit tracking, event mapping, and metrics.
- Refactored `OpenSkyClient` by extracting bbox resolution, response parsing, and HTTP metrics helpers while preserving existing runtime contracts.
- Refactored `OpenSkyTokenService` by extracting cooldown and token HTTP metrics helpers while keeping token cache/cooldown behavior unchanged.
- Removed ingester quality suppressions/exclusions in Checkstyle and PMD and updated ingester architecture documentation to match the new internal design.
- Added dedicated unit tests for extracted collaborators, plus parser malformed-payload coverage.

## Validation
- `mvn -B -f src/ingester/pom.xml verify`

## Notes
- Runtime behavior/contract scope for this PR remained isofunctional (no external API/Redis contract changes).
- Deferred known runtime-risk fix is tracked separately: `Refs #566`.

Closes #559
