### PR TITLE
fix(failover): support offline-only apply and SES recipient identity

### DIFF
--- a/docs/runbooks/ci-cd/ci-failover.md
+++ b/docs/runbooks/ci-cd/ci-failover.md
@@ -23,6 +23,7 @@ Set these GitHub Actions variables:
 Runtime prerequisites:
 - `live.<dns_zone_name>` record must already exist (created by `ci-infra`), because Route53 PRIMARY failover aliases that record.
 - The role behind `AWS_FAILOVER_TERRAFORM_ROLE_ARN` must include CloudFront/Route53/ACM/SES/API Gateway/Lambda/IAM/Logs permissions required by `infra/aws/failover`.
+- For intentional offline-only operation (live infra destroyed), enable `offline_mode=true` at workflow dispatch.
 
 Optional tuning:
 - `OFFLINE_SITE_ENABLED` (default: `true`)
@@ -44,7 +45,16 @@ Optional tuning:
 - `action`: `plan` | `apply` | `destroy`
 - `auto_approve`: required `true` for `apply`
 - `import_existing`: best-effort migration import before plan/apply
+- `offline_mode`: allow run when `live.<dns_zone_name>` A record is missing
 - `confirm_destroy`: must be `DESTROY` for `destroy`
+
+## Offline-only usage
+When online infrastructure is intentionally destroyed:
+1. Run `ci-failover` with:
+   - `action=apply`
+   - `auto_approve=true`
+   - `offline_mode=true`
+2. The workflow keeps Route53 failover resources manageable even if `live.<dns_zone_name>` does not exist.
 
 ## Recommended order
 1. `bootstrap-terraform-backend`

--- a/docs/runbooks/operations/offline-fallback.md
+++ b/docs/runbooks/operations/offline-fallback.md
@@ -67,6 +67,9 @@ Recommended sequence for this project:
 2. Run `ci-infra` for live env (creates/updates `live.<zone>` record used by failover health checks).
 3. Run `ci-failover` (`action=apply`, `auto_approve=true`).
 
+If online infra is intentionally destroyed and `live.<zone>` is absent:
+- run `ci-failover` with `offline_mode=true` to keep failover stack deployable/manageable.
+
 In CI, use workflows:
 1. `bootstrap-terraform-backend` for backend + optional DNS/TLS bootstrap.
 2. `ci-infra` for live env.
@@ -88,6 +91,13 @@ aws route53 list-health-checks --query "HealthChecks[?contains(FullyQualifiedDom
    - `*._domainkey.<dns_zone_name>` CNAME (DKIM)
 5. Open `https://offline.<zone>` and submit a test contact request.
 6. Confirm SES email reception.
+
+### SES sandbox note
+If SES is still in sandbox mode (`ProductionAccessEnabled=false`), the recipient identity must be verified.
+The Terraform Lambda IAM policy authorizes:
+- domain identity (`identity/<dns_zone_name>`)
+- recipient identity (`identity/<offline_contact_recipient_email>`)
+to prevent `AccessDenied` at `ses:SendEmail`.
 
 ## Spam-protection checks
 - Submit 1 valid request -> expected `200`.

--- a/docs/runbooks/troubleshooting/issue-log.md
+++ b/docs/runbooks/troubleshooting/issue-log.md
@@ -2,6 +2,23 @@
 
 This log tracks incidents and fixes in reverse chronological order. Use it for debugging patterns and onboarding.
 
+## 2026-03-16
+
+### [failover/contact] Offline form returned generic `Internal error` after deployment
+- **Severity:** Medium
+- **Impact:** Offline contact form submissions failed while fallback page remained available.
+- **Signal:** API returned `500 {"error":"Internal error"}` and Lambda logs initially showed only START/END without useful diagnostics.
+- **Analysis:** Two combined factors:
+  1. Lambda runtime was still on an older handler version that swallowed exceptions in generic `except Exception`.
+  2. After deploying improved diagnostics, CloudWatch showed `AccessDenied` on `ses:SendEmail` for recipient identity ARN (`identity/<recipient_email>`). Lambda IAM policy only authorized SES domain identity.
+- **Resolution:**
+  1. Deploy handler with structured error logging (`logger.exception`, request context hash, client error code mapping).
+  2. Extend Terraform Lambda IAM SES policy to authorize both:
+     - `identity/<dns_zone_name>`
+     - `identity/<offline_contact_recipient_email>`
+  3. Add `offline_mode` workflow checkbox in `ci-failover` to allow apply/plan when `live.<zone>` is absent by design.
+- **Guardrail:** For SES sandbox-compatible automation, always include recipient identity ARN in IAM policy when using verified-recipient flow.
+
 ## 2026-03-12
 
 ### [app/ingester] Startup crash after refactor (`FlightIngestJob` bean instantiation)

--- a/infra/aws/failover/main.tf
+++ b/infra/aws/failover/main.tf
@@ -248,7 +248,10 @@ resource "aws_iam_role_policy" "offline_contact_lambda" {
           "ses:SendEmail",
           "ses:SendRawEmail"
         ]
-        Resource = "arn:aws:ses:${var.region}:*:identity/${local.dns_zone_name}"
+        Resource = [
+          "arn:aws:ses:${var.region}:*:identity/${local.dns_zone_name}",
+          "arn:aws:ses:${var.region}:*:identity/${var.offline_contact_recipient_email}"
+        ]
       }
     ]
   })


### PR DESCRIPTION
## Summary
- add `offline_mode` workflow-dispatch checkbox in `ci-failover` to allow apply/plan when `live.<dns_zone_name>` is intentionally absent (offline-only state)
- keep strict guardrail by default: when `offline_mode=false`, missing `live.<dns_zone_name>` still fails fast
- fix failover Lambda IAM SES permissions to allow both domain identity and verified recipient identity

## Why
- when live infra is destroyed on purpose, failover stack still needs to be deployable/manageable
- offline contact form failed with `AccessDenied` on `ses:SendEmail` for recipient identity in SES sandbox flows

## Docs updated
- `docs/runbooks/ci-cd/ci-failover.md`
- `docs/runbooks/operations/offline-fallback.md`
- `docs/runbooks/troubleshooting/issue-log.md`

## Validation
- `terraform -chdir=infra/aws/failover fmt -check`
- workflow YAML parsed successfully after update

## Context
- Refs #576
