### PR TITLE
fix(failover): prevent cache masking during offline/online switch

### DIFF
--- a/.github/workflows/ci-failover.yml
+++ b/.github/workflows/ci-failover.yml
@@ -433,6 +433,34 @@ jobs:
         if: ${{ inputs.action == 'apply' && inputs.auto_approve }}
         run: terraform -chdir=infra/aws/failover apply -input=false -lock-timeout=300s -auto-approve tfplan
 
+      - name: Invalidate offline CloudFront HTML entrypoints
+        if: ${{ inputs.action == 'apply' && inputs.auto_approve }}
+        run: |
+          set -euo pipefail
+
+          OFFLINE_SITE_ENABLED="${{ vars.OFFLINE_SITE_ENABLED || 'true' }}"
+          if [[ "${OFFLINE_SITE_ENABLED}" != "true" ]]; then
+            echo "OFFLINE_SITE_ENABLED=${OFFLINE_SITE_ENABLED}; skipping CloudFront invalidation."
+            exit 0
+          fi
+
+          DNS_ZONE_NO_DOT="${{ vars.DNS_ZONE_NAME }}"
+          DNS_ZONE_NO_DOT="${DNS_ZONE_NO_DOT%.}"
+          DIST_ID="$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?Aliases.Quantity > \`0\` && contains(Aliases.Items, '${DNS_ZONE_NO_DOT}')].Id | [0]" \
+            --output text 2>/dev/null || true)"
+
+          if [[ -z "${DIST_ID}" || "${DIST_ID}" == "None" || "${DIST_ID}" == "null" ]]; then
+            echo "::warning title=ci-failover::Offline CloudFront distribution not found; skipping invalidation."
+            exit 0
+          fi
+
+          aws cloudfront create-invalidation \
+            --distribution-id "${DIST_ID}" \
+            --paths "/" "/index.html" \
+            >/dev/null
+          echo "CloudFront invalidation submitted for distribution ${DIST_ID}: / and /index.html"
+
       - name: Guard destroy confirmation
         if: ${{ inputs.action == 'destroy' && inputs.confirm_destroy != 'DESTROY' }}
         run: |

--- a/docs/runbooks/ci-cd/ci-failover.md
+++ b/docs/runbooks/ci-cd/ci-failover.md
@@ -4,6 +4,7 @@ This runbook explains the `ci-failover` GitHub Actions workflow used to manage t
 
 ## Purpose
 Manage offline fallback infrastructure in a dedicated Terraform state (`cloudradar/failover/terraform.tfstate`) so it is not impacted by `ci-infra-destroy`.
+The workflow also keeps user-visible switch latency low by invalidating offline CloudFront HTML entrypoints (`/` and `/index.html`) after apply.
 
 ## Terraform root
 - `infra/aws/failover`
@@ -65,3 +66,6 @@ When online infrastructure is intentionally destroyed:
 - `ci-failover` uses a dedicated remote state key and lock table.
 - `ci-infra-destroy` does not remove failover resources.
 - Route53 failover remains active when live infra is down.
+- Cache guardrails:
+  - `index.html` is configured with `Cache-Control: no-store, max-age=0, must-revalidate`.
+  - `/api/contact-demo` uses a disabled CloudFront cache policy and response `Cache-Control: no-store`.

--- a/docs/runbooks/operations/offline-fallback.md
+++ b/docs/runbooks/operations/offline-fallback.md
@@ -9,6 +9,10 @@ Serve a branded CloudRadar offline landing page with demo-contact form when live
 - Both failover records use the same public hostname (`cloudradar.<domain>`); Route53 returns PRIMARY or SECONDARY target depending on primary health-check status.
 - Contact form: `/api/contact-demo` -> CloudFront behavior -> API Gateway HTTP API -> Lambda -> SES.
 - Anti-spam baseline (no WAF): API throttling + honeypot + backend validation + DynamoDB IP/window rate limit.
+- Cache strategy for switch visibility:
+  - `index.html`: `Cache-Control: no-store, max-age=0, must-revalidate` (online and offline paths)
+  - `/api/contact-demo`: CloudFront `CachingDisabled` + runtime `Cache-Control: no-store`
+  - `ci-failover` triggers CloudFront invalidation for `/` and `/index.html` after apply
 
 ## Offline fallback diagram
 ```mermaid
@@ -91,6 +95,11 @@ aws route53 list-health-checks --query "HealthChecks[?contains(FullyQualifiedDom
    - `*._domainkey.<dns_zone_name>` CNAME (DKIM)
 5. Open `https://offline.<zone>` and submit a test contact request.
 6. Confirm SES email reception.
+7. Verify headers on public host:
+```bash
+curl -sSI https://cloudradar.<domain>/ | grep -i '^cache-control:'
+curl -sSI https://cloudradar.<domain>/index.html | grep -i '^cache-control:'
+```
 
 ### SES sandbox note
 If SES is still in sandbox mode (`ProductionAccessEnabled=false`), the recipient identity must be verified.

--- a/infra/aws/failover/main.tf
+++ b/infra/aws/failover/main.tf
@@ -123,6 +123,11 @@ resource "aws_s3_object" "offline_static" {
   source       = each.value.source_path
   etag         = filemd5(each.value.source_path)
   content_type = each.value.content_type
+  cache_control = (
+    each.key == "index.html"
+    ? "no-store, max-age=0, must-revalidate"
+    : null
+  )
 }
 
 resource "aws_s3_object" "offline_screenshots" {
@@ -406,6 +411,33 @@ data "aws_cloudfront_cache_policy" "caching_optimized" {
   name = "Managed-CachingOptimized"
 }
 
+resource "aws_cloudfront_cache_policy" "offline_static_default" {
+  count = local.offline_enabled ? 1 : 0
+
+  name        = "cloudradar-offline-static-default"
+  comment     = "Default static cache policy with min TTL 0 to honor no-store on index.html"
+  default_ttl = 86400
+  max_ttl     = 31536000
+  min_ttl     = 0
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+
+    headers_config {
+      header_behavior = "none"
+    }
+
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+
+    enable_accept_encoding_brotli = true
+    enable_accept_encoding_gzip   = true
+  }
+}
+
 data "aws_cloudfront_cache_policy" "caching_disabled" {
   count = local.offline_enabled ? 1 : 0
 
@@ -454,7 +486,7 @@ resource "aws_cloudfront_distribution" "offline" {
     allowed_methods        = ["GET", "HEAD", "OPTIONS"]
     cached_methods         = ["GET", "HEAD"]
     compress               = true
-    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_optimized[0].id
+    cache_policy_id        = aws_cloudfront_cache_policy.offline_static_default[0].id
   }
 
   ordered_cache_behavior {

--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -10,6 +10,15 @@ server {
     return 200 'ok';
   }
 
+  location = / {
+    add_header Cache-Control "no-store, max-age=0, must-revalidate" always;
+    try_files /index.html =404;
+  }
+
+  location = /index.html {
+    add_header Cache-Control "no-store, max-age=0, must-revalidate" always;
+  }
+
   location / {
     try_files $uri /index.html;
   }


### PR DESCRIPTION
## Summary
- enforce `no-store` on offline `index.html` object metadata
- switch offline CloudFront default behavior to a custom cache policy with `min_ttl=0`
- enforce `no-store` for online frontend entrypoints (`/` and `/index.html`)
- add CloudFront invalidation (`/`, `/index.html`) after `ci-failover` apply
- update failover runbooks with cache/switch guardrails and verification commands

## Validation
- `terraform -chdir=infra/aws/failover init -backend=false -reconfigure`
- `terraform -chdir=infra/aws/failover validate`
- `python3 -m unittest discover -s infra/aws/failover/lambda/tests -p 'test_*.py'`

Refs #57
