### PR TITLE
fix(ci): make failover import non-interactive

### DIFF
--- a/.github/workflows/ci-failover.yml
+++ b/.github/workflows/ci-failover.yml
@@ -127,7 +127,16 @@ jobs:
           OFFLINE_SITE_BUCKET_NAME="${{ vars.OFFLINE_SITE_BUCKET_NAME }}"
           OFFLINE_SUBDOMAIN_LABEL="${{ vars.OFFLINE_SUBDOMAIN_LABEL || 'offline' }}"
           OFFLINE_PRIMARY_DOMAIN_LABEL="${{ vars.OFFLINE_PRIMARY_DOMAIN_LABEL || 'live' }}"
+          OFFLINE_CONTACT_RECIPIENT_EMAIL="${{ vars.OFFLINE_CONTACT_RECIPIENT_EMAIL }}"
+          OFFLINE_CONTACT_SENDER_LOCAL_PART="${{ vars.OFFLINE_CONTACT_SENDER_LOCAL_PART || 'noreply' }}"
+          OFFLINE_LOGS_RETENTION_DAYS="${{ vars.OFFLINE_LOGS_RETENTION_DAYS || '7' }}"
+          OFFLINE_RATE_LIMIT_WINDOW_SECONDS="${{ vars.OFFLINE_RATE_LIMIT_WINDOW_SECONDS || '900' }}"
+          OFFLINE_RATE_LIMIT_MAX_HITS="${{ vars.OFFLINE_RATE_LIMIT_MAX_HITS || '3' }}"
+          OFFLINE_API_THROTTLE_RATE_LIMIT="${{ vars.OFFLINE_API_THROTTLE_RATE_LIMIT || '5' }}"
+          OFFLINE_API_THROTTLE_BURST_LIMIT="${{ vars.OFFLINE_API_THROTTLE_BURST_LIMIT || '10' }}"
           OFFLINE_PRIMARY_HEALTH_PATH="${{ vars.OFFLINE_PRIMARY_HEALTH_PATH || '/statusz' }}"
+          OFFLINE_PRIMARY_HEALTH_PORT="${{ vars.OFFLINE_PRIMARY_HEALTH_PORT || '443' }}"
+          OFFLINE_ROUTE53_FAILOVER_ENABLED="${{ vars.OFFLINE_ROUTE53_FAILOVER_ENABLED || 'true' }}"
           DNS_ZONE_NO_DOT="${DNS_ZONE_NAME%.}"
 
           if [[ "${OFFLINE_SITE_ENABLED}" != "true" ]]; then
@@ -135,13 +144,37 @@ jobs:
             exit 0
           fi
 
+          if [[ -z "${OFFLINE_CONTACT_RECIPIENT_EMAIL}" ]]; then
+            echo "OFFLINE_CONTACT_RECIPIENT_EMAIL is required when OFFLINE_SITE_ENABLED=true" >&2
+            exit 1
+          fi
+
+          # Ensure terraform import is fully non-interactive in CI.
+          export TF_VAR_region="${AWS_REGION}"
+          export TF_VAR_dns_zone_name="${DNS_ZONE_NAME}"
+          export TF_VAR_offline_site_enabled="${OFFLINE_SITE_ENABLED}"
+          export TF_VAR_offline_site_bucket_name="${OFFLINE_SITE_BUCKET_NAME}"
+          export TF_VAR_offline_subdomain_label="${OFFLINE_SUBDOMAIN_LABEL}"
+          export TF_VAR_offline_primary_domain_label="${OFFLINE_PRIMARY_DOMAIN_LABEL}"
+          export TF_VAR_offline_contact_sender_local_part="${OFFLINE_CONTACT_SENDER_LOCAL_PART}"
+          export TF_VAR_offline_contact_recipient_email="${OFFLINE_CONTACT_RECIPIENT_EMAIL}"
+          export TF_VAR_offline_logs_retention_days="${OFFLINE_LOGS_RETENTION_DAYS}"
+          export TF_VAR_offline_rate_limit_window_seconds="${OFFLINE_RATE_LIMIT_WINDOW_SECONDS}"
+          export TF_VAR_offline_rate_limit_max_hits="${OFFLINE_RATE_LIMIT_MAX_HITS}"
+          export TF_VAR_offline_api_throttle_rate_limit="${OFFLINE_API_THROTTLE_RATE_LIMIT}"
+          export TF_VAR_offline_api_throttle_burst_limit="${OFFLINE_API_THROTTLE_BURST_LIMIT}"
+          export TF_VAR_offline_primary_health_path="${OFFLINE_PRIMARY_HEALTH_PATH}"
+          export TF_VAR_offline_primary_health_port="${OFFLINE_PRIMARY_HEALTH_PORT}"
+          export TF_VAR_offline_route53_failover_enabled="${OFFLINE_ROUTE53_FAILOVER_ENABLED}"
+
           tf_import() {
             local address="$1"
             local import_id="${2:-}"
             if [[ -z "${import_id}" || "${import_id}" == "None" || "${import_id}" == "null" ]]; then
               return 0
             fi
-            terraform -chdir=infra/aws/failover import "${address}" "${import_id}" || true
+            echo "Importing ${address}..."
+            terraform -chdir=infra/aws/failover import -input=false "${address}" "${import_id}" || true
           }
 
           ZONE_ID="$(aws route53 list-hosted-zones-by-name \


### PR DESCRIPTION
## Summary
- make `ci-failover` import step fully non-interactive in CI
- export required `TF_VAR_*` values before `terraform import`
- force `terraform import -input=false` and add explicit import progress logs
- guard missing `OFFLINE_CONTACT_RECIPIENT_EMAIL` early when offline stack is enabled

## Why
The `Import existing failover resources (best effort)` step could appear stuck because Terraform prompted for missing variables (for example `dns_zone_name`) during import. This update removes interactive prompts so imports complete or fail fast.

Refs #576
