### PR TITLE
feat(edge): add offline fallback landing page and Route53 failover

### DIFF
--- a/.github/workflows/bootstrap-terraform-backend.yml
+++ b/.github/workflows/bootstrap-terraform-backend.yml
@@ -60,6 +60,19 @@ jobs:
           BACKUP_BUCKET="${{ vars.TF_BACKUP_BUCKET_NAME }}"
           AIRCRAFT_REFERENCE_BUCKET="${{ vars.TF_AIRCRAFT_REFERENCE_BUCKET_NAME }}"
           DNS_ZONE_NAME="${{ vars.DNS_ZONE_NAME }}"
+          OFFLINE_SITE_ENABLED="${{ vars.OFFLINE_SITE_ENABLED }}"
+          OFFLINE_SITE_BUCKET_NAME="${{ vars.OFFLINE_SITE_BUCKET_NAME }}"
+          OFFLINE_SUBDOMAIN_LABEL="${{ vars.OFFLINE_SUBDOMAIN_LABEL }}"
+          OFFLINE_PRIMARY_DOMAIN_LABEL="${{ vars.OFFLINE_PRIMARY_DOMAIN_LABEL }}"
+          OFFLINE_CONTACT_SENDER_EMAIL="${{ vars.OFFLINE_CONTACT_SENDER_EMAIL }}"
+          OFFLINE_CONTACT_RECIPIENT_EMAIL="${{ vars.OFFLINE_CONTACT_RECIPIENT_EMAIL }}"
+          OFFLINE_LOGS_RETENTION_DAYS="${{ vars.OFFLINE_LOGS_RETENTION_DAYS }}"
+          OFFLINE_RATE_LIMIT_WINDOW_SECONDS="${{ vars.OFFLINE_RATE_LIMIT_WINDOW_SECONDS }}"
+          OFFLINE_RATE_LIMIT_MAX_HITS="${{ vars.OFFLINE_RATE_LIMIT_MAX_HITS }}"
+          OFFLINE_API_THROTTLE_RATE_LIMIT="${{ vars.OFFLINE_API_THROTTLE_RATE_LIMIT }}"
+          OFFLINE_API_THROTTLE_BURST_LIMIT="${{ vars.OFFLINE_API_THROTTLE_BURST_LIMIT }}"
+          OFFLINE_PRIMARY_HEALTH_PATH="${{ vars.OFFLINE_PRIMARY_HEALTH_PATH }}"
+          OFFLINE_PRIMARY_HEALTH_PORT="${{ vars.OFFLINE_PRIMARY_HEALTH_PORT }}"
           ISSUE_TLS="${{ inputs.issue_tls }}"
           TLS_DOMAIN="${{ vars.TLS_DOMAIN }}"
 
@@ -82,6 +95,7 @@ jobs:
             echo "TF_VAR_state_bucket_name=${STATE_BUCKET}"
             echo "TF_VAR_lock_table_name=${LOCK_TABLE}"
             echo "TF_VAR_region=${REGION}"
+            echo "TF_VAR_offline_site_enabled=${OFFLINE_SITE_ENABLED:-false}"
           } >> "${GITHUB_ENV}"
 
           if [[ -n "${BACKUP_BUCKET}" ]]; then
@@ -103,6 +117,43 @@ jobs:
               echo "DNS_ZONE_NAME=${DNS_ZONE_NAME}"
               echo "TF_VAR_dns_zone_name=${DNS_ZONE_NAME}"
             } >> "${GITHUB_ENV}"
+          fi
+
+          if [[ -n "${OFFLINE_SITE_BUCKET_NAME}" ]]; then
+            echo "TF_VAR_offline_site_bucket_name=${OFFLINE_SITE_BUCKET_NAME}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_SUBDOMAIN_LABEL}" ]]; then
+            echo "TF_VAR_offline_subdomain_label=${OFFLINE_SUBDOMAIN_LABEL}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_PRIMARY_DOMAIN_LABEL}" ]]; then
+            echo "TF_VAR_offline_primary_domain_label=${OFFLINE_PRIMARY_DOMAIN_LABEL}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_CONTACT_SENDER_EMAIL}" ]]; then
+            echo "TF_VAR_offline_contact_sender_email=${OFFLINE_CONTACT_SENDER_EMAIL}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_CONTACT_RECIPIENT_EMAIL}" ]]; then
+            echo "TF_VAR_offline_contact_recipient_email=${OFFLINE_CONTACT_RECIPIENT_EMAIL}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_LOGS_RETENTION_DAYS}" ]]; then
+            echo "TF_VAR_offline_logs_retention_days=${OFFLINE_LOGS_RETENTION_DAYS}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_RATE_LIMIT_WINDOW_SECONDS}" ]]; then
+            echo "TF_VAR_offline_rate_limit_window_seconds=${OFFLINE_RATE_LIMIT_WINDOW_SECONDS}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_RATE_LIMIT_MAX_HITS}" ]]; then
+            echo "TF_VAR_offline_rate_limit_max_hits=${OFFLINE_RATE_LIMIT_MAX_HITS}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_API_THROTTLE_RATE_LIMIT}" ]]; then
+            echo "TF_VAR_offline_api_throttle_rate_limit=${OFFLINE_API_THROTTLE_RATE_LIMIT}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_API_THROTTLE_BURST_LIMIT}" ]]; then
+            echo "TF_VAR_offline_api_throttle_burst_limit=${OFFLINE_API_THROTTLE_BURST_LIMIT}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_PRIMARY_HEALTH_PATH}" ]]; then
+            echo "TF_VAR_offline_primary_health_path=${OFFLINE_PRIMARY_HEALTH_PATH}" >> "${GITHUB_ENV}"
+          fi
+          if [[ -n "${OFFLINE_PRIMARY_HEALTH_PORT}" ]]; then
+            echo "TF_VAR_offline_primary_health_port=${OFFLINE_PRIMARY_HEALTH_PORT}" >> "${GITHUB_ENV}"
           fi
 
       - name: Import existing backend resources (idempotent)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Security is treated as a **first-class concern**, not an afterthought:
 | **Edge Access** | Nginx + Basic Auth (dev), TLS | ✅ Implemented |
 | **Least Privilege** | IAM roles scoped per service, OIDC for CI | ✅ Implemented |
 | **Secrets Rotation** | Automated rotation via ESO + SSM | 📝 Planned |
-| **WAF / CloudFront** | Edge security + caching | 📝 Planned |
+| **Route53 Failover + CloudFront (offline path)** | Automatic fallback to branded offline landing page + demo contact form | 🔧 In progress |
 
 ---
 
@@ -354,7 +354,7 @@ All services expose `/healthz` (liveness) and `/metrics` (Prometheus scrape).
 | **SSM Parameter Store** | Runtime secrets + config | ✅ |
 | **IAM OIDC** | GitHub Actions ↔ AWS trust (zero static keys) | ✅ |
 | **VPC Endpoints** | Private access to SSM, S3 | ✅ |
-| **CloudFront** | Edge CDN + WAF | 📝 Planned |
+| **CloudFront (offline fallback path)** | Serves persistent offline page and contact endpoint when primary live path is unhealthy | 🔧 In progress |
 
 > Full details: [Infrastructure Architecture](docs/architecture/infrastructure.md)
 
@@ -364,7 +364,7 @@ All services expose `/healthz` (liveness) and `/metrics` (Prometheus scrape).
 
 - Single AWS region (`us-east-1`) with a small cluster footprint (edge + control plane + one worker): no multi-region HA.
 - Data layer is still MVP-grade: Redis storage resilience hardening is in progress.
-- Edge security is pragmatic for MVP (Nginx + Basic Auth + Let's Encrypt/SSM); managed edge hardening (CloudFront/WAF path) is planned.
+- Edge security is pragmatic for MVP (Nginx + Basic Auth + Let's Encrypt/SSM). Route53 failover + CloudFront are introduced for the offline fallback path while keeping the online path unchanged.
 - Performance validation is baseline-level (nightly k6), not full-scale capacity modeling.
 - Some high-impact operations are intentionally manual-gated in CI/CD (apply/destroy) for safety and cost control.
 

--- a/docs/architecture/application-architecture.md
+++ b/docs/architecture/application-architecture.md
@@ -1,6 +1,6 @@
 # CloudRadar Application Architecture
 
-**Last updated**: 2026-03-12
+**Last updated**: 2026-03-13
 
 This document describes the architecture and design of all microservices in the CloudRadar platform. Each service is containerized and deployed to k3s via ArgoCD.
 
@@ -17,6 +17,10 @@ CloudRadar consists of six implemented application services:
 
 ```mermaid
 graph TB
+    User["User Browser"]
+    Route53["Route53 Failover<br/>(cloudradar.<domain>)"]
+    CloudFrontOffline["CloudFront Offline<br/>(secondary path)"]
+    OfflineSite["Offline Landing + Contact API<br/>(S3 + API Gateway/Lambda)"]
     OpenSky["OpenSky API"]
     Ingester["Ingester<br/>(Java 17)"]
     Redis["Redis Buffer<br/>(cloudradar:ingest:queue)"]
@@ -30,6 +34,11 @@ graph TB
     Prometheus["Prometheus<br/>(metrics collection)"]
     Grafana["Grafana<br/>(dashboards)"]
 
+    User -->|HTTPS| Route53
+    Route53 -->|PRIMARY healthy| Edge
+    Route53 -->|SECONDARY on failover| CloudFrontOffline
+    CloudFrontOffline --> OfflineSite
+
     OpenSky -->|periodic fetch| Ingester
     Ingester -->|push events| Redis
     Redis -->|consume events| Processor
@@ -41,12 +50,16 @@ graph TB
     Prometheus -->|visualize| Grafana
     DashboardAPI -->|read aggregates| RedisAgg
     DashboardAPI -->|REST + SSE| Frontend
+    Edge -->|proxy /api| DashboardAPI
+    Edge -->|proxy /| Frontend
     Frontend -->|embed dashboards| Grafana
     Grafana -->|query| Prometheus
 ```
 
 ### Observability Access Path
-- **Edge Nginx (EC2)** is the only public entrypoint and applies Basic Auth. It forwards to K3s nodeports/Ingress.
+- **Primary online path**: Route53 failover record targets **Edge Nginx (EC2)** when healthy.
+- **Secondary offline path**: Route53 failover targets **CloudFront offline distribution** (S3 static page + `/api/contact-demo`).
+- **Edge Nginx (EC2)** remains the online public entrypoint and applies Basic Auth where configured. It forwards to K3s nodeports/Ingress.
 - **In-cluster**: Traefik (k3s default) routes HTTP to services (Grafana, Prometheus). No additional in-cluster proxy.
 - **Security**: Secrets for Basic Auth are stored in SSM (surfaced via ESO where needed). Remove duplicate proxies to reduce attack surface.
 

--- a/docs/architecture/decisions/ADR-0022-2026-03-13-offline-fallback-route53-failover.md
+++ b/docs/architecture/decisions/ADR-0022-2026-03-13-offline-fallback-route53-failover.md
@@ -1,0 +1,64 @@
+# ADR-0022: Offline Fallback via Route53 Failover (No WAF in v1.1)
+
+## Status
+Accepted
+
+## Context
+CloudRadar runtime infrastructure can be intentionally destroyed for FinOps optimization. In that state, users currently hit an unavailable site instead of a branded fallback experience.
+
+Constraints:
+- keep the online runtime path unchanged (`edge` + Let's Encrypt cert loaded from SSM),
+- preserve low recurring cost,
+- provide a conversion-oriented contact path for demo requests,
+- add anti-spam controls without introducing high fixed-cost components.
+
+## Decision
+Implement an offline fallback stack in the persistent bootstrap layer with Route53 failover:
+
+Important DNS behavior:
+- `PRIMARY` and `SECONDARY` are two failover records for the same public hostname (`cloudradar.<domain>`).
+- Users always access the same URL; Route53 selects which target to return based on the primary health check.
+
+1. **Primary DNS path (online)**
+   - `cloudradar.<domain>` failover PRIMARY points to `live.<domain>` (existing edge path).
+   - Primary health check probes `https://live.<domain>/statusz`.
+
+2. **Secondary DNS path (offline)**
+   - `cloudradar.<domain>` failover SECONDARY points to an offline CloudFront distribution.
+   - CloudFront serves static assets from private S3 and routes `/api/contact-demo` to API Gateway.
+
+3. **Contact form backend**
+   - API Gateway HTTP API -> Lambda (arm64, non-VPC) -> SES email.
+   - Anti-spam baseline: API throttling, honeypot, payload validation, DynamoDB rate limiting.
+
+4. **Security/FinOps stance (v1.1)**
+   - No WAF in v1.1 (fixed monthly cost avoided).
+   - CloudWatch retention aligned with existing 3-7 day policy.
+   - CloudFront `PriceClass_100` (EU + some US audience).
+
+## Consequences
+### Positive
+- Branded offline UX remains available while live infra is down.
+- Online architecture and existing edge TLS flow stay unchanged.
+- Very low incremental cost for low traffic/demo volume.
+- Contact conversion path remains functional during downtime.
+
+### Trade-offs
+- Offline fallback introduces additional DNS/TLS objects (Route53 failover + ACM for CloudFront fallback path).
+- Route53 failover adds propagation and health-check detection delay.
+- Without WAF, spam defense relies on application/API controls only.
+
+## Rejected alternatives
+1. **Single-domain CloudFront in front of online + offline**
+   - Rejected for this iteration to avoid changing the online runtime path and certificate termination model.
+
+2. **S3 website-only fallback**
+   - Rejected because HTTPS + custom-domain behavior is insufficient for the main domain fallback requirement.
+
+3. **WAF from day one**
+   - Rejected for v1.1 due fixed cost/complexity; deferred unless abuse patterns justify it.
+
+## Implementation links
+- Issue: #576
+- Runbook: `docs/runbooks/operations/offline-fallback.md`
+- Infra doc: `docs/architecture/infrastructure.md`

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -5,24 +5,30 @@ This document describes the Terraform layout and the baseline VPC network used p
 ## Terraform layout
 
 ### Terraform roots
-- `infra/aws/bootstrap`: creates the Terraform backend (state bucket, lock table) and the SQLite backup bucket.
+- `infra/aws/bootstrap`: creates the Terraform backend (state bucket, lock table), optional data buckets, optional DNS zone, and optional persistent offline fallback stack.
 - `infra/aws/live/dev`: deploys the full dev stack (VPC, NAT instance, k3s, edge) and wires the backup bucket name to k3s.
 - `infra/aws/live/prod`: deploys the prod VPC baseline only (future app/edge/k3s TBD).
 
 ```mermaid
 flowchart TB
   subgraph Bootstrap["infra/aws/bootstrap"]
+    direction LR
     backend["state S3 bucket"]
     lock["DynamoDB lock table"]
-    backups["SQLite backup bucket"]
+    backend --> lock
+    lock -. optional .-> dns_zone["Route53 hosted zone"]
+    lock -. optional .-> backups["SQLite backup bucket"]
+    lock -. optional .-> offline_stack["Offline fallback stack<br/>Route53 failover + CloudFront + S3 + API/Lambda + DynamoDB"]
   end
 
   subgraph Live["infra/aws/live"]
+    direction LR
     dev["dev root"]
     prod["prod root"]
   end
 
   subgraph Modules["infra/aws/modules"]
+    direction TB
     subgraph vpc["vpc module"]
       vpc_res["VPC"]
       subnets["Public/private subnets"]
@@ -54,6 +60,7 @@ flowchart TB
     end
   end
 
+  Bootstrap -->|backend for| Live
   dev --> vpc
   dev --> nat
   dev --> k3s
@@ -103,6 +110,23 @@ flowchart TB
 
   edge -. "SSM (optional)" .-> ssmEndpoints
   k3s -. "SSM (optional)" .-> ssmEndpoints
+```
+
+## Offline failover path (optional, bootstrap-persistent)
+
+When enabled, DNS failover keeps the online path unchanged and serves a branded offline page when the primary health check fails.
+Both failover records share the same public hostname (`cloudradar.<domain>`): Route53 returns PRIMARY (online) or SECONDARY (offline) target according to the health-check result.
+
+```mermaid
+flowchart LR
+  user["User browser"] --> r53["Route53 failover record (cloudradar.<domain>)"]
+  r53 -->|PRIMARY healthy| live["live.<domain> -> edge Nginx (existing online path)"]
+  r53 -->|PRIMARY unhealthy| cf["CloudFront offline distribution"]
+  cf --> s3["S3 offline static assets"]
+  cf --> api["API Gateway HTTP API (/api/contact-demo)"]
+  api --> lambda["Lambda contact handler"]
+  lambda --> ddb["DynamoDB rate-limit table"]
+  lambda --> ses["SES email notification"]
 ```
 
 ## Edge TLS Certificate Architecture (MVP)
@@ -224,6 +248,7 @@ Prod values are currently aligned with module defaults and may be overridden lat
 - EBS CSI driver deployed via ArgoCD (kube-system).
 - `ebs-gp3` StorageClass for stateful workloads.
 - S3 backup bucket for SQLite snapshots.
+- Optional bootstrap-persistent offline S3 bucket for static fallback assets.
 
 ### Security
 - Security group for k3s nodes (explicit ports).
@@ -289,6 +314,7 @@ See [docs/runbooks/observability.md](../runbooks/observability.md) for operation
 ## Status
 
 - Implemented (IaC): VPC, subnets, route tables, internet gateway, NAT instance, k3s nodes, edge EC2, S3 backup bucket for SQLite snapshots.
+- Implemented (optional): Route53 failover + CloudFront/S3 offline fallback + serverless contact path (API Gateway + Lambda + DynamoDB + SES), managed in `infra/aws/bootstrap`.
 - Implemented (Edge TLS MVP): Let's Encrypt DNS-01 issuance from bootstrap workflow and certificate storage in SSM (`/cloudradar/edge/tls/*`) consumed by edge at boot in strict mode.
 - Implemented (IaC, dev): SSM/KMS interface endpoints are temporarily disabled to reduce cost; edge uses HTTPS egress for SSM.
 - Implemented (Platform): ArgoCD bootstrap via SSM/CI for GitOps delivery, Redis buffer in the data namespace, EBS CSI driver + `ebs-gp3` StorageClass.

--- a/docs/architecture/technical-architecture-summary.fr.md
+++ b/docs/architecture/technical-architecture-summary.fr.md
@@ -1,7 +1,7 @@
 # CloudRadar — Synthese Technique d'Architecture
 
 **Version**: v1-mvp  
-**Date**: 2026-03-10  
+**Date**: 2026-03-13  
 **Audience**: Ingenieurs DevOps, Architectes Cloud, Recruteurs Techniques  
 **Objectif**: Portfolio mettant en avant une architecture cloud de niveau production, des pratiques GitOps et l'automatisation de l'infrastructure
 
@@ -34,7 +34,7 @@ Les choix techniques suivent une strategie FinOps explicite: maximiser la valeur
 **Observabilite et Pratiques SRE**:
 - ✅ Metriques full-stack (app -> plateforme -> infra) avec Prometheus + Grafana
 - ✅ Instrumentation service-level (`/healthz` + endpoints de scrape Prometheus)
-- ✅ 21 Architecture Decision Records documentant les compromis
+- ✅ 22 Architecture Decision Records documentant les compromis
 
 **Securite et Conformite**:
 - ✅ Architecture zero-trust (acces IAM uniquement, pas de SSH)
@@ -54,20 +54,31 @@ Les choix techniques suivent une strategie FinOps explicite: maximiser la valeur
 
 ```mermaid
 graph TB
-    USER[👤 DevOps Engineer]
-    CORE[☁️ CloudRadar Platform<br/>Event-Driven Pipeline<br/>Ingester → Redis → Processor → Dashboard]
+    USER[DevOps Engineer]
+    R53[Route53 Failover<br/>cloudradar.domain.tld]
+    EDGE[Edge Nginx primaire<br/>Lets Encrypt via SSM]
+    OFFLINE[CloudFront offline secondaire<br/>S3 + API Gateway/Lambda]
+    CORE[CloudRadar Platform<br/>Ingester -> Redis -> Processor -> Dashboard]
     
-    OPENSKY[🌐 OpenSky API<br/>Flight telemetry source]
-    GITHUB[🌐 GitHub<br/>CI/CD & GitOps]
-    AWS[🏗️ AWS Infrastructure<br/>VPC · EC2 · S3 · SSM · IAM]
+    OPENSKY[OpenSky API<br/>Flight telemetry source]
+    GITHUB[GitHub<br/>CI/CD & GitOps]
+    AWS[AWS Infrastructure<br/>VPC, EC2, S3, SSM, IAM]
     
-    USER -->|Views dashboards<br/>HTTPS| CORE
+    USER -->|HTTPS| R53
+    R53 -->|PRIMARY healthy| EDGE
+    R53 -->|SECONDARY failover| OFFLINE
+    EDGE -->|Acces app online| CORE
     CORE -->|Polls states<br/>REST/OAuth2| OPENSKY
     GITHUB -->|Deploys<br/>Actions/OIDC| CORE
+    GITHUB -->|Deploy bootstrap/offline IaC| OFFLINE
     CORE -->|Runs on<br/>Terraform/k8s| AWS
+    OFFLINE -->|Runs on<br/>Terraform/bootstrap| AWS
     
     style USER fill:#1976d2,stroke:#0d47a1,stroke-width:2px,color:#fff
     style CORE fill:#388e3c,stroke:#1b5e20,stroke-width:3px,color:#fff
+    style R53 fill:#1565c0,stroke:#0d47a1,stroke-width:2px,color:#fff
+    style EDGE fill:#00897b,stroke:#004d40,stroke-width:2px,color:#fff
+    style OFFLINE fill:#6a1b9a,stroke:#4a148c,stroke-width:2px,color:#fff
     style OPENSKY fill:#757575,stroke:#424242,stroke-width:2px,color:#fff
     style GITHUB fill:#757575,stroke:#424242,stroke-width:2px,color:#fff
     style AWS fill:#ff9800,stroke:#e65100,stroke-width:2px,color:#fff
@@ -95,8 +106,10 @@ graph TB
 ### 2.1 Topologie VPC et Reseau
 
 ```mermaid
-graph LR
+graph TB
     INTERNET((Internet))
+    R53[Route53 failover]
+    CF[CloudFront offline secondaire]
     
     subgraph VPC["VPC 10.0.0.0/16 (dev, us-east-1a)"]
         IGW[IGW]
@@ -113,7 +126,9 @@ graph LR
         end
     end
     
-    INTERNET -->|User requests<br/>HTTPS| IGW
+    INTERNET -->|User requests HTTPS| R53
+    R53 -->|PRIMARY healthy| IGW
+    R53 -->|SECONDARY failover| CF
     IGW -->|Routes to| EDGE
     EDGE -.->|Proxies to| K3S_S
     K3S_S -->|Manages| K3S_W
@@ -548,7 +563,7 @@ Note sizing EBS (defaults dev): 40GB (k3s server) + 40GB (k3s worker) + 40GB (ed
 
 **Pour des details techniques complets**:
 - [Full Technical Architecture Document](./technical-architecture-document.md) — Analyse complete avec 28 schemas (1000+ lignes)
-- [Architecture Decision Records](./decisions/) — 21 ADRs (contexte, alternatives, compromis)
+- [Architecture Decision Records](./decisions/) — 22 ADRs (contexte, alternatives, compromis)
 - [Infrastructure Documentation](./infrastructure.md) — Details architecture AWS/Terraform
 - [Application Architecture](./application-architecture.md) — Patterns de design microservices
 - [Runbooks](../runbooks/) — Bootstrap, operations, troubleshooting
@@ -556,4 +571,4 @@ Note sizing EBS (defaults dev): 40GB (k3s server) + 40GB (k3s worker) + 40GB (ed
 
 ---
 
-**Maintenance du Document**: a mettre a jour quand des changements d'architecture majeurs sont merges. Derniere mise a jour: 2026-03-10.
+**Maintenance du Document**: a mettre a jour quand des changements d'architecture majeurs sont merges. Derniere mise a jour: 2026-03-13.

--- a/docs/architecture/technical-architecture-summary.md
+++ b/docs/architecture/technical-architecture-summary.md
@@ -1,7 +1,7 @@
 # CloudRadar — Technical Architecture Summary
 
 **Version**: v1-mvp  
-**Date**: 2026-03-10  
+**Date**: 2026-03-13  
 **Audience**: DevOps Engineers, Cloud Architects, Technical Recruiters  
 **Purpose**: Portfolio showcase demonstrating production-grade cloud architecture, GitOps practices, and infrastructure automation
 
@@ -34,7 +34,7 @@ Technical choices follow an explicit FinOps strategy: maximize demonstration val
 **Observability & SRE Practices**:
 - ✅ Full-stack metrics (app → platform → infra) with Prometheus + Grafana
 - ✅ Service-level instrumentation (`/healthz` + Prometheus scrape endpoints)
-- ✅ 21 Architecture Decision Records documenting trade-offs
+- ✅ 22 Architecture Decision Records documenting trade-offs
 
 **Security & Compliance**:
 - ✅ Zero-trust network architecture (IAM-only access, no SSH)
@@ -54,20 +54,31 @@ Technical choices follow an explicit FinOps strategy: maximize demonstration val
 
 ```mermaid
 graph TB
-    USER[👤 DevOps Engineer]
-    CORE[☁️ CloudRadar Platform<br/>Event-Driven Pipeline<br/>Ingester → Redis → Processor → Dashboard]
+    USER[DevOps Engineer]
+    R53[Route53 Failover<br/>cloudradar.domain.tld]
+    EDGE[Edge Nginx primary<br/>Lets Encrypt cert from SSM]
+    OFFLINE[CloudFront offline secondary<br/>S3 + API Gateway/Lambda]
+    CORE[CloudRadar Platform<br/>Ingester -> Redis -> Processor -> Dashboard]
     
-    OPENSKY[🌐 OpenSky API<br/>Flight telemetry source]
-    GITHUB[🌐 GitHub<br/>CI/CD & GitOps]
-    AWS[🏗️ AWS Infrastructure<br/>VPC · EC2 · S3 · SSM · IAM]
+    OPENSKY[OpenSky API<br/>Flight telemetry source]
+    GITHUB[GitHub<br/>CI/CD and GitOps]
+    AWS[AWS Infrastructure<br/>VPC, EC2, S3, SSM, IAM]
     
-    USER -->|Views dashboards<br/>HTTPS| CORE
+    USER -->|HTTPS| R53
+    R53 -->|PRIMARY healthy| EDGE
+    R53 -->|SECONDARY failover| OFFLINE
+    EDGE -->|Online app access| CORE
     CORE -->|Polls states<br/>REST/OAuth2| OPENSKY
     GITHUB -->|Deploys<br/>Actions/OIDC| CORE
+    GITHUB -->|Deploys bootstrap/offline IaC| OFFLINE
     CORE -->|Runs on<br/>Terraform/k8s| AWS
+    OFFLINE -->|Runs on<br/>Terraform/bootstrap| AWS
     
     style USER fill:#1976d2,stroke:#0d47a1,stroke-width:2px,color:#fff
     style CORE fill:#388e3c,stroke:#1b5e20,stroke-width:3px,color:#fff
+    style R53 fill:#1565c0,stroke:#0d47a1,stroke-width:2px,color:#fff
+    style EDGE fill:#00897b,stroke:#004d40,stroke-width:2px,color:#fff
+    style OFFLINE fill:#6a1b9a,stroke:#4a148c,stroke-width:2px,color:#fff
     style OPENSKY fill:#757575,stroke:#424242,stroke-width:2px,color:#fff
     style GITHUB fill:#757575,stroke:#424242,stroke-width:2px,color:#fff
     style AWS fill:#ff9800,stroke:#e65100,stroke-width:2px,color:#fff
@@ -95,8 +106,10 @@ graph TB
 ### 2.1 VPC & Network Topology
 
 ```mermaid
-graph LR
+graph TB
     INTERNET((Internet))
+    R53[Route53 failover]
+    CF[CloudFront offline secondary]
     
     subgraph VPC["VPC 10.0.0.0/16 (dev, us-east-1a)"]
         IGW[IGW]
@@ -113,7 +126,9 @@ graph LR
         end
     end
     
-    INTERNET -->|User requests<br/>HTTPS| IGW
+    INTERNET -->|User requests HTTPS| R53
+    R53 -->|PRIMARY healthy| IGW
+    R53 -->|SECONDARY failover| CF
     IGW -->|Routes to| EDGE
     EDGE -.->|Proxies to| K3S_S
     K3S_S -->|Manages| K3S_W
@@ -548,7 +563,7 @@ EBS sizing note (dev defaults): 40GB (k3s server) + 40GB (k3s worker) + 40GB (ed
 
 **For deeper technical details**:
 - [Full Technical Architecture Document](./technical-architecture-document.md) — Complete 28-diagram analysis (1000+ lines)
-- [Architecture Decision Records](./decisions/) — 21 ADRs (context, alternatives, trade-offs)
+- [Architecture Decision Records](./decisions/) — 22 ADRs (context, alternatives, trade-offs)
 - [Infrastructure Documentation](./infrastructure.md) — AWS/Terraform architecture details
 - [Application Architecture](./application-architecture.md) — Microservices design patterns
 - [Runbooks](../runbooks/) — Bootstrap, operations, troubleshooting
@@ -556,4 +571,4 @@ EBS sizing note (dev defaults): 40GB (k3s server) + 40GB (k3s worker) + 40GB (ed
 
 ---
 
-**Document Maintenance**: Update when major architectural changes are merged. Last updated: 2026-03-10.
+**Document Maintenance**: Update when major architectural changes are merged. Last updated: 2026-03-13.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -155,6 +155,12 @@ Purpose: run and verify the React/Leaflet frontend that consumes dashboard API e
 
 - Runbook: `docs/runbooks/operations/frontend.md`
 
+## 3.6.2) Offline fallback landing page (optional)
+
+Purpose: keep a branded offline experience with demo contact form when live infra is down, using Route53 failover.
+
+- Runbook: `docs/runbooks/operations/offline-fallback.md`
+
 ## 3.7) Observability stack (Prometheus + Grafana)
 
 Purpose: deploy Prometheus (metrics collection) and Grafana (dashboards) for cluster and application health monitoring.

--- a/docs/runbooks/bootstrap/terraform-backend-bootstrap.md
+++ b/docs/runbooks/bootstrap/terraform-backend-bootstrap.md
@@ -8,6 +8,7 @@ Optionally, it can also create:
 - an S3 bucket for SQLite backups
 - an S3 bucket for aircraft reference data artifacts
 - a Route53 hosted zone for DNS delegation
+- an offline fallback stack (S3 + CloudFront + API Gateway + Lambda + SES wiring + Route53 failover)
 
 When requested (`issue_tls=true`), it can also:
 - issue a public certificate with Let's Encrypt DNS-01
@@ -57,6 +58,9 @@ flowchart TB
   - `TF_AIRCRAFT_REFERENCE_BUCKET_NAME` (optional, aircraft reference bucket)
   - `DNS_ZONE_NAME` (optional unless `issue_tls=true`)
   - `TLS_DOMAIN` (required when `issue_tls=true`)
+  - `OFFLINE_SITE_ENABLED` (optional; set `true` to enable offline fallback stack)
+  - `OFFLINE_CONTACT_SENDER_EMAIL` (required when `OFFLINE_SITE_ENABLED=true`)
+  - `OFFLINE_CONTACT_RECIPIENT_EMAIL` (required when `OFFLINE_SITE_ENABLED=true`)
 
 ## Run
 1) In GitHub Actions, run **bootstrap-terraform-backend** workflow.
@@ -146,6 +150,7 @@ sequenceDiagram
 - SQLite backup bucket created (if `backup_bucket_name` provided).
 - Aircraft reference bucket created (if `aircraft_reference_bucket_name` provided).
 - Route53 hosted zone created (if `dns_zone_name` provided).
+- Offline fallback stack created (if `offline_site_enabled=true`): offline S3 assets, CloudFront distribution, contact API/Lambda, Route53 failover records.
 - TLS artifacts stored in SSM (if `issue_tls=true`):
   - `/cloudradar/edge/tls/fullchain_pem` (`SecureString`)
   - `/cloudradar/edge/tls/privkey_pem` (`SecureString`)
@@ -193,6 +198,9 @@ terraform -chdir=infra/aws/live/dev init -backend-config=backend.hcl
   - Forces RSA key generation (`--key-type rsa --rsa-key-size 2048`) for edge compatibility.
   - `TLS_DOMAIN` must be inside `DNS_ZONE_NAME`.
   - SSM writes use `SecureString` Standard tier first, then Advanced tier fallback only if value size exceeds Standard limits.
+- Offline fallback details:
+  - Route53 failover keeps the online path unchanged and switches to offline CloudFront only when the primary health check fails.
+  - Anti-spam baseline excludes WAF by design (FinOps): API throttling + honeypot + backend validation + DynamoDB rate limits.
 
 ## State Persistence (Recommended)
 This workflow intentionally uses a local Terraform backend on the GitHub Actions runner to avoid a chicken-and-egg dependency.

--- a/docs/runbooks/operations/offline-fallback.md
+++ b/docs/runbooks/operations/offline-fallback.md
@@ -1,0 +1,70 @@
+# Offline Fallback Landing Page (Route53 Failover)
+
+## Purpose
+Serve a branded CloudRadar offline landing page with demo-contact form when live infrastructure is down (or intentionally destroyed), while keeping the online stack unchanged.
+
+## Architecture summary
+- Primary path (online): `cloudradar.<domain>` -> edge Nginx (existing, Let's Encrypt cert from SSM).
+- Failover path (offline): Route53 failover switches to CloudFront offline distribution backed by bootstrap S3.
+- Both failover records use the same public hostname (`cloudradar.<domain>`); Route53 returns PRIMARY or SECONDARY target depending on primary health-check status.
+- Contact form: `/api/contact-demo` -> CloudFront behavior -> API Gateway HTTP API -> Lambda -> SES.
+- Anti-spam baseline (no WAF): API throttling + honeypot + backend validation + DynamoDB IP/window rate limit.
+
+## Prerequisites
+- `DNS_ZONE_NAME` configured in bootstrap workflow vars.
+- Hosted zone managed by `infra/aws/bootstrap`.
+- Sender/recipient emails configured for SES and available for the selected region.
+
+## Required GitHub Action variables
+Set in repository variables before running `bootstrap-terraform-backend`:
+- `OFFLINE_SITE_ENABLED=true`
+- `OFFLINE_CONTACT_SENDER_EMAIL=<verified-ses-sender>`
+- `OFFLINE_CONTACT_RECIPIENT_EMAIL=<your-mailbox>`
+
+Optional tuning:
+- `OFFLINE_SITE_BUCKET_NAME`
+- `OFFLINE_SUBDOMAIN_LABEL` (default: `offline`)
+- `OFFLINE_PRIMARY_DOMAIN_LABEL` (default: `live`)
+- `OFFLINE_LOGS_RETENTION_DAYS` (default: `7`)
+- `OFFLINE_RATE_LIMIT_WINDOW_SECONDS` (default: `900`)
+- `OFFLINE_RATE_LIMIT_MAX_HITS` (default: `3`)
+- `OFFLINE_API_THROTTLE_RATE_LIMIT` (default: `5`)
+- `OFFLINE_API_THROTTLE_BURST_LIMIT` (default: `10`)
+- `OFFLINE_PRIMARY_HEALTH_PATH` (default: `/statusz`)
+- `OFFLINE_PRIMARY_HEALTH_PORT` (default: `443`)
+
+## Apply order
+To avoid DNS record conflicts on the root domain:
+1. Apply `infra/aws/live/dev` once (contains `live.<zone>` record used by failover health checks).
+2. Apply `infra/aws/bootstrap` with `OFFLINE_SITE_ENABLED=true`.
+
+In CI, use workflows:
+1. `ci-infra` for live env.
+2. `bootstrap-terraform-backend` for bootstrap/offline stack.
+
+## Verification checklist
+1. Validate offline DNS records:
+```bash
+aws route53 list-resource-record-sets --hosted-zone-id <ZONE_ID> \
+  --query "ResourceRecordSets[?Name=='cloudradar.iotx.fr.' || Name=='offline.cloudradar.iotx.fr.' || Name=='live.cloudradar.iotx.fr.']"
+```
+2. Verify Route53 health check is healthy (primary):
+```bash
+aws route53 list-health-checks --query "HealthChecks[?contains(FullyQualifiedDomainName, 'live.')].Id"
+```
+3. Verify CloudFront distribution deployed and aliases include root + offline domains.
+4. Open `https://offline.<zone>` and submit a test contact request.
+5. Confirm SES email reception.
+
+## Spam-protection checks
+- Submit 1 valid request -> expected `200`.
+- Submit a request with honeypot field set -> expected `400`.
+- Submit > configured `OFFLINE_RATE_LIMIT_MAX_HITS` in one window -> expected `429`.
+
+## Rollback
+- Set `OFFLINE_SITE_ENABLED=false` and rerun bootstrap workflow.
+- Root domain routing returns to primary live endpoint only.
+
+## Notes
+- No WAF in v1.1 by FinOps choice.
+- CloudWatch retention should remain in the existing 3-7 day policy range.

--- a/infra/aws/bootstrap/.terraform.lock.hcl
+++ b/infra/aws/bootstrap/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.7.1"
+  constraints = "~> 2.5"
+  hashes = [
+    "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"

--- a/infra/aws/bootstrap/lambda/contact_demo.py
+++ b/infra/aws/bootstrap/lambda/contact_demo.py
@@ -1,0 +1,157 @@
+import hashlib
+import json
+import os
+import re
+import time
+from typing import Any
+
+try:
+  import boto3
+  from botocore.exceptions import ClientError
+except ImportError:  # pragma: no cover - local unit-test fallback
+  boto3 = None
+
+  class ClientError(Exception):
+    pass
+
+EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+NAME_RE = re.compile(r"^[A-Za-zÀ-ÖØ-öø-ÿ0-9 .,'-]{2,80}$")
+
+TABLE_NAME = os.environ["RATE_LIMIT_TABLE_NAME"]
+RECIPIENT_EMAIL = os.environ["RECIPIENT_EMAIL"]
+SENDER_EMAIL = os.environ["SENDER_EMAIL"]
+RATE_LIMIT_WINDOW_SECONDS = int(os.environ.get("RATE_LIMIT_WINDOW_SECONDS", "900"))
+RATE_LIMIT_MAX_HITS = int(os.environ.get("RATE_LIMIT_MAX_HITS", "3"))
+
+_dynamodb = boto3.client("dynamodb") if boto3 else None
+_ses = boto3.client("ses") if boto3 else None
+
+
+def _json_response(status_code: int, body: dict[str, Any]) -> dict[str, Any]:
+  return {
+      "statusCode": status_code,
+      "headers": {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-store"
+      },
+      "body": json.dumps(body)
+  }
+
+
+def _parse_body(event: dict[str, Any]) -> dict[str, str]:
+  raw_body = event.get("body") or "{}"
+  try:
+    body = json.loads(raw_body)
+  except json.JSONDecodeError:
+    raise ValueError("Invalid JSON payload")
+
+  if not isinstance(body, dict):
+    raise ValueError("Invalid JSON payload")
+
+  payload = {
+      "name": str(body.get("name", "")).strip(),
+      "email": str(body.get("email", "")).strip(),
+      "message": str(body.get("message", "")).strip(),
+      "honeypot": str(body.get("honeypot", "")).strip(),
+      "page": str(body.get("page", "")).strip(),
+      "userAgent": str(body.get("userAgent", "")).strip()
+  }
+  return payload
+
+
+def _validate(payload: dict[str, str]) -> None:
+  if payload["honeypot"]:
+    raise PermissionError("Invalid request")
+
+  if not NAME_RE.match(payload["name"]):
+    raise ValueError("Invalid name")
+
+  email = payload["email"]
+  if len(email) > 254 or not EMAIL_RE.match(email):
+    raise ValueError("Invalid email")
+
+  message = payload["message"]
+  if len(message) < 10 or len(message) > 2000:
+    raise ValueError("Invalid message")
+
+
+def _source_ip(event: dict[str, Any]) -> str:
+  return (
+      event.get("requestContext", {})
+      .get("http", {})
+      .get("sourceIp", "unknown")
+  )
+
+
+def _apply_rate_limit(ip: str) -> None:
+  now = int(time.time())
+  window = now // RATE_LIMIT_WINDOW_SECONDS
+  digest = hashlib.sha256(ip.encode("utf-8")).hexdigest()
+  key = f"{digest}#{window}"
+
+  expires_at = now + RATE_LIMIT_WINDOW_SECONDS + 120
+  try:
+    _dynamodb.update_item(
+        TableName=TABLE_NAME,
+        Key={"pk": {"S": key}},
+        UpdateExpression="ADD hit_count :one SET expires_at = :expires_at",
+        ExpressionAttributeValues={
+            ":one": {"N": "1"},
+            ":max": {"N": str(RATE_LIMIT_MAX_HITS)},
+            ":expires_at": {"N": str(expires_at)}
+        },
+        ConditionExpression="attribute_not_exists(hit_count) OR hit_count < :max"
+    )
+  except ClientError as exc:
+    code = exc.response.get("Error", {}).get("Code", "")
+    if code == "ConditionalCheckFailedException":
+      raise TimeoutError("Too many requests")
+    raise
+
+
+def _send_email(payload: dict[str, str], ip: str) -> None:
+  subject = f"[CloudRadar Demo] Request from {payload['name']}"
+  text_body = (
+      "CloudRadar demo request\n\n"
+      f"Name: {payload['name']}\n"
+      f"Email: {payload['email']}\n"
+      f"Source IP: {ip}\n"
+      f"Page: {payload['page']}\n"
+      f"User-Agent: {payload['userAgent']}\n\n"
+      "Message:\n"
+      f"{payload['message']}\n"
+  )
+
+  _ses.send_email(
+      Source=SENDER_EMAIL,
+      Destination={"ToAddresses": [RECIPIENT_EMAIL]},
+      Message={
+          "Subject": {"Data": subject, "Charset": "UTF-8"},
+          "Body": {
+              "Text": {"Data": text_body, "Charset": "UTF-8"}
+          }
+      },
+      ReplyToAddresses=[payload["email"]]
+  )
+
+
+def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+  method = event.get("requestContext", {}).get("http", {}).get("method", "")
+  if method != "POST":
+    return _json_response(405, {"error": "Method not allowed"})
+
+  try:
+    payload = _parse_body(event)
+    _validate(payload)
+    ip = _source_ip(event)
+    _apply_rate_limit(ip)
+    _send_email(payload, ip)
+    return _json_response(200, {"ok": True})
+  except PermissionError:
+    return _json_response(400, {"error": "Invalid request"})
+  except ValueError as exc:
+    return _json_response(400, {"error": str(exc)})
+  except TimeoutError:
+    return _json_response(429, {"error": "Too many requests, please retry later"})
+  except Exception:
+    return _json_response(500, {"error": "Internal error"})

--- a/infra/aws/bootstrap/lambda/tests/test_contact_demo.py
+++ b/infra/aws/bootstrap/lambda/tests/test_contact_demo.py
@@ -1,0 +1,101 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock
+
+
+class ContactDemoLambdaTest(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    os.environ["RATE_LIMIT_TABLE_NAME"] = "demo-rate-limit"
+    os.environ["RECIPIENT_EMAIL"] = "demo@example.com"
+    os.environ["SENDER_EMAIL"] = "noreply@example.com"
+    os.environ["RATE_LIMIT_WINDOW_SECONDS"] = "900"
+    os.environ["RATE_LIMIT_MAX_HITS"] = "3"
+
+  def setUp(self):
+    self.mock_ddb = MagicMock()
+    self.mock_ses = MagicMock()
+    module_path = Path(__file__).resolve().parents[1] / "contact_demo.py"
+    spec = importlib.util.spec_from_file_location("contact_demo", module_path)
+    assert spec is not None and spec.loader is not None
+    self.module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(self.module)
+    self.module._dynamodb = self.mock_ddb
+    self.module._ses = self.mock_ses
+
+  def tearDown(self):
+    pass
+
+  def _event(self, body):
+    return {
+      "requestContext": {"http": {"method": "POST", "sourceIp": "1.2.3.4"}},
+      "body": json.dumps(body)
+    }
+
+  def test_accepts_valid_request(self):
+    event = self._event(
+      {
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+        "message": "I would like a live demo next week.",
+        "honeypot": "",
+        "page": "https://cloudradar.iotx.fr",
+        "userAgent": "unit-test"
+      }
+    )
+
+    response = self.module.handler(event, None)
+
+    self.assertEqual(200, response["statusCode"])
+    self.mock_ddb.update_item.assert_called_once()
+    self.mock_ses.send_email.assert_called_once()
+
+  def test_blocks_honeypot(self):
+    event = self._event(
+      {
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+        "message": "I would like a live demo next week.",
+        "honeypot": "spam"
+      }
+    )
+
+    response = self.module.handler(event, None)
+
+    self.assertEqual(400, response["statusCode"])
+    self.mock_ses.send_email.assert_not_called()
+
+  def test_rejects_invalid_method(self):
+    event = {
+      "requestContext": {"http": {"method": "GET", "sourceIp": "1.2.3.4"}},
+      "body": "{}"
+    }
+
+    response = self.module.handler(event, None)
+
+    self.assertEqual(405, response["statusCode"])
+    self.mock_ddb.update_item.assert_not_called()
+    self.mock_ses.send_email.assert_not_called()
+
+  def test_rejects_invalid_email(self):
+    event = self._event(
+      {
+        "name": "Jane Doe",
+        "email": "not-an-email",
+        "message": "I would like a live demo next week.",
+        "honeypot": ""
+      }
+    )
+
+    response = self.module.handler(event, None)
+
+    self.assertEqual(400, response["statusCode"])
+    self.mock_ddb.update_item.assert_not_called()
+    self.mock_ses.send_email.assert_not_called()
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/infra/aws/bootstrap/offline-site/app.js
+++ b/infra/aws/bootstrap/offline-site/app.js
@@ -1,0 +1,85 @@
+const form = document.getElementById("demo-form");
+const statusNode = document.getElementById("form-status");
+const submitButton = document.getElementById("submit-button");
+
+function setStatus(message, type) {
+  statusNode.textContent = message;
+  statusNode.classList.remove("success", "error");
+  if (type) {
+    statusNode.classList.add(type);
+  }
+}
+
+function sanitize(input) {
+  return String(input || "").trim();
+}
+
+function validate(payload) {
+  if (payload.honeypot) {
+    return "Invalid request.";
+  }
+  if (payload.name.length < 2 || payload.name.length > 80) {
+    return "Please provide a valid name.";
+  }
+  if (payload.email.length < 5 || payload.email.length > 254 || !payload.email.includes("@")) {
+    return "Please provide a valid email address.";
+  }
+  if (payload.message.length < 10 || payload.message.length > 2000) {
+    return "Message must be between 10 and 2000 characters.";
+  }
+  return null;
+}
+
+async function submitRequest(payload) {
+  const response = await fetch("/api/contact-demo", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+
+  if (!response.ok) {
+    const message = body?.error || "Request failed. Please try again.";
+    throw new Error(message);
+  }
+}
+
+form?.addEventListener("submit", async (event) => {
+  event.preventDefault();
+
+  const payload = {
+    name: sanitize(document.getElementById("name")?.value),
+    email: sanitize(document.getElementById("email")?.value),
+    message: sanitize(document.getElementById("message")?.value),
+    honeypot: sanitize(document.getElementById("website")?.value),
+    page: window.location.href,
+    userAgent: navigator.userAgent
+  };
+
+  const validationError = validate(payload);
+  if (validationError) {
+    setStatus(validationError, "error");
+    return;
+  }
+
+  submitButton.disabled = true;
+  setStatus("Sending request...", null);
+
+  try {
+    await submitRequest(payload);
+    form.reset();
+    setStatus("Demo request sent. Thank you, I will get back to you soon.", "success");
+  } catch (error) {
+    setStatus(error.message || "Request failed. Please try again.", "error");
+  } finally {
+    submitButton.disabled = false;
+  }
+});

--- a/infra/aws/bootstrap/offline-site/index.html
+++ b/infra/aws/bootstrap/offline-site/index.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CloudRadar - Currently Offline</title>
+    <meta
+      name="description"
+      content="CloudRadar demo is currently offline for cost-optimized infrastructure cycles. Request a live demo."
+    />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="topbar">
+        <div class="brand-block">
+          <div class="brand-title">CloudRadar</div>
+          <div class="brand-subtitle">Live IDF Air Traffic Console</div>
+        </div>
+        <a class="readme-link" id="readme-link" href="https://github.com/ClementV78/CloudRadar" target="_blank" rel="noopener noreferrer">
+          View Project README
+        </a>
+      </header>
+
+      <main>
+        <section class="hero-card">
+          <div class="offline-badge">CURRENTLY OFFLINE</div>
+          <h1>Infrastructure paused to optimize cost</h1>
+          <p>
+            CloudRadar is temporarily offline during cost-saving windows. If you want to see the full live stack,
+            send a quick message and I will schedule a demo.
+          </p>
+        </section>
+
+        <section class="contact-card" aria-labelledby="demo-request-title">
+          <h2 id="demo-request-title">Request a live demo</h2>
+          <form id="demo-form" novalidate>
+            <div class="field-grid">
+              <label>
+                Name
+                <input id="name" name="name" type="text" autocomplete="name" minlength="2" maxlength="80" required />
+              </label>
+              <label>
+                Email
+                <input id="email" name="email" type="email" autocomplete="email" maxlength="254" required />
+              </label>
+            </div>
+            <label>
+              Message
+              <textarea id="message" name="message" rows="5" minlength="10" maxlength="2000" required></textarea>
+            </label>
+
+            <input id="website" name="website" type="text" class="hp-field" tabindex="-1" autocomplete="off" aria-hidden="true" />
+
+            <div class="form-actions">
+              <button id="submit-button" type="submit">Request a demo</button>
+              <p class="form-hint">Please include your preferred timezone and availability.</p>
+            </div>
+            <p id="form-status" class="form-status" role="status" aria-live="polite"></p>
+          </form>
+        </section>
+
+        <section class="preview-card" aria-labelledby="preview-title">
+          <h2 id="preview-title">Project preview</h2>
+          <p>Key screens from the live platform:</p>
+          <div class="preview-grid">
+            <figure>
+              <img src="/screenshots/dashboard.png" alt="CloudRadar map dashboard with live aircraft view" loading="lazy" />
+              <figcaption>Real-time map dashboard</figcaption>
+            </figure>
+            <figure>
+              <img src="/screenshots/grafana-app-telemetry.png" alt="Grafana application telemetry dashboard" loading="lazy" />
+              <figcaption>Application telemetry</figcaption>
+            </figure>
+            <figure>
+              <img src="/screenshots/grafana-ops.png" alt="Grafana infrastructure operations dashboard" loading="lazy" />
+              <figcaption>Operations monitoring</figcaption>
+            </figure>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <script src="/app.js" type="module"></script>
+  </body>
+</html>

--- a/infra/aws/bootstrap/offline-site/styles.css
+++ b/infra/aws/bootstrap/offline-site/styles.css
@@ -1,0 +1,267 @@
+:root {
+  --bg-0: #060a15;
+  --bg-1: #0a1226;
+  --bg-2: #0f1a35;
+  --line: #1e335a;
+  --line-bright: #00e5ff;
+  --text: #e9f3ff;
+  --text-soft: #b9ccdf;
+  --accent: #09d6ff;
+  --success: #34f6a2;
+  --warning: #ff6d6d;
+  --panel: rgba(8, 18, 35, 0.86);
+  --shadow: 0 20px 56px rgba(2, 8, 20, 0.48);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  font-family: "Rajdhani", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(1200px 650px at 8% -8%, rgba(0, 229, 255, 0.24), transparent 58%),
+    radial-gradient(850px 520px at 90% 0%, rgba(13, 91, 255, 0.22), transparent 58%),
+    linear-gradient(170deg, var(--bg-0) 0%, var(--bg-1) 52%, var(--bg-2) 100%);
+}
+
+.page-shell {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 18px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.brand-title {
+  color: var(--line-bright);
+  font-size: 1.85rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.brand-subtitle {
+  color: var(--text-soft);
+  font-size: 1rem;
+}
+
+.readme-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border: 1px solid var(--line-bright);
+  border-radius: 10px;
+  color: #001f2b;
+  background: linear-gradient(90deg, var(--line-bright), #00b4ff);
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 0.98rem;
+  transition: transform 140ms ease, filter 140ms ease;
+}
+
+.readme-link:hover,
+.readme-link:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.06);
+}
+
+main {
+  margin-top: 20px;
+  display: grid;
+  gap: 16px;
+}
+
+.hero-card,
+.contact-card,
+.preview-card {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  padding: 22px;
+}
+
+.offline-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid #ff7d7d;
+  color: #ffe4e4;
+  background: rgba(183, 30, 48, 0.42);
+  font-weight: 700;
+  font-size: 0.86rem;
+  letter-spacing: 0.08em;
+}
+
+.hero-card h1 {
+  margin: 14px 0 10px;
+  font-size: clamp(1.72rem, 2.9vw, 2.65rem);
+  line-height: 1.1;
+}
+
+.hero-card p,
+.preview-card p {
+  margin: 0;
+  color: var(--text-soft);
+  line-height: 1.55;
+  max-width: 72ch;
+}
+
+.contact-card h2,
+.preview-card h2 {
+  margin: 0 0 12px;
+  font-size: 1.42rem;
+}
+
+#demo-form {
+  display: grid;
+  gap: 12px;
+}
+
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+label {
+  display: grid;
+  gap: 6px;
+  color: var(--text-soft);
+  font-size: 0.98rem;
+}
+
+input,
+textarea {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid #314f7f;
+  background: rgba(6, 15, 28, 0.94);
+  color: var(--text);
+  padding: 10px 12px;
+  font: inherit;
+}
+
+input:focus,
+textarea:focus {
+  outline: 2px solid rgba(0, 229, 255, 0.38);
+  border-color: var(--line-bright);
+}
+
+.hp-field {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+button[type="submit"] {
+  border: 0;
+  border-radius: 10px;
+  padding: 11px 18px;
+  font: inherit;
+  font-weight: 700;
+  color: #001f2b;
+  background: linear-gradient(90deg, #00ebff, #11b9ff);
+  cursor: pointer;
+  transition: transform 120ms ease, filter 120ms ease;
+}
+
+button[type="submit"]:hover,
+button[type="submit"]:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.06);
+}
+
+button[disabled] {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.form-hint {
+  margin: 0;
+  color: var(--text-soft);
+  font-size: 0.94rem;
+}
+
+.form-status {
+  min-height: 1.28rem;
+  margin: 0;
+  font-weight: 600;
+}
+
+.form-status.success {
+  color: var(--success);
+}
+
+.form-status.error {
+  color: var(--warning);
+}
+
+.preview-grid {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+figure {
+  margin: 0;
+  border: 1px solid #273f67;
+  border-radius: 12px;
+  background: rgba(6, 14, 28, 0.92);
+  overflow: hidden;
+}
+
+figure img {
+  display: block;
+  width: 100%;
+  height: 196px;
+  object-fit: cover;
+}
+
+figcaption {
+  padding: 10px;
+  color: var(--text-soft);
+  font-size: 0.92rem;
+}
+
+@media (max-width: 920px) {
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .field-grid,
+  .preview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  figure img {
+    height: 210px;
+  }
+}

--- a/infra/aws/bootstrap/offline.tf
+++ b/infra/aws/bootstrap/offline.tf
@@ -1,0 +1,514 @@
+locals {
+  offline_enabled = var.offline_site_enabled && local.dns_zone_name != ""
+
+  offline_domain = local.offline_enabled ? "${var.offline_subdomain_label}.${local.dns_zone_name}" : ""
+  live_domain    = local.offline_enabled ? "${var.offline_primary_domain_label}.${local.dns_zone_name}" : ""
+
+  offline_bucket_name = local.offline_enabled ? (
+    trimspace(var.offline_site_bucket_name) != ""
+    ? trimspace(var.offline_site_bucket_name)
+    : "cloudradar-offline-${replace(local.dns_zone_name, ".", "-")}"
+  ) : ""
+
+  zone_id = try(aws_route53_zone.cloudradar[0].zone_id, "")
+
+  offline_static_files = local.offline_enabled ? {
+    "index.html" = {
+      source_path  = "${path.module}/offline-site/index.html"
+      content_type = "text/html; charset=utf-8"
+    }
+    "styles.css" = {
+      source_path  = "${path.module}/offline-site/styles.css"
+      content_type = "text/css; charset=utf-8"
+    }
+    "app.js" = {
+      source_path  = "${path.module}/offline-site/app.js"
+      content_type = "application/javascript; charset=utf-8"
+    }
+  } : {}
+
+  offline_screenshot_files = local.offline_enabled ? {
+    "screenshots/dashboard.png" = {
+      source_path  = "${path.module}/../../../docs/screenshots/dashboard.png"
+      content_type = "image/png"
+    }
+    "screenshots/grafana-app-telemetry.png" = {
+      source_path  = "${path.module}/../../../docs/screenshots/grafana-app-telemetry.png"
+      content_type = "image/png"
+    }
+    "screenshots/grafana-ops.png" = {
+      source_path  = "${path.module}/../../../docs/screenshots/grafana-ops.png"
+      content_type = "image/png"
+    }
+  } : {}
+}
+
+resource "aws_s3_bucket" "offline_site" {
+  count = local.offline_enabled ? 1 : 0
+
+  bucket = local.offline_bucket_name
+  tags   = merge(var.tags, { Name = "cloudradar-offline-site" })
+}
+
+resource "aws_s3_bucket_versioning" "offline_site" {
+  count = local.offline_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.offline_site[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "offline_site" {
+  count = local.offline_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.offline_site[0].id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "offline_site" {
+  count = local.offline_enabled ? 1 : 0
+
+  bucket                  = aws_s3_bucket.offline_site[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_ownership_controls" "offline_site" {
+  count = local.offline_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.offline_site[0].id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_object" "offline_static" {
+  for_each = local.offline_static_files
+
+  bucket       = aws_s3_bucket.offline_site[0].id
+  key          = each.key
+  source       = each.value.source_path
+  etag         = filemd5(each.value.source_path)
+  content_type = each.value.content_type
+}
+
+resource "aws_s3_object" "offline_screenshots" {
+  for_each = local.offline_screenshot_files
+
+  bucket       = aws_s3_bucket.offline_site[0].id
+  key          = each.key
+  source       = each.value.source_path
+  etag         = filemd5(each.value.source_path)
+  content_type = each.value.content_type
+}
+
+resource "aws_ses_email_identity" "offline_sender" {
+  count = local.offline_enabled ? 1 : 0
+
+  email = var.offline_contact_sender_email
+}
+
+resource "aws_dynamodb_table" "offline_rate_limit" {
+  count = local.offline_enabled ? 1 : 0
+
+  name         = "cloudradar-offline-contact-rate-limit"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "pk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+
+  tags = merge(var.tags, { Name = "cloudradar-offline-contact-rate-limit" })
+}
+
+data "archive_file" "offline_contact_lambda" {
+  count = local.offline_enabled ? 1 : 0
+
+  type        = "zip"
+  source_file = "${path.module}/lambda/contact_demo.py"
+  output_path = "${path.module}/.terraform/offline-contact-lambda.zip"
+}
+
+data "aws_iam_policy_document" "offline_contact_lambda_assume" {
+  count = local.offline_enabled ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "offline_contact_lambda" {
+  count = local.offline_enabled ? 1 : 0
+
+  name_prefix        = "cloudradar-offline-contact-lambda-"
+  assume_role_policy = data.aws_iam_policy_document.offline_contact_lambda_assume[0].json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy" "offline_contact_lambda" {
+  count = local.offline_enabled ? 1 : 0
+
+  name_prefix = "cloudradar-offline-contact-lambda-"
+  role        = aws_iam_role.offline_contact_lambda[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${var.region}:*:*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:UpdateItem"
+        ]
+        Resource = aws_dynamodb_table.offline_rate_limit[0].arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ses:SendEmail",
+          "ses:SendRawEmail"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_log_group" "offline_contact_lambda" {
+  count = local.offline_enabled ? 1 : 0
+
+  name              = "/aws/lambda/cloudradar-offline-contact"
+  retention_in_days = var.offline_logs_retention_days
+  tags              = var.tags
+}
+
+resource "aws_lambda_function" "offline_contact" {
+  count = local.offline_enabled ? 1 : 0
+
+  function_name = "cloudradar-offline-contact"
+  role          = aws_iam_role.offline_contact_lambda[0].arn
+  runtime       = "python3.12"
+  handler       = "contact_demo.handler"
+  architectures = ["arm64"]
+  timeout       = 5
+  memory_size   = 128
+
+  filename         = data.archive_file.offline_contact_lambda[0].output_path
+  source_code_hash = data.archive_file.offline_contact_lambda[0].output_base64sha256
+
+  environment {
+    variables = {
+      RATE_LIMIT_TABLE_NAME     = aws_dynamodb_table.offline_rate_limit[0].name
+      RECIPIENT_EMAIL           = var.offline_contact_recipient_email
+      SENDER_EMAIL              = var.offline_contact_sender_email
+      RATE_LIMIT_WINDOW_SECONDS = tostring(var.offline_rate_limit_window_seconds)
+      RATE_LIMIT_MAX_HITS       = tostring(var.offline_rate_limit_max_hits)
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.offline_contact_lambda]
+  tags       = var.tags
+}
+
+resource "aws_apigatewayv2_api" "offline_contact" {
+  count = local.offline_enabled ? 1 : 0
+
+  name          = "cloudradar-offline-contact"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_integration" "offline_contact" {
+  count = local.offline_enabled ? 1 : 0
+
+  api_id                 = aws_apigatewayv2_api.offline_contact[0].id
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  integration_uri        = aws_lambda_function.offline_contact[0].invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "offline_contact" {
+  count = local.offline_enabled ? 1 : 0
+
+  api_id    = aws_apigatewayv2_api.offline_contact[0].id
+  route_key = "POST /api/contact-demo"
+  target    = "integrations/${aws_apigatewayv2_integration.offline_contact[0].id}"
+}
+
+resource "aws_apigatewayv2_stage" "offline_contact" {
+  count = local.offline_enabled ? 1 : 0
+
+  api_id      = aws_apigatewayv2_api.offline_contact[0].id
+  name        = "$default"
+  auto_deploy = true
+
+  default_route_settings {
+    throttling_burst_limit = var.offline_api_throttle_burst_limit
+    throttling_rate_limit  = var.offline_api_throttle_rate_limit
+  }
+
+  tags = var.tags
+}
+
+resource "aws_lambda_permission" "offline_contact_apigw" {
+  count = local.offline_enabled ? 1 : 0
+
+  statement_id  = "AllowApiGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.offline_contact[0].function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.offline_contact[0].execution_arn}/*/*"
+}
+
+resource "aws_acm_certificate" "offline" {
+  count = local.offline_enabled ? 1 : 0
+
+  domain_name               = local.dns_zone_name
+  subject_alternative_names = [local.offline_domain]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(var.tags, { Name = "cloudradar-offline-certificate" })
+}
+
+resource "aws_route53_record" "offline_certificate_validation" {
+  for_each = local.offline_enabled ? {
+    for dvo in aws_acm_certificate.offline[0].domain_validation_options : dvo.domain_name => {
+      name  = dvo.resource_record_name
+      type  = dvo.resource_record_type
+      value = dvo.resource_record_value
+    }
+  } : {}
+
+  allow_overwrite = true
+  zone_id         = local.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  ttl             = 60
+  records         = [each.value.value]
+}
+
+resource "aws_acm_certificate_validation" "offline" {
+  count = local.offline_enabled ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.offline[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.offline_certificate_validation : record.fqdn]
+}
+
+resource "aws_cloudfront_origin_access_control" "offline_site" {
+  count = local.offline_enabled ? 1 : 0
+
+  name                              = "cloudradar-offline-oac"
+  description                       = "OAC for CloudRadar offline site bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+data "aws_cloudfront_cache_policy" "caching_optimized" {
+  name = "Managed-CachingOptimized"
+}
+
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+data "aws_cloudfront_origin_request_policy" "all_viewer_except_host_header" {
+  name = "Managed-AllViewerExceptHostHeader"
+}
+
+resource "aws_cloudfront_distribution" "offline" {
+  count = local.offline_enabled ? 1 : 0
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "CloudRadar offline fallback distribution"
+  default_root_object = "index.html"
+  price_class         = "PriceClass_100"
+  aliases             = [local.dns_zone_name, local.offline_domain]
+
+  origin {
+    domain_name              = aws_s3_bucket.offline_site[0].bucket_regional_domain_name
+    origin_id                = "offline-s3"
+    origin_access_control_id = aws_cloudfront_origin_access_control.offline_site[0].id
+  }
+
+  origin {
+    domain_name = trimprefix(aws_apigatewayv2_api.offline_contact[0].api_endpoint, "https://")
+    origin_id   = "offline-contact-api"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "offline-s3"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_optimized.id
+  }
+
+  ordered_cache_behavior {
+    path_pattern             = "/api/*"
+    target_origin_id         = "offline-contact-api"
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["GET", "HEAD", "OPTIONS", "POST"]
+    cached_methods           = ["GET", "HEAD"]
+    compress                 = true
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host_header.id
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.offline[0].certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = merge(var.tags, { Name = "cloudradar-offline-cloudfront" })
+}
+
+data "aws_iam_policy_document" "offline_bucket_policy" {
+  count = local.offline_enabled ? 1 : 0
+
+  statement {
+    sid = "AllowCloudFrontReadOnly"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions = ["s3:GetObject"]
+    resources = [
+      "${aws_s3_bucket.offline_site[0].arn}/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.offline[0].arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "offline_site" {
+  count = local.offline_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.offline_site[0].id
+  policy = data.aws_iam_policy_document.offline_bucket_policy[0].json
+}
+
+resource "aws_route53_record" "offline_domain_alias" {
+  count = local.offline_enabled ? 1 : 0
+
+  zone_id = local.zone_id
+  name    = local.offline_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.offline[0].domain_name
+    zone_id                = aws_cloudfront_distribution.offline[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+
+  allow_overwrite = true
+}
+
+resource "aws_route53_health_check" "primary_live" {
+  count = local.offline_enabled ? 1 : 0
+
+  fqdn              = local.live_domain
+  port              = var.offline_primary_health_port
+  type              = "HTTPS"
+  resource_path     = var.offline_primary_health_path
+  request_interval  = 30
+  failure_threshold = 3
+  measure_latency   = true
+
+  tags = merge(var.tags, { Name = "cloudradar-primary-live-health-check" })
+}
+
+resource "aws_route53_record" "main_failover_primary" {
+  count = local.offline_enabled ? 1 : 0
+
+  zone_id         = local.zone_id
+  name            = local.dns_zone_name
+  type            = "A"
+  set_identifier  = "primary-live"
+  health_check_id = aws_route53_health_check.primary_live[0].id
+
+  failover_routing_policy {
+    type = "PRIMARY"
+  }
+
+  alias {
+    name                   = local.live_domain
+    zone_id                = local.zone_id
+    evaluate_target_health = false
+  }
+
+  allow_overwrite = true
+}
+
+resource "aws_route53_record" "main_failover_secondary" {
+  count = local.offline_enabled ? 1 : 0
+
+  zone_id        = local.zone_id
+  name           = local.dns_zone_name
+  type           = "A"
+  set_identifier = "secondary-offline"
+
+  failover_routing_policy {
+    type = "SECONDARY"
+  }
+
+  alias {
+    name                   = aws_cloudfront_distribution.offline[0].domain_name
+    zone_id                = aws_cloudfront_distribution.offline[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+
+  allow_overwrite = true
+}

--- a/infra/aws/bootstrap/outputs.tf
+++ b/infra/aws/bootstrap/outputs.tf
@@ -42,3 +42,18 @@ output "dns_zone_name_servers" {
   value       = try(aws_route53_zone.cloudradar[0].name_servers, [])
   description = "Name servers for the delegated subdomain (if created)."
 }
+
+output "offline_domain" {
+  value       = local.offline_enabled ? local.offline_domain : ""
+  description = "Offline preview domain (if offline stack is enabled)."
+}
+
+output "offline_cloudfront_domain_name" {
+  value       = local.offline_enabled ? aws_cloudfront_distribution.offline[0].domain_name : ""
+  description = "CloudFront domain for the offline fallback distribution."
+}
+
+output "offline_contact_api_endpoint" {
+  value       = local.offline_enabled ? aws_apigatewayv2_api.offline_contact[0].api_endpoint : ""
+  description = "Direct API Gateway endpoint for offline contact form."
+}

--- a/infra/aws/bootstrap/variables.tf
+++ b/infra/aws/bootstrap/variables.tf
@@ -33,6 +33,94 @@ variable "dns_zone_name" {
   default     = ""
 }
 
+variable "offline_site_enabled" {
+  type        = bool
+  description = "Enable persistent offline fallback stack (S3 + CloudFront + contact API + Route53 failover)."
+  default     = false
+}
+
+variable "offline_site_bucket_name" {
+  type        = string
+  description = "Optional S3 bucket name for offline static assets. If empty, a name is derived from dns_zone_name."
+  default     = ""
+}
+
+variable "offline_subdomain_label" {
+  type        = string
+  description = "Subdomain label used for offline preview page (offline.<dns_zone_name>)."
+  default     = "offline"
+}
+
+variable "offline_primary_domain_label" {
+  type        = string
+  description = "Subdomain label for primary live endpoint used by Route53 failover health checks (live.<dns_zone_name>)."
+  default     = "live"
+}
+
+variable "offline_contact_sender_email" {
+  type        = string
+  description = "SES sender email used by offline contact form."
+  default     = ""
+
+  validation {
+    condition     = !var.offline_site_enabled || length(trimspace(var.offline_contact_sender_email)) > 0
+    error_message = "offline_contact_sender_email must be set when offline_site_enabled is true."
+  }
+}
+
+variable "offline_contact_recipient_email" {
+  type        = string
+  description = "Recipient email for offline contact form submissions."
+  default     = ""
+
+  validation {
+    condition     = !var.offline_site_enabled || length(trimspace(var.offline_contact_recipient_email)) > 0
+    error_message = "offline_contact_recipient_email must be set when offline_site_enabled is true."
+  }
+}
+
+variable "offline_logs_retention_days" {
+  type        = number
+  description = "CloudWatch logs retention for offline Lambda/API logs."
+  default     = 7
+}
+
+variable "offline_rate_limit_window_seconds" {
+  type        = number
+  description = "Rate-limit window size in seconds per source IP."
+  default     = 900
+}
+
+variable "offline_rate_limit_max_hits" {
+  type        = number
+  description = "Maximum accepted contact submissions per IP and window."
+  default     = 3
+}
+
+variable "offline_api_throttle_rate_limit" {
+  type        = number
+  description = "API Gateway throttle rate limit (requests per second)."
+  default     = 5
+}
+
+variable "offline_api_throttle_burst_limit" {
+  type        = number
+  description = "API Gateway throttle burst limit."
+  default     = 10
+}
+
+variable "offline_primary_health_path" {
+  type        = string
+  description = "Health-check path for Route53 primary live endpoint."
+  default     = "/statusz"
+}
+
+variable "offline_primary_health_port" {
+  type        = number
+  description = "Health-check port for Route53 primary live endpoint."
+  default     = 443
+}
+
 variable "tags" {
   type        = map(string)
   description = "Common tags for backend resources."

--- a/infra/aws/bootstrap/versions.tf
+++ b/infra/aws/bootstrap/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.5"
+    }
   }
 }

--- a/infra/aws/live/dev/dns.tf
+++ b/infra/aws/live/dev/dns.tf
@@ -14,7 +14,7 @@ locals {
   dns_zone_id = local.dns_enabled ? data.aws_route53_zone.cloudradar[0].zone_id : ""
 
   dns_a_records = {
-    (local.dns_zone_name)                 = module.edge.edge_public_ip
+    ("live.${local.dns_zone_name}")       = module.edge.edge_public_ip
     ("grafana.${local.dns_zone_name}")    = module.edge.edge_public_ip
     ("prometheus.${local.dns_zone_name}") = module.edge.edge_public_ip
     ("app.${local.dns_zone_name}")        = module.edge.edge_public_ip


### PR DESCRIPTION
## Summary
- added a persistent offline fallback stack in `infra/aws/bootstrap` (S3 + CloudFront + API Gateway + Lambda + DynamoDB + SES) with Route53 failover
- added branded offline landing assets (visible README link, contact form, screenshots) and Lambda unit tests
- updated live DNS to use `live.<zone>` as failover primary target and kept online path unchanged
- documented the architecture/runbook/ADR updates, including failover behavior and cert model

## Validation
- `python3 -m unittest infra/aws/bootstrap/lambda/tests/test_contact_demo.py`
- `terraform -chdir=infra/aws/bootstrap validate`

## Issue
Closes #576
