### PR TITLE
fix(ci): handle provider-specific missing resource import errors

### DIFF
--- a/.github/workflows/ci-failover.yml
+++ b/.github/workflows/ci-failover.yml
@@ -196,6 +196,11 @@ jobs:
               return 0
             fi
 
+            if grep -Eqi "could(n't| not) find resource" <<<"${output}"; then
+              echo "Skipping ${address}: provider could not find remote resource, it will be created by terraform apply if required."
+              return 0
+            fi
+
             if grep -q "Resource already managed by Terraform" <<<"${output}"; then
               echo "Skipping ${address}: already present in Terraform state."
               return 0


### PR DESCRIPTION
## Summary
- extend failover `tf_import` best-effort handling for provider messages like "couldn't find resource"
- keep import non-blocking when target resources do not exist yet
- preserve hard failures for real execution/permission/lock errors

## Why
Some resource imports (for example `aws_lambda_permission`) fail with provider-specific "couldn't find resource" instead of Terraform's standard "Cannot import non-existent remote object". This should not block the workflow when resources are expected to be created by apply.

Refs #576
