### PR TITLE
fix(k8s): bootstrap cloudradar namespace before ESO config

### DIFF
--- a/k8s/apps/kustomization.yaml
+++ b/k8s/apps/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - namespace.yaml
   - ebs-csi-application.yaml
   - admin-scale
   - frontend

--- a/k8s/platform/kustomization.yaml
+++ b/k8s/platform/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - namespaces/cloudradar.yaml
   - namespaces/monitoring.yaml
   - external-secrets/helmrelease.yaml
   - external-secrets/config-application.yaml

--- a/k8s/platform/namespaces/cloudradar.yaml
+++ b/k8s/platform/namespaces/cloudradar.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudradar


### PR DESCRIPTION
Fixes #598

- moved `Namespace/cloudradar` ownership from `k8s/apps` to `k8s/platform`
- created the namespace before `external-secrets-config` sync so namespaced `ExternalSecret` objects can be applied on fresh bootstrap
- kept the change surgical to avoid broader ArgoCD/bootstrap behavior changes

## Validation
- `kubectl kustomize k8s/platform`
- `kubectl kustomize k8s/apps`
- reproduced cluster failure and confirmed root cause from ArgoCD + pod events:
  - `external-secrets-config`: `namespaces "cloudradar" not found`
  - app pods: `secret "processor-aircraft-db" not found`
