### PR TITLE
fix(failover): make screenshot lightbox truly larger than card preview

### DIFF
--- a/infra/aws/failover/offline-site/styles.css
+++ b/infra/aws/failover/offline-site/styles.css
@@ -293,7 +293,7 @@ figcaption {
 }
 
 .lightbox-figure {
-  width: min(1200px, 96vw);
+  width: min(1400px, 98vw);
   margin: 0;
   border: 1px solid #3a5581;
   border-radius: 14px;
@@ -302,8 +302,12 @@ figcaption {
 }
 
 .lightbox-figure img {
-  width: 100%;
+  display: block;
+  width: auto;
+  max-width: 100%;
+  height: auto;
   max-height: 82vh;
+  margin: 0 auto;
   object-fit: contain;
   background: #030a14;
 }


### PR DESCRIPTION
## Summary
- fix offline fallback lightbox sizing so zoomed screenshots are effectively larger than preview cards
- override inherited card image fixed height in lightbox (`height: auto`)
- increase lightbox max width from `96vw/1200px` to `98vw/1400px`

## Root cause
- generic `figure img { height: 294px; }` rule also affected lightbox images, forcing a small render area

## Context
- Refs #576
